### PR TITLE
Fix discrepancies between User Guide Milvus CLI examples and the main Milvus CLI Command Reference

### DIFF
--- a/site/en/userGuide/collection_alias.md
+++ b/site/en/userGuide/collection_alias.md
@@ -197,7 +197,7 @@ milvusClient.dropAlias(
 ```
 
 ```shell
-delete alias -c book -a publication
+delete alias -a publication
 ```
 
 ```curl
@@ -268,10 +268,6 @@ curl -X 'DELETE' \
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td>-c</td>
-            <td>Name of the collection to drop alias on.</td>
-        </tr>
         <tr>
             <td>-a</td>
             <td>Collection alias to drop.</td>

--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -138,7 +138,7 @@ CreateCollectionParam createCollectionReq = CreateCollectionParam.newBuilder()
 ```
 
 ```shell
-create collection -c book -f book_id:INT64 -f word_count:INT64 -f book_intro:FLOAT_VECTOR:2 -p book_id
+create collection -c book -f book_id:INT64:book_id -f word_count:INT64:word_count -f book_intro:FLOAT_VECTOR:2 -p book_id
 ```
 
 ```curl

--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -489,7 +489,7 @@ Output:
         </tr>
         <tr>
             <td>-f (Multiple)</td>
-            <td>The field schema in the    ```<fieldName>:<dataType>:<dimOfVector/desc>``` format.</td>
+            <td>The field schema in the `<fieldName>:<dataType>:<dimOfVector/desc>` format.</td>
         </tr>
         <tr>
             <td>-p</td>


### PR DESCRIPTION
Some of the User Guide Milvus CLI examples are incorrect compared to the Milvus CLI Command Reference. Tested using the https://github.com/zilliztech/milvus_cli docker image of the following versions:
```
Milvus cli version: 0.3.0
Pymilvus version: 2.1.0   
```

## Collection Creation
The [User Guide](https://milvus.io/docs/v2.1.x/create_collection.md#Prepare-Schema) shows the following command to create a collection
```sh
create collection -c book -f book_id:INT64 -f word_count:INT64 -f book_intro:FLOAT_VECTOR:2 -p book_id
```
However, using the command returns the following error:
```
Error!
Field should contain three paremeters and concat by ":".
```

The [Milvus CLI Command Reference](https://milvus.io/docs/v2.1.x/cli_commands.md#create-collection) indicates that the field schema should be `<fieldName>:<dataType>:<dimOfVector/desc>`

## Alias Deletion
The [User Guide](https://milvus.io/docs/v2.1.x/collection_alias.md#Drop-a-collection-alias) shows the following command to delete a collection alias
```sh
create alias -c book -A -a publication
```
However, using the command returns the following message:
```
Usage: milvus_cli delete alias [OPTIONS]
Try 'milvus_cli delete alias --help' for help.

Error: No such option: -c
```

The [Milvus CLI Command Reference](https://milvus.io/docs/v2.1.x/cli_commands.md#delete-alias) indicates that the `-c` flag is not needed


## Other
- Aside from these differences that I have pointed out, the User Guide generally misses out on the `--timeout` and `--help` flags as mentioned in the Command Reference. Let me know if I should add these in, or if they are inconsequential