### PR TITLE
Milvus should be from langchain_milvus.vectorstores

### DIFF
--- a/site/en/integrations/langchain/integrate_with_langchain.md
+++ b/site/en/integrations/langchain/integrate_with_langchain.md
@@ -91,7 +91,7 @@ We will initialize a Milvus vector store with the documents, which load the docu
 
 
 ```python
-from langchain_milvus import Milvus, Zilliz
+from langchain_milvus.vectorstores import Milvus, Zilliz
 from langchain_openai import OpenAIEmbeddings
 
 embeddings = OpenAIEmbeddings()


### PR DESCRIPTION
Without this change, it will fail with

```
Invalid Milvus URI: ./milvus_demo.db
```

But even with this change, it still fail with

```
pymilvus.exceptions.MilvusException: <MilvusException: (code=2, message=Fail connecting to server on unix:/var/folders/r8/vnb_8wm96j151_t9yms3159c0000gn/T/tmpdudd4706_milvus_demo.db.sock, illegal connection params or server unavailable)>
```

