### PR TITLE
Update delete-entities.md

### DIFF
--- a/site/en/userGuide/insert-and-delete/delete-entities.md
+++ b/site/en/userGuide/insert-and-delete/delete-entities.md
@@ -53,7 +53,7 @@ ilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
 
 DeleteResp deleteResp = client.delete(DeleteReq.builder()
         .collectionName("quick_setup")
-        .filter("color in ['red_7025', 'purple_4976]")
+        .filter("color in ['red_7025', 'purple_4976']")
         .build());
 
 ```


### PR DESCRIPTION
'purple_4976 lacks a single quote on the right side. for example: filter("color in ['red_7025', 'purple_4976]") -> filter("color in ['red_7025', 'purple_4976']")