### PR TITLE
fix: typo 'PQCodeBugetGBRatio' to 'PQCodeBudgetGBRatio'

### DIFF
--- a/site/en/reference/disk_index.md
+++ b/site/en/reference/disk_index.md
@@ -51,7 +51,7 @@ DiskANN is tunable. You can modify DiskANN-related parameters in `${MILVUS_ROOT_
 DiskIndex:
   MaxDegree: 56
   SearchListSize: 100
-  PQCodeBugetGBRatio: 0.125
+  PQCodeBudgetGBRatio: 0.125
   SearchCacheBudgetGBRatio: 0.125
   BeamWidthRatio: 4.0
 ...
@@ -61,7 +61,7 @@ DiskIndex:
 | --- | --- | --- | --- |
 | `MaxDegree` | Maximum degree of the Vamana graph. <br/> A larger value offers a higher recall rate but increases the size of and time to build the index. | [1, 512] | 56 | 
 | `SearchListSize` | Size of the candidate list. <br/> A larger value increases the time spent on building the index but offers a higher recall rate. <br/> Set it to a value smaller than `MaxDegree` unless you need to reduce the index-building time. | [1, int32_max] | 100 |
-| `PQCodeBugetGBRatio` | Size limit on the PQ code. <br/> A larger value offers a higher recall rate but increases memory usage. | (0.0, 0.25] | 0.125 |
+| `PQCodeBudgetGBRatio` | Size limit on the PQ code. <br/> A larger value offers a higher recall rate but increases memory usage. | (0.0, 0.25] | 0.125 |
 | `SearchCacheBudgetGBRatio` | Ratio of cached node numbers to raw data. <br/> A larger value improves index-building performance with increased memory usage. | [0.0, 0.3) | 0.10 |
 | `BeamWidthRatio` | Ratio between the maximum number of IO requests per search iteration and CPU number. | [1, max(128 / CPU number, 16)] | 4.0 |
 


### PR DESCRIPTION
This PR fixes typo 'PQCodeBugetGBRatio' to 'PQCodeBudgetGBRatio', in `site/en/reference/disk_index.md`

Related Issue: #2323 