### PR TITLE
Issue 743 : v2.0.0 Release Notes (release_notes.md) Doc Missing an Intro

### DIFF
--- a/site/en/release_notes.md
+++ b/site/en/release_notes.md
@@ -4,6 +4,8 @@ summary: Milvus Release Notes
 ---
 # Release Notes
 
+Find out what’s new in Milvus! This page summarizes information about new features, improvements, known issues, and bug fixes in each release. You can find the release notes for each component in this section. We suggest that you regularly visit the release notes to learn about updates.
+
 ## v2.0.0-RC6
 
 Release date: 2021-09-10


### PR DESCRIPTION
## Description

This PR adds an introduction section to the Release Notes page.

## Issue

This PR fixes https://github.com/milvus-io/milvus-docs/issues/743


> **NOTE:**  Keeping in mind https://github.com/milvus-io/milvus-docs/issues/783, the Chinese translation for the same section has not been added as it needs someone proficient in Chinese to do the job. This opens the scope for another ticket that can be contributed to by some other contributor who is proficient in the language.