### PR TITLE
Remove migrate docs in 2.0.x

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -529,39 +529,6 @@
       "order": 3
     },
     {
-      "id": "migrate",
-      "title": "Migrate",
-      "label1": "admin_guide",
-      "label2": "",
-      "label3": "",
-      "order": 8,
-      "isMenu": true
-    },
-    {
-      "id": "h2m.md",
-      "title": "HDF5 to Milvus",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 0
-    },
-    {
-      "id": "f2m.md",
-      "title": "Faiss to Milvus ",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 1
-    },
-    {
-      "id": "m2m.md",
-      "title": "Milvus 1.x to 2.0",
-      "label1": "admin_guide",
-      "label2": "migrate",
-      "label3": "",
-      "order": 2
-    },
-    {
       "id": "tools",
       "title": "Tools",
       "label1": "",

--- a/site/en/migrate/migrate_overview.md
+++ b/site/en/migrate/migrate_overview.md
@@ -4,7 +4,13 @@ summary: MilvusDM allows data migration between Milvus and many other sources of
 ---
 
 # Overview
-[MilvusDM](https://github.com/milvus-io/milvus-tools) (Milvus Data Migration) is an open-source tool designed specifically for importing and exporting data with Milvus. MilvusDM allows you to migrate data in a specific collection or partition. To substantially improve data management efficiency and reduce DevOps costs, MilvusDM supports the following migration channels: 
+[MilvusDM](https://github.com/milvus-io/milvus-tools) (Milvus Data Migration) is an open-source tool designed specifically for importing and exporting data with Milvus. MilvusDM allows you to migrate data in a specific collection or partition. 
+
+<div class="alert note">
+Currently, MilvusDM is only supported in Milvus 1.x version.
+</div>
+
+To substantially improve data management efficiency and reduce DevOps costs, MilvusDM supports the following migration channels: 
 
 - [Milvus to Milvus](m2m.md): Migrates data between instances of Milvus.
 - [Faiss to Milvus](f2m.md): Imports unzipped data from Faiss to Milvus.


### PR DESCRIPTION
This function is not tested and removed as suggested by Yanliang Qiao.