### PR TITLE
Update install_cluster-helm.md

### DIFF
--- a/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
+++ b/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
@@ -46,10 +46,10 @@ $ helm repo add milvus https://github.com/zilliztech/milvus-helm
 
 <div class="alert note">
 
-The Milvus Helm Charts repo at `https://github.com/milvus-io/milvus-helm` has been archived and you can get further updates from `https://github.com/zilliztech/milvus-helm` as follows:
+The Milvus Helm Charts repo at `https://github.com/milvus-io/milvus-helm` has been archived and you can get further updates from `[https://github.com/zilliztech/milvus-helm](https://zilliztech.github.io/milvus-helm)` as follows:
 
 ```shell
-helm repo add zilliztech https://github.com/zilliztech/milvus-helm
+helm repo add zilliztech [https://github.com/zilliztech/milvus-helm](https://zilliztech.github.io/milvus-helm)
 helm repo update
 # upgrade existing helm release
 helm upgrade my-release zilliztech/milvus


### PR DESCRIPTION
-- Previous url for installing helm chart is throwing the following error: Error: looks like "https://github.com/zilliztech/milvus-helm" is not a valid chart repository or cannot be reached: failed to fetch https://github.com/zilliztech/milvus-helm/index.yaml : 404 Not -- Found the updated url from the readme in this repository: https://github.com/milvus-io/milvus-helm which worked for me