### PR TITLE
[911] TASK: Add spanish translation for `example_code`

### DIFF
--- a/site/en/getstarted/example_code_es.md
+++ b/site/en/getstarted/example_code_es.md
@@ -1,10 +1,5 @@
 ---
 id: example_code_es.md
-related_key: pymilvus
-label: Python
-order: 0
-group: example
-summary: Get started with Milvus faster using this Python example code.
 ---
 
 # Ejecuta Milvus usando Python


### PR DESCRIPTION
From issue -> https://github.com/milvus-io/milvus-docs/issues/911

# Problem
- example_code is missing spanish translation

# Solution
- Added spanish translation 😁 