### PR TITLE
removed non-quote chars with double quotes for java example in search.md

### DIFF
--- a/site/en/userGuide/search/search.md
+++ b/site/en/userGuide/search/search.md
@@ -91,7 +91,7 @@ sp, _ := entity.NewIndexFlatSearchParam( // NewIndex*SearchParam func
 
 ```java
 final Integer SEARCH_K = 2;                       // TopK
-final String SEARCH_PARAM = "{\"nprobe\":10, \”offset\”:5}";    // Params
+final String SEARCH_PARAM = "{\"nprobe\":10, \"offset\":5}";    // Params
 ```
 
 ```shell


### PR DESCRIPTION
Copy pasting failed due to strange quote chars. 