### PR TITLE
Fix model for OpenAI embeddings

### DIFF
--- a/site/en/integrations/integrate_with_langchain.md
+++ b/site/en/integrations/integrate_with_langchain.md
@@ -67,7 +67,7 @@ Once the documents are ready, we need to convert them into vector embeddings and
 
 ```python
 # Set up an embedding model to covert document chunks into vector embeddings.
-embeddings = OpenAIEmbeddings(model="ada")
+embeddings = OpenAIEmbeddings()
 
 # Set up a vector store used to save the vector embeddings. Here we use Milvus as the vector store.
 vector_store = Milvus.from_documents(


### PR DESCRIPTION
The current default model is 'text-embedding-ada-002', 'ada' is not accepted by the OpenAI API key.

I've removed the model parameter as by default it uses the correct model.