### PR TITLE
Fix typo in clustering-compaction.md

### DIFF
--- a/site/en/userGuide/clustering-compaction.md
+++ b/site/en/userGuide/clustering-compaction.md
@@ -61,8 +61,8 @@ common:
     | `enable` | Specifies whether to enable clustering compaction.<br>Setting this to `true` if you need to enable this feature for every collection having a clustering key. | `false` |
     | `autoEnable` | Specifies whether to enable automatically triggered compaction.<br>Setting this to `true` indicates that Milvus compacts the collections having a clustering key at the specified intervals. | `false` |
     | `triggerInterval` | Specifies the interval in milliseconds at which Milvus starts clustering compaction.<br>This parameter is valid only when `autoEnable` is set to `true`. | - |
-    | `minInterval` | Specifies the minimum interval in milliseconds.<br>This parameter is valid only when `autoEnable` is set to `true`.<br>Setting this to an integer greater than triggerInterval helps avoid repeated compactions within a short period. | - |
-    | `maxInterval` | Specifies the maximum interval in milliseconds.<br>This parameter is valid only when `autoEnable` is set to `true`.<br>Once Milvus detects that a collection has not been clustering-compacted for a duration longer than this value, it forces a clustering compaction. | - |
+    | `minInterval` | Specifies the minimum interval in seconds.<br>This parameter is valid only when `autoEnable` is set to `true`.<br>Setting this to an integer greater than triggerInterval helps avoid repeated compactions within a short period. | - |
+    | `maxInterval` | Specifies the maximum interval in seconds.<br>This parameter is valid only when `autoEnable` is set to `true`.<br>Once Milvus detects that a collection has not been clustering-compacted for a duration longer than this value, it forces a clustering compaction. | - |
     | `newDataSizeThreshold` | Specifies the upper threshold to trigger a clustering compaction.<br>This parameter is valid only when `autoEnable` is set to `true`.<br>Once Milvus detects that the data volume in a collection exceeds this value, it initiates a clustering compaction process. | - |    
     | `timeout` | Specifies the timeout duration for a clustering compaction.<br>A clustering compaction fails if its execution time exceeds this value. | - |
 


### PR DESCRIPTION
### Related Issue

resolve #2794

### Description

- There are a few typos in clustering compaction document. I think that `minInterval` and `maxInterval` are in seconds not milliseconds, because milvus internal code handles these configs as seconds.

> https://github.com/milvus-io/milvus/blob/6130a85444a7e750bfaf917a5b64645cbd3fd64c/internal/datacoord/compaction_policy_clustering.go#L238-L245

```go
if time.Since(pTime) < Params.DataCoordCfg.ClusteringCompactionMinInterval.GetAsDuration(time.Second) {
  log.Info("Too short time before last clustering compaction, skip compaction")
  return false, nil
}
if time.Since(pTime) > Params.DataCoordCfg.ClusteringCompactionMaxInterval.GetAsDuration(time.Second) {
  log.Info("It is a long time after last clustering compaction, do compaction")
  return true, nil
}
```