### PR TITLE
Fixed milvus.io docs links in readme.md & contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The Milvus docs are open-source just like the database itself and welcome contributions from everyone in the Milvus community.
 
-> This repository is for Milvus technical documentation update and maintenance. Visit [Milvus.io](milvus.io) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
+> This repository is for Milvus technical documentation update and maintenance. Visit [Milvus.io](https://milvus.io/docs) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
 
 ## What contributions can I make?
 
@@ -42,7 +42,7 @@ For detailed information on this workflow, see [Make Your First Contribution](ht
 
 ![Folders](assets/folder-structure.png)
 
-- [Languages](#languages)
+- [Languages](#language)
 - [Pages](#pages)
 - [Sidebar](#sidebar)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Milvus documentation!
 
-This repository contains technical documentation for [Milvus](https://github.com/milvus-io/milvus), the world's most advanced open-source vector database. Visit [Milvus.io](https://milvus.io/) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
+This repository contains technical documentation for [Milvus](https://github.com/milvus-io/milvus), the world's most advanced open-source vector database. Visit [Milvus.io](https://milvus.io/docs) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
 
 Each branch corresponds to a Milvus release by name. We've set the branch of the latest Milvus release as the default branch. For documentation of a different Milvus release, switch to the corresponding branch.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Milvus documentation!
 
-This repository contains technical documentation for [Milvus](https://github.com/milvus-io/milvus), the world's most advanced open-source vector database. Visit [Milvus.io](milvus.io) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
+This repository contains technical documentation for [Milvus](https://github.com/milvus-io/milvus), the world's most advanced open-source vector database. Visit [Milvus.io](https://milvus.io/) or [Web content repo](https://github.com/milvus-io/web-content) for fully rendered documents.
 
 Each branch corresponds to a Milvus release by name. We've set the branch of the latest Milvus release as the default branch. For documentation of a different Milvus release, switch to the corresponding branch.
 


### PR DESCRIPTION
I have corrected all the links that were not working for milvus.io docs in the Readme.md and CONTRIBUTING.md. 
If you want to change anything in this PR please feel free to tell me, I will be more than happy to rectify it.

I have also changed the `#languages` to `#language` in CONTRIBUTING.md as it was not working earlier.

This PR closes the issue #2328 