### PR TITLE
Fix rendering of field description of the Create Collection CLI command

### DIFF
--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -489,7 +489,7 @@ Output:
         </tr>
         <tr>
             <td>-f (Multiple)</td>
-            <td>The field schema in the `&lt;fieldName&gt;:&lt;dataType&gt;:&lt;dimOfVector/desc&gt;` format.</td>
+            <td>The field schema in the <code>&lt;fieldName&gt;:&lt;dataType&gt;:&lt;dimOfVector/desc&gt;</code> format.</td>
         </tr>
         <tr>
             <td>-p</td>

--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -489,7 +489,7 @@ Output:
         </tr>
         <tr>
             <td>-f (Multiple)</td>
-            <td>The field schema in the `<fieldName>:<dataType>:<dimOfVector/desc>` format.</td>
+            <td>The field schema in the `&lt;fieldName&gt;:&lt;dataType&gt;:&lt;dimOfVector/desc&gt;` format.</td>
         </tr>
         <tr>
             <td>-p</td>


### PR DESCRIPTION
In the [user guide](https://milvus.io/docs/v2.1.x/create_collection.md#shell) for creating a collection via the milvus CLI, the description for the `-f` flag doesn't appear right due to the use of backticks instead of `<code>`  as well as because of the `<` and `>` characters being parsed as HTML  

This PR fixes that

