### PR TITLE
[Do Not Merge] Removed m2h.md

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -365,20 +365,12 @@
       "isMenu": true
     },
     {
-      "id": "m2h.md",
-      "title": "Milvus to HDF5 ",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 0
-    },
-    {
       "id": "h2m.md",
       "title": "HDF5 to Milvus",
       "label1": "admin_guide",
       "label2": "migrate",
       "label3": "",
-      "order": 1
+      "order": 0
     },
     {
       "id": "f2m.md",
@@ -386,7 +378,7 @@
       "label1": "admin_guide",
       "label2": "migrate",
       "label3": "",
-      "order": 2
+      "order": 1
     },
     {
       "id": "m2m.md",
@@ -394,7 +386,7 @@
       "label1": "admin_guide",
       "label2": "migrate",
       "label3": "",
-      "order": 3
+      "order": 2
     },
     {
       "id": "upgrade.md",


### PR DESCRIPTION
Removed this doc under Migrate as it is not supported by Milvus 2.0.
> MilvusDM only supports exporting data to HDF5 files with Milvus version 1.x.