### PR TITLE
Update supported datatype for primary key field

### DIFF
--- a/site/en/reference/schema.md
+++ b/site/en/reference/schema.md
@@ -70,9 +70,6 @@ embedding_field = FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim
 `DataType` defines the kind of data a field contains. Different fields support different data types.
 
 - Primary key field supports:
-  - INT8: numpy.int8
-  - INT16: numpy.int16
-  - INT32: numpy.int32
   - INT64: numpy.int64
 - Scalar field supports:
   - BOOL: Boolean (`true` or `false`)


### PR DESCRIPTION
Deleted INT8/16/32 in "Primary key field supports:".