### PR TITLE
Remove consistency from create a collection

### DIFF
--- a/site/en/reference/consistency.md
+++ b/site/en/reference/consistency.md
@@ -10,7 +10,7 @@ This topic introduces the four levels of consistency in Milvus and their best-su
 
 Consistency in a distributed database specifically refers to the property that ensures every node or replica has the same view of data when writing or reading data at a given time. 
 
-Milvus supports four consistency levels:  strong, bounded staleness, session, and eventually. The default consistency level in Milvus is bounded staleness.  You can easily tune the consistency level when [creating a collection](create_collection.md) or conducting a [vector similarity search](search.md) or [query](query.md) to make it best suit your application.
+Milvus supports four consistency levels:  strong, bounded staleness, session, and eventually. The default consistency level in Milvus is bounded staleness.  You can easily tune the consistency level when conducting a [vector similarity search](search.md) or [query](query.md) to make it best suit your application.
 
 ## Consistency levels
 
@@ -69,7 +69,6 @@ See [How GuaranteeTs Works](https://github.com/milvus-io/milvus/blob/f3f46d3bb2d
 ## What's next
 
 - Learn how to tune consistency level when:
-  - [creating a collection](create_collection.md)
   - [conducting a vector similarity search](search.md)
   - [conducting a vector query](query.md)
 

--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -12,8 +12,6 @@ A collection consists of one or more partitions. While creating a new collection
 
 The following example builds a two-[shard](glossary.md#Sharding) collection named `book`, with a primary key field named `book_id`, an `INT64` scalar field named `word_count`, and a two-dimensional floating-point vector field named `book_intro`. Real applications will likely use much higher dimensional vectors than the example.
 
-Milvus supports setting consistency level while creating a collection. The example in this topic sets the consistency level of the collection as `Strong`. You can also set the consistency level as `Bounded`, `Session` or `Eventually`. See [Consistency](consistency.md) for more information about the four consistency levels in Milvus.
-
 
 ## Prepare Schema
 
@@ -150,7 +148,6 @@ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -d '{
     "collection_name": "book",
-    "consistency_level": 1,
     "schema": {
       "autoID": false,
       "description": "Test book search",
@@ -524,17 +521,6 @@ Output:
             <td>N/A</td>
         </tr>
         <tr>
-            <td><code>consistency_level</code></td>
-            <td>Consistency level of the collection to create.</td>
-            <td><ul>
-                    <li>0 for <code>Strong</code></li>
-                    <li>1 for <code>Session</code> (default)</li>
-                    <li>2 for <code>Bounded</code></li>
-                    <li>3 for <code>Eventually</code></li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
             <td><code>name</code> (schema)</td>
             <td>Must be the same as <code>collection_name</code>, this duplicated field is kept for historical reasons.</td>
             <td>Same as <code>collection_name</code></td>
@@ -620,7 +606,7 @@ Output:
 
 ## Create a collection with the schema
 
-Then, create a collection with `Strong` consistency level and the schema you specified above.
+Then, create a collection with the schema you specified above.
 
 {{fragments/multiple_code.md}}
 
@@ -631,7 +617,6 @@ collection = Collection(
     schema=schema, 
     using='default', 
     shards_num=2,
-    consistency_level="Strong"
     )
 ```
 
@@ -680,19 +665,6 @@ milvusClient.createCollection(createCollectionReq);
             <td><code>shards_num</code> (optional)</td>
             <td>Number of the shards for the collection to create.</td>
             <td>[1,256]</td>
-        </tr>
-        <tr>
-            <td><code>consistency_level</code> (optional)</td>
-            <td>Consistency level of the collection to create.</td>
-            <td>
-                <ul>
-                    <li><code>Strong</code></li>
-                    <li><code>Bounded</code></li>
-                    <li><code>Session</code></li>
-                    <li><code>Eventually</code></li>
-                    <li><code>Customized</code></li>
-                </ul>
-            </td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Tuning consistency level is not suggested when creating a collection. Users should choose the consistency level while conducting a search or query.