### PR TITLE
Fix description of MatchOp

### DIFF
--- a/site/en/reference/boolean.md
+++ b/site/en/reference/boolean.md
@@ -69,7 +69,7 @@ The following table lists the description of each symbol mentioned in the above 
 | SingleExpr   |  SingleExpr, namely single expression, can be either a TermExpr or a CompareExpr.      |
 | LogicalExpr      | A LogicalExpr can be a BinaryLogicalOp on two LogicalExprs, or a UnaryLogicalOp on a single LogicalExpr, or a LogicalExpr grouped within parentheses, or a SingleExpr. The LogicalExpr is defined recursively.    |
 | Expr   | Expr, an abbreviation meaning expression, can be LogicalExpr or NIL. |
-| MatchOp   | A MatchOp, namely a match operator, compares a string to a regular expression. |
+| MatchOp   | A MatchOp, namely a match operator, compares a string to a string constant or a string prefix constant. |
 
 ## Operators
 


### PR DESCRIPTION
When reading "regular expression" most people will assume a POSIX / Perl regex.
However the LIKE operation does not support arbitrary regexes, only a constant string or a prefix.
ref https://github.com/milvus-io/milvus/blob/ac389f3e9309f8197122c30d1298494ece4d2afa/internal/parser/planparserv2/pattern_match.go#L70-L75