### PR TITLE
Update import path for the latest llama index

### DIFF
--- a/site/en/integrations/integrate_with_llamaindex.md
+++ b/site/en/integrations/integrate_with_llamaindex.md
@@ -16,7 +16,7 @@ The RAG system combines a retrieval system with a generative model to generate n
 Code snippets on this page require **pymilvus** and **llamaindex** libraries. You can install them using the following commands:
 
 ```shell
-python3 -m pip install --upgrade pymilvus llamaindex openai
+python3 -m pip install --upgrade pymilvus llama-index openai
 ```
 
 What's more, LlamaIndex requires an LLM model at the backend. In this article, we will use the OpenAI as the LLM backend. You can sign up for a free API key at [OpenAI](https://openai.com/).
@@ -52,8 +52,8 @@ print("Document ID:", documents[0].doc_id)
 Now can can create a Milvus collection and insert the documents into it.
 
 ```python
-from llama_index.vector_stores import VectorStoreIndex, MilvusVectorStore
-from llama_index.storage.storage_context import StorageContext
+from llama_index.core import VectorStoreIndex, StorageContext
+from llama_index.vector_stores.milvus import MilvusVectorStore
 
 vector_store = MilvusVectorStore(dim=1536, overwrite=True)
 storage_context = StorageContext.from_defaults(vector_store=vector_store)


### PR DESCRIPTION
Per the llama index v0.10.18 doc, https://docs.llamaindex.ai/en/stable/examples/vector_stores/MilvusIndexDemo.html, update the llama index import path.