### PR TITLE
Update disk_index.md

### DIFF
--- a/site/en/reference/disk_index.md
+++ b/site/en/reference/disk_index.md
@@ -19,8 +19,8 @@ Currently, a vector field only supports one index type. Milvus automatically del
 
 To use DiskANN, note that
 - DiskANN is enabled by default. If you prefer in-memory index over on-disk index, you are advised to disable this feature for a better performance.
-  - To disable it, you can change `queryNode.enableDisk` to `false` in your milvus configuration file.
-  - To enable it again, you can set `queryNode.enableDisk` to `true`.
+  - To disable it, you can change `indexNode.enableDisk` to `false` in your milvus configuration file.
+  - To enable it again, you can set `indexNode.enableDisk` to `true`.
 - The Milvus instance runs on Ubuntu 18.04.6 or a later release.
 - The Milvus data path should be mounted to an NVMe SSD for full performance:
   - For a Milvus Standalone instance, the data path should be **/var/lib/milvus/data** in the container where the instance runs.


### PR DESCRIPTION
For the issue: https://github.com/milvus-io/milvus-docs/issues/2853


There seems to be a mismatch between the diskANN configs:
https://github.com/milvus-io/milvus/blob/master/configs/milvus.yaml

Below is for indexNode, here it is enabled.
<img width="532" alt="Screenshot 2024-11-04 at 10 52 07 PM" src="https://github.com/user-attachments/assets/e9691dc2-1cb0-4f99-ba5b-a89c432bb92c">

and here for queryNode, it is disabled.
<img width="699" alt="Screenshot 2024-11-04 at 10 52 33 PM" src="https://github.com/user-attachments/assets/37607530-918c-4e3a-a45c-48c3d80812a2">

Based on my understanding it seems it should be indexNode.diskANN as index node will do the indexing.