### PR TITLE
The page says SSE42. I think it's supposed to be SSE4.2.

### DIFF
--- a/site/en/quick_start/install_milvus/milvus_docker-cpu.md
+++ b/site/en/quick_start/install_milvus/milvus_docker-cpu.md
@@ -24,7 +24,7 @@ summary: Learn how to install and start CPU-only Milvus using Docker.
 | Component | Recommended configuration             |
 | ---------- | ------------------------------------- |
 | CPU        | Intel CPU Sandy Bridge or higher. |
-| CPU Instruction Set | <ul><li>SSE42</li><li>AVX</li><li>AVX2</li><li>AVX512</li></ul> |
+| CPU Instruction Set | <ul><li>SSE4.2</li><li>AVX</li><li>AVX2</li><li>AVX512</li></ul> |
 | RAM        | 8 GB or more (depends on the data volume) |
 | Hard Drive | SATA 3.0 SSD or higher                |
 


### PR DESCRIPTION
Like on this page on Intel's website:
https://www.intel.in/content/www/in/en/products/sku/75122/intel-core-i74770-processor-8m-cache-up-to-3-90-ghz/specifications.html

![image](https://github.com/milvus-io/milvus-docs/assets/84750225/e7066b38-be42-45ab-9032-6eb27d6472a6)