### PR TITLE
Update the default of The maximum number of partitions in each collection in manage-partitions.md 

### DIFF
--- a/site/en/userGuide/manage-partitions.md
+++ b/site/en/userGuide/manage-partitions.md
@@ -1025,7 +1025,7 @@ console.log(res)
 
 - __What is the maximum number of partitions that can be created?__
 
-    By default, Milvus allows a maximum of 4,096 partitions to be created. You can adjust the maximum number of partitions by configuring `rootCoord.maxPartitionNum`. For details, refer to [System Configurations](https://milvus.io/docs/configure_rootcoord.md#rootCoordmaxPartitionNum).
+    By default, Milvus allows a maximum of 1,024 partitions to be created. You can adjust the maximum number of partitions by configuring `rootCoord.maxPartitionNum`. For details, refer to [System Configurations](https://milvus.io/docs/configure_rootcoord.md#rootCoordmaxPartitionNum).
 
 - __How can I differentiate between partitions and partition keys?__
 


### PR DESCRIPTION
from the newest doc  of  [rootCoord-related Configurations](https://milvus.io/docs/configure_rootcoord.md#rootCoordmaxPartitionNum) the default value of the max number of partition has change from 4096 to 1024
 on 8/1/2024, 2:10:03 PM.
commit msg: update other files
commit hash 28cae359d5ac6de493a2f6ae67358700a830be33