### PR TITLE
Improve clarity and fix inconsistencies in install Milvus standalone docs

### DIFF
--- a/site/en/fragments/installation_guide.md
+++ b/site/en/fragments/installation_guide.md
@@ -1,6 +1,4 @@
-This topic describes how to install Milvus standalone with Docker Compose or on Kubernetes. 
-
-[Check the requirements for hardware and software](prerequisite-docker.md) prior to your installation. 
+This topic describes how to install Milvus standalone using Docker Compose, Kubernetes, or APT/YUM.
 
 If you run into image loading errors while installing, you can [Install Milvus Offline](install_offline-docker.md).
 

--- a/site/en/getstarted/standalone/install_standalone-aptyum.md
+++ b/site/en/getstarted/standalone/install_standalone-aptyum.md
@@ -13,16 +13,20 @@ summary: Learn how to install Milvus stanalone with APT or YUM.
 
 {{tab}}
 
+## Prerequisites
+
+Ensure that your CPU, RAM, and disk meets the requirements in [Environment Checklist](prerequisite-docker.md) prior to your installation.
+
 ## Install Milvus with APT on Ubuntu
 
-You can install Milvus standalone with either Launchpad PPA or directly with the Debian software package.
+On Ubuntu, you can install Milvus standalone either via Launchpad PPA or directly with a `.deb` package.
 
-### Install via Launchpad PPA on Ubuntu
+### Install via Launchpad PPA
 
-Milvus standalone is now available on Launchpad PPA.
+You can install Milvus standalone via Launchpad PPA (Personal Package Archive). PPA allows you to install packages outside Ubuntu's official repository with APT.
 
 <div class="alert note">
-Currently, Milvus supports installation via Launchpad PPA only on Ubuntu 18.04.
+Currently, the PPA package of Milvus only supports Ubuntu 18.04.
 </div>
 
 ```bash
@@ -32,9 +36,9 @@ $ sudo apt update
 $ sudo apt install milvus
 ```
 
-### Install with Debian software package
+### Install with a `.deb` package
 
-Alternatively, you can download the Debian software package and install Milvus standalone.
+You can also download the `.deb` package that Milvus provides and install Milvus standalone.
 
 ```bash
 $ wget https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_release_tag}}/{{var.milvus_deb_name}}.deb
@@ -45,22 +49,35 @@ $ sudo apt-get -f install
 
 ## Install Milvus with YUM on CentOS
 
-You can install Milvus standalone with YUM.
+On CentOS, you can install Milvus standalone with YUM.
 
 ```bash
 $ sudo yum install https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_release_tag}}/{{var.milvus_rpm_name}}.rpm
 ```
 
-
 ## Check the status of Milvus and its dependencies
 
-After installation, Milvus standalone and its dependencies, i.e. etcd and MinIO, start directly. You can check their status.
+After installation, Milvus standalone and its dependencies (etcd and MinIO) start automatically. You can check their status by:
 
 ```bash
 $ sudo systemctl status milvus
 $ sudo systemctl status milvus-etcd
 $ sudo systemctl status milvus-minio
 ```
+
+## Uninstall Milvus
+
+Run the following command to uninstall Milvus.
+
+```bash
+$ sudo apt-get remove milvus
+```
+
+Additionally, remove Milvus from your system's repository list if you installed via PPA.
+
+```bash
+$ sudo add-apt-repository --remove ppa:milvusdb/milvus
+````
 
 ## What's next
 

--- a/site/en/getstarted/standalone/install_standalone-aptyum.md
+++ b/site/en/getstarted/standalone/install_standalone-aptyum.md
@@ -7,11 +7,11 @@ group: install_standalone-docker.md
 summary: Learn how to install Milvus stanalone with APT or YUM.
 ---
 
+{{tab}}
+
 # Install Milvus Standalone
 
-{{fragments/installation_guide.md}}
-
-{{tab}}
+This topic describes how to install Milvus standalone using package manager APT or YUM on Linux systems.
 
 ## Prerequisites
 

--- a/site/en/getstarted/standalone/install_standalone-docker.md
+++ b/site/en/getstarted/standalone/install_standalone-docker.md
@@ -13,35 +13,44 @@ summary: Learn how to install Milvus stanalone with Docker Compose.
 
 {{tab}}
 
-## Download an installation file
+## Prerequisites
 
-[Download](https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_release_tag}}/milvus-standalone-docker-compose.yml) `milvus-standalone-docker-compose.yml` directly or with the following command, and save it as `docker-compose.yml`.
+Check [the requirements](prerequisite-docker.md) for hardware and software prior to your installation.
+
+## Download the `YAML` file
+
+[Download](https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_release_tag}}/milvus-standalone-docker-compose.yml) `milvus-standalone-docker-compose.yml` and save it as `docker-compose.yml` manually, or with the following command.
 
 ```
 $ wget https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_release_tag}}/milvus-standalone-docker-compose.yml -O docker-compose.yml
 ```
 
-
 ## Start Milvus
+
+In the same directory as the `docker-compose.yml` file, start up Milvus by running:
 
 ```shell
 $ sudo docker-compose up -d
 ```
 
+<div class="alert note">
+If your system has Docker Compose V2 installed instead of V1, use `docker compose` instead of `docker-compose`. Check if this is the case with `$ docker compose version`. Read [here](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command) for more information.
+</div>
+
 ```text
-Docker Compose is now in the Docker CLI, try `docker compose up`
 Creating milvus-etcd  ... done
 Creating milvus-minio ... done
 Creating milvus-standalone ... done
 ```
 
+Now check if the containers are up and running.
 
-Check the status of the containers.
 ```
 $ sudo docker-compose ps
 ```
 
-After Milvus standalone starts, three running docker containers appear including two dependencies and one Milvus service. 
+After Milvus standalone starts, there will be three docker containers running, including the Milvus standalone service and its two dependencies.
+
 ```
       Name                     Command                  State                          Ports
 ----------------------------------------------------------------------------------------------------------------

--- a/site/en/getstarted/standalone/install_standalone-docker.md
+++ b/site/en/getstarted/standalone/install_standalone-docker.md
@@ -7,11 +7,11 @@ group: install_standalone-docker.md
 summary: Learn how to install Milvus stanalone with Docker Compose.
 ---
 
+{{tab}}
+
 # Install Milvus Standalone
 
-{{fragments/installation_guide.md}}
-
-{{tab}}
+This topic describes how to install Milvus standalone using Docker Compose.
 
 ## Prerequisites
 

--- a/site/en/getstarted/standalone/install_standalone-helm.md
+++ b/site/en/getstarted/standalone/install_standalone-helm.md
@@ -6,11 +6,11 @@ group: install_standalone-docker.md
 summary: Learn how to install Milvus stanalone on Kubernetes.
 ---
 
+{{tab}}
+
 # Install Milvus Standalone
 
-{{fragments/installation_guide.md}}
-
-{{tab}}
+This topic describes how to install Milvus standalone using Kubernetes.
 
 ## Prerequisites
 

--- a/site/en/getstarted/standalone/install_standalone-helm.md
+++ b/site/en/getstarted/standalone/install_standalone-helm.md
@@ -10,25 +10,25 @@ summary: Learn how to install Milvus stanalone on Kubernetes.
 
 {{fragments/installation_guide.md}}
 
-
 {{tab}}
 
-We recommend installing Milvus on Kubernetes with minikube. minikube has a dependency on default storageclass when installed. Check the dependency by running the following command. Other installation methods requires manual configuration of the storageclass. See [Change the Default Storageclass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) for more information.
+## Prerequisites
 
-```
+Check [the requirements](prerequisite-helm.md)  for hardware and software prior to your installation.
+
+We recommend installing Milvus on Kubernetes (K8s) with minikube, which is a tool that allows you to run Kubernetes locally.
+
+minikube has a dependency on default StorageClass when installed. Check the dependency by running the following command. Other installation methods requires manual configuration of the StorageClass. See [Change the Default StorageClass](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) for more information.
+
+```bash
 $ kubectl get sc
-```
-```
 NAME                  PROVISIONER                  RECLAIMPOLICY    VOLUMEBIINDINGMODE    ALLOWVOLUMEEXPANSION     AGE
 standard (default)    k8s.io/minikube-hostpath     Delete           Immediate             false                    3m36s
 ```
 
-
 ## Start a K8s cluster
 
-minikube is a tool that allows you to run Kubernetes locally.
-
-```
+```bash
 $ minikube start
 ```
 
@@ -36,15 +36,15 @@ $ minikube start
 
 Helm is a Kubernetes package manager that can help you deploy Milvus quickly.
 
-1. Add Milvus Helm repository.
+1. Add Milvus to Helm's repository.
 
-```
+```bash
 $ helm repo add milvus https://milvus-io.github.io/milvus-helm/
 ```
 
-2. Update charts locally.
+2. Update your local chart repository.
 
-```
+```bash
 $ helm repo update
 ```
 
@@ -52,8 +52,7 @@ $ helm repo update
 
 Start Milvus with Helm by specifying the release name, the chart, and parameters you expect to change. This topic uses <code>my-release</code> as the release name. To use a different release name, replace <code>my-release</code> in the command.
 
-
-```
+```bash
 $ helm install my-release milvus/milvus --set cluster.enabled=false --set etcd.replicaCount=1 --set minio.mode=standalone --set pulsar.enabled=false
 ```
 
@@ -63,13 +62,13 @@ See <a href="https://artifacthub.io/packages/helm/milvus/milvus">Milvus Helm Cha
 
 Check the status of the running pods.
 
-```
+```bash
 $ kubectl get pods
 ```
 
 After Milvus starts, the `READY` column displays `1/1` for all pods.
 
-```
+```text
 NAME                                               READY   STATUS      RESTARTS   AGE
 my-release-etcd-0                                  1/1     Running     0          30s
 my-release-milvus-standalone-54c4f88cb9-f84pf      1/1     Running     0          30s
@@ -78,21 +77,26 @@ my-release-minio-5564fbbddc-mz7f5                  1/1     Running     0        
 
 ## Connect to Milvus
 
-Open a new terminal and run the following command to forward the local port to the port that Milvus uses.
+Verify which local port the Milvus server is listening on. Replace the pod name with your own.
 
-```
-$ kubectl port-forward service/my-release-milvus 19530
+```bash
+$ kubectl get pod my-release-milvus-standalone-54c4f88cb9-f84pf --template
+='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+19530
 ```
 
-```
-Forwarding from 127.0.0.1:19530 -> 19530
+Open a new terminal and run the following command to forward a local port to the port that Milvus uses. Optionally, omit the designated port and use `:19530` to let `kubectl` allocate a local port for you so that you don't have to manage port conflicts.
+
+```bash
+$ kubectl port-forward service/my-release-milvus 27017:19530
+Forwarding from 127.0.0.1:27017 -> 19530
 ```
 
 ## Uninstall Milvus
 
 Run the following command to uninstall Milvus.
 
-```
+```bash
 $ helm uninstall my-release
 ```
 
@@ -100,24 +104,23 @@ $ helm uninstall my-release
 
 Stop the cluster and the minikube VM without deleting the resources you created.
 
-```
+```bash
 $ minikube stop
 ```
 
 Run `minikube start` to restart the cluster.
 
-
 ## Delete the K8s cluster
-
-Delete the cluster, the minikube VM, and all resources you created including persistent volumes.
-
-```
-$ minikube delete
-```
 
 <div class="alert note">
 Run <code>$ kubectl logs `pod_name`</code> to get the <code>stderr</code> log of the pod before deleting the cluster and all resources.
 </div>
+
+Delete the cluster, the minikube VM, and all resources you created including persistent volumes.
+
+```bash
+$ minikube delete
+```
 
 ## What's next
 

--- a/site/en/release_notes.md
+++ b/site/en/release_notes.md
@@ -38,7 +38,7 @@ Milvus 2.0.2 is a minor bug-fix version of Milvus 2.0. We fixed multiple critica
 
 <h3 id="v2.0.2">Bug fixes</h3>
 
-- [#16338](https://github.com/milvus-io/milvus/pull/16338) Data coord uses VChannel when when unsubscribing to data node.
+- [#16338](https://github.com/milvus-io/milvus/pull/16338) Data coord uses VChannel when unsubscribing to data node.
 - [#16178](https://github.com/milvus-io/milvus/pull/16178) [#15725](https://github.com/milvus-io/milvus/pull/15725) Query node crashes.
 - [#16035](https://github.com/milvus-io/milvus/pull/16035) [#16063](https://github.com/milvus-io/milvus/pull/16063) [#16066](https://github.com/milvus-io/milvus/pull/16066) Collection load error.
 - [#15932](https://github.com/milvus-io/milvus/pull/15932) Compaction runtime error.


### PR DESCRIPTION
- Move prerequisites to individual tabs
- Add explanations on PPA
- Add uninstallation guide for APT/YUM
- Add note on Docker Compose V2
- Bridge gaps in the Milvus connection guide