### PR TITLE
Fix the max ShardsNum

### DIFF
--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -470,7 +470,7 @@ Output:
         <tr>
             <td><code>ShardsNum</code></td>
             <td>Number of the shards for the collection to create.</td>
-            <td>[1,256]</td>
+            <td>[1,64]</td>
         </tr>
 	</tbody>
 </table>


### PR DESCRIPTION
The max shard number of a collection in Milvus should be 64.