### PR TITLE
Update performance_faq.md suggestion

### DIFF
--- a/site/en/faq/performance_faq.md
+++ b/site/en/faq/performance_faq.md
@@ -18,6 +18,7 @@ Setting `nlist` is scenario-specific. As a rule of thumb, the recommended value 
 The size of each segment is determined by the `datacoord.segment.maxSize` parameter, which is set to 512 MB by default. The total number of entities in a segment n can be estimated by dividing `datacoord.segment.maxSize` by the size of each entity.
 
 Setting `nprobe` is specific to the dataset and scenario, and involves a trade-off between accuracy and query performance. We recommend finding the ideal value through repeated experimentation.
+If the data volume of the entities is within the millions, you might consider using brute-force search. In other words, set `nprobe` to `nlist`.
 
 The following charts are results from a test running on the sift50m dataset and IVF_SQ8 index, which compares recall and query performance of different `nlist`/`nprobe` pairs.
 


### PR DESCRIPTION
If the data volume of the entities is within the millions, you might consider using brute-force search. In other words, set nprobe to nlist.