### PR TITLE
fix :  default num_partitions value from 16->64 in use-partition-key.md

### DIFF
--- a/site/en/userGuide/use-partition-key.md
+++ b/site/en/userGuide/use-partition-key.md
@@ -17,7 +17,7 @@ You can use the partition key to implement multi-tenancy. For details on multi-t
 
 To set a field as the partition key, specify `partition_key_field` when creating a collection schema.
 
-In the example code below, `num_partitions` determines the number of partitions that will be created. By default, it is set to `16`. We recommend you retain the default value.
+In the example code below, `num_partitions` determines the number of partitions that will be created. By default, it is set to `64`. We recommend you retain the default value.
 
 <div class="language-python">
 
@@ -59,7 +59,7 @@ schema = MilvusClient.create_schema(
     auto_id=False,
     enable_dynamic_field=True,
     partition_key_field="color",
-    num_partitions=16 # Number of partitions. Defaults to 16.
+    num_partitions=64 # Number of partitions. Defaults to 64.
 )
 
 schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)


### PR DESCRIPTION
from source code of Milvus :
https://github.com/milvus-io/milvus/blob/031ee6f155e5f508811492d4196e30946cb4aba0/internal/distributed/proxy/httpserver/handler_v2.go since this commit: 
https://github.com/milvus-io/milvus/commit/afa4193fc234cb964372760a151b71bd44ad071a 
the correct value is 64 in these versions  (from v2.4.0 to now v2.4.9)