### PR TITLE
Issue 743 : v2.0.0 Release Notes (release_notes.md) Doc Missing an Intro

### DIFF
--- a/site/en/about/roadmap.md
+++ b/site/en/about/roadmap.md
@@ -6,8 +6,6 @@ summary: Roadmap and enhancement plan of Milvus.
 ---
 # Milvus Roadmap
 
-The Milvus roadmap shares an overview of new benefits and feature upgrades we hope to provide for users in our upcoming releases, as well as our long-term goals. It is driven by user priorities and may change as their requirement or demand changes.
-
 ![Roadmap](../../../assets/roadmap.jpg)
 
 


### PR DESCRIPTION
## Description

This PR adds an introduction section to the Release Notes page.

## Issue

This PR fixes https://github.com/milvus-io/milvus-docs/issues/743


> **NOTE:**  Keeping in mind https://github.com/milvus-io/milvus-docs/issues/783, the Chinese translation for the same section has not been added as it needs someone proficient in Chinese to do the job. This opens the scope for another ticket that can be contributed to by some other contributor who is proficient in the language.