### PR TITLE
migrate to docker compose command

### DIFF
--- a/site/en/adminGuide/configure-docker.md
+++ b/site/en/adminGuide/configure-docker.md
@@ -216,7 +216,7 @@ Data are stored in the <code>/volumes</code> folder according to the default con
 Having finished modifying the configuration file and installation file, you can then start Milvus.
 
 ```
-$ sudo docker-compose up -d
+$ sudo docker compose up -d
 ```
 
 ## What's next

--- a/site/en/adminGuide/deploy_etcd.md
+++ b/site/en/adminGuide/deploy_etcd.md
@@ -47,7 +47,7 @@ See [etcd-related Configurations](configure_etcd.md) for more information.
 Run the following command to start Milvus that uses the etcd configurations.
 
 ```
-docker-compose up
+docker compose up
 ```
 
 <div class="alert note">Configurations only take effect after Milvus starts. See <a href=https://milvus.io/docs/install_standalone-docker.md#Start-Milvus>Start Milvus</a> for more information.</div>

--- a/site/en/adminGuide/deploy_s3.md
+++ b/site/en/adminGuide/deploy_s3.md
@@ -33,7 +33,7 @@ You'd also remove the `MINIO_ADDRESS` environment variable for milvus service at
 ### 3. Run Milvus
 Run the following command to start Milvus that uses the S3 configurations.
 ```shell
-docker-compose up
+docker compose up
 ```
 <div class="alert note">Configurations only take effect after Milvus starts. See <a href=https://milvus.io/docs/install_standalone-docker.md#Start-Milvus>Start Milvus</a> for more information.</div>
 

--- a/site/en/adminGuide/upgrade_milvus_cluster-docker.md
+++ b/site/en/adminGuide/upgrade_milvus_cluster-docker.md
@@ -57,8 +57,8 @@ In normal cases, you can upgrade Milvus as follows:
 2. Run the following commands to perform the upgrade.
 
     ```shell
-    docker-compose down
-    docker-compose up -d
+    docker compose down
+    docker compose up -d
     ```
 
 ## Migrate the metadata
@@ -103,8 +103,8 @@ In normal cases, you can upgrade Milvus as follows:
 
     ```
     Update the milvus image tag in the docker-compose.yaml
-    docker-compose down
-    docker-compose up -d
+    docker compose down
+    docker compose up -d
     ```
 
 ## What's next

--- a/site/en/adminGuide/upgrade_milvus_standalone-docker.md
+++ b/site/en/adminGuide/upgrade_milvus_standalone-docker.md
@@ -37,8 +37,8 @@ In normal cases, you can upgrade Milvus as follows:
 2. Run the following commands to perform the upgrade.
 
     ```shell
-    docker-compose down
-    docker-compose up -d
+    docker compose down
+    docker compose up -d
     ```
 
 ## Migrate the metadata
@@ -83,8 +83,8 @@ In normal cases, you can upgrade Milvus as follows:
 
     ```shell
     // Run the following only after update the milvus image tag in the docker-compose.yaml
-    docker-compose down
-    docker-compose up -d
+    docker compose down
+    docker compose up -d
     ```
 
 ## What's next

--- a/site/en/getstarted/standalone/install_standalone-docker.md
+++ b/site/en/getstarted/standalone/install_standalone-docker.md
@@ -32,7 +32,7 @@ $ wget https://github.com/milvus-io/milvus/releases/download/v{{var.milvus_relea
 In the same directory as the `docker-compose.yml` file, start up Milvus by running:
 
 ```shell
-$ sudo docker-compose up -d
+$ sudo docker compose up -d
 ```
 
 <div class="alert note">

--- a/site/en/getstarted/standalone/install_standalone-gpu-docker.md
+++ b/site/en/getstarted/standalone/install_standalone-gpu-docker.md
@@ -141,7 +141,7 @@ You can connect to Milvus using the local IP address and port number returned by
 
 To stop Milvus standalone, run:
 ```
-sudo docker-compose down
+sudo docker compose down
 ```
 
 To delete data after stopping Milvus, run:


### PR DESCRIPTION
Removes all references to v1 docker-compose command. 

supersedes https://github.com/milvus-io/milvus-docs/pull/2362 and https://github.com/milvus-io/milvus-docs/pull/2387