### PR TITLE
update docker-compose for V2

### DIFF
--- a/site/en/getstarted/standalone/install_standalone-docker.md
+++ b/site/en/getstarted/standalone/install_standalone-docker.md
@@ -32,7 +32,7 @@ $ wget https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_relea
 In the same directory as the `docker-compose.yml` file, start up Milvus by running:
 
 ```shell
-$ sudo docker compose up -d
+$ sudo docker-compose up -d
 ```
 
 <div class="alert note">


### PR DESCRIPTION
recommended by https://docs.docker.com/compose/migrate/

```Update scripts to use Compose V2 by replacing the hyphen (-) with a space, using docker compose instead of docker-compose.```

so we shall use `docker-compose` here for V2