### PR TITLE
Incorrect field name for Node.js collection spec.

### DIFF
--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -65,7 +65,7 @@ const params = {
         dim: "2",
       },
     },
-	{
+    {
       name: "book_id",
       data_type: 5,   //DataType.Int64
       is_primary_key: true,
@@ -389,14 +389,14 @@ Output:
             <td>Refer to <a href="https://github.com/milvus-io/milvus-sdk-node/blob/main/milvus/const/Milvus.ts#L287">data type reference number</a> for more information.</td>
         </tr>
         <tr>
-            <td><code>is_primary</code> (Mandatory for primary key field)</td>
+            <td><code>is_primary_key</code> (Mandatory for primary key field)</td>
             <td>Switch to control if the field is primary key field.</td>
-            <td><code>True</code> or <code>False</code></td>
+            <td><code>true</code> or <code>false</code></td>
         </tr>
         <tr>
             <td><code>auto_id</code></td>
             <td>Switch to enable or disable Automatic ID (primary key) allocation.</td>
-            <td><code>True</code> or <code>False</code></td>
+            <td><code>true</code> or <code>false</code></td>
         </tr>
         <tr>
             <td><code>dim</code> (Mandatory for vector field)</td>

--- a/site/en/userGuide/create_collection.md
+++ b/site/en/userGuide/create_collection.md
@@ -394,7 +394,7 @@ Output:
             <td><code>true</code> or <code>false</code></td>
         </tr>
         <tr>
-            <td><code>auto_id</code></td>
+            <td><code>autoID</code></td>
             <td>Switch to enable or disable Automatic ID (primary key) allocation.</td>
             <td><code>true</code> or <code>false</code></td>
         </tr>


### PR DESCRIPTION
In the specification of available fields for when creating collections using the Node.js SDK: The field "is_primary_key" is mislabeled as "is_primary". Might trip up some other first time user.

Also cleaned up 2 things while I was at it:
* Indentation in the Node.js collection parameters example
* Default values for boolean values in the JS examples were written as "True" / "False" instead of "true" / "false"