### PR TITLE
docs: update milvus_lite.md - Fix minor typo

### DIFF
--- a/site/en/getstarted/milvus_lite.md
+++ b/site/en/getstarted/milvus_lite.md
@@ -62,7 +62,7 @@ Having installed Milvus in Docker, you can:
 
 - [Upgrade Milvus Using Helm Chart](upgrade_milvus_cluster-helm.md).
 - [Scale your Milvus cluster](scaleout.md).
-- Deploy your Milvu cluster on clouds:
+- Deploy your Milvus cluster on clouds:
   - [Amazon EC2](aws.md)
   - [Amazon EKS](eks.md)
   - [Google Cloud](gcp.md)


### PR DESCRIPTION
## Description

Please detail what this PR addresses. 

This PR addresses a minor typo in the Docs: 
[Milvus lite doc page](https://milvus.io/docs/milvus_lite.md)

<img width="1039" alt="image" src="https://github.com/milvus-io/milvus-docs/assets/65303904/e0a20a2f-3d8b-4ca6-8ca9-f379dba1712f">

## Type of change

Please indicate all that apply to this pull request:

- [x] Documentation update
- [ ] New Core feature
- [ ] Other








