### PR TITLE
Remove migrate docs

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -611,45 +611,12 @@
       "order": 4
     },
     {
-      "id": "migrate",
-      "title": "Migrate",
-      "label1": "admin_guide",
-      "label2": "",
-      "label3": "",
-      "order": 6,
-      "isMenu": true
-    },
-    {
-      "id": "h2m.md",
-      "title": "HDF5 to Milvus",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 0
-    },
-    {
-      "id": "f2m.md",
-      "title": "Faiss to Milvus ",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 1
-    },
-    {
-      "id": "m2m.md",
-      "title": "Milvus 1.x to 2.0",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 2
-    },
-    {
       "id": "security",
       "title": "Security",
       "label1": "admin_guide",
       "label2": "",
       "label3": "",
-      "order": 7,
+      "order": 6,
       "isMenu": true
     },
     {

--- a/site/en/migrate/migrate_overview.md
+++ b/site/en/migrate/migrate_overview.md
@@ -4,8 +4,13 @@ summary: MilvusDM allows data migration between Milvus and many other sources of
 ---
 
 # Overview
-[MilvusDM](https://github.com/milvus-io/milvus-tools) (Milvus Data Migration) is an open-source tool designed specifically for importing and exporting data with Milvus. MilvusDM allows you to migrate data in a specific collection or partition. To substantially improve data management efficiency and reduce DevOps costs, MilvusDM supports the following migration channels: 
+[MilvusDM](https://github.com/milvus-io/milvus-tools) (Milvus Data Migration) is an open-source tool designed specifically for importing and exporting data with Milvus. MilvusDM allows you to migrate data in a specific collection or partition. 
 
+<div class="alert note">
+Currently, MilvusDM is only supported in Milvus 1.x version.
+</div>
+
+To substantially improve data management efficiency and reduce DevOps costs, MilvusDM supports the following migration channels: 
 - [Milvus to Milvus](m2m.md): Migrates data between instances of Milvus.
 - [Faiss to Milvus](f2m.md): Imports unzipped data from Faiss to Milvus.
 - [HDF5 to Milvus](h2m.md): Imports HDF5 files into Milvus.


### PR DESCRIPTION
The migrate function in 2.1.x is not tested. And it seems like MilvusDM is not compatible with Milvus 2.1.x. Remove the docs temporarily as suggested by Yanliang Qiao.