### PR TITLE
Nit. Add import call for CohereEmbedding

### DIFF
--- a/site/en/embeddings/embed-with-cohere.md
+++ b/site/en/embeddings/embed-with-cohere.md
@@ -21,6 +21,8 @@ pip install "pymilvus[model]"
 Then, instantiate the `CohereEmbeddingFunction`:
 
 ```python
+from pymilvus.model.dense import CohereEmbeddingFunction
+
 cohere_ef = CohereEmbeddingFunction(
     model_name="embed-english-light-v3.0",
     api_key="YOUR_COHERE_API_KEY",


### PR DESCRIPTION
Import is missing, which means when copy pasting it won't work.