### PR TITLE
Issue 742 : Milvus Roadmap is missing an introduction

### DIFF
--- a/site/en/about/roadmap.md
+++ b/site/en/about/roadmap.md
@@ -6,6 +6,8 @@ summary: Roadmap and enhancement plan of Milvus.
 ---
 # Milvus Roadmap
 
+The Milvus roadmap shares an overview of new benefits and feature upgrades we hope to provide for users in our upcoming releases, as well as our long-term goals. It is driven by user priorities and may change as their requirement or demand changes.
+
 ![Roadmap](../../../assets/roadmap.jpg)
 
 


### PR DESCRIPTION
## Description

This PR adds an introduction section in the Milvus Roadmap.md file.

## Issue

This PR fixes https://github.com/milvus-io/milvus-docs/issues/742


> **NOTE:**  Keeping in mind https://github.com/milvus-io/milvus-docs/issues/783, the Chinese translation for the same section has not been added as it needs someone proficient in Chinese to do the job. This opens the scope for another ticket that can be contributed to by some other contributor who is proficient in the language.