### PR TITLE
Change 'indexNode' to 'dataNode' in GPU config

### DIFF
--- a/site/en/getstarted/run-milvus-gpu/install_cluster-helm-gpu.md
+++ b/site/en/getstarted/run-milvus-gpu/install_cluster-helm-gpu.md
@@ -82,7 +82,7 @@ Milvus with GPU support allows you to assign one or more GPU devices.
 
   ```bash
   cat <<EOF > custom-values.yaml
-  indexNode:
+  dataNode:
     resources:
       requests:
         nvidia.com/gpu: "1"
@@ -126,7 +126,7 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
 
   ```bash
   cat <<EOF > custom-values.yaml
-  indexNode:
+  dataNode:
     resources:
       requests:
         nvidia.com/gpu: "2"
@@ -141,11 +141,11 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
   EOF
   ```
 
-  In the configuration above, the indexNode and queryNode share two GPUs. To assign different GPUs to the indexNode and the queryNode, you can modify the configuration accordingly by setting `extraEnv` in the configuration file as follows:
+  In the configuration above, the dataNode and queryNode share two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting `extraEnv` in the configuration file as follows:
 
   ```bash
   cat <<EOF > custom-values.yaml
-  indexNode:
+  dataNode:
     resources:
       requests:
         nvidia.com/gpu: "1"
@@ -184,7 +184,7 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
 
   ```bash
   cat <<EOF > custom-values.yaml
-  indexNode:
+  dataNode:
     resources:
       requests:
         nvidia.com/gpu: "2"
@@ -199,11 +199,11 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
   EOF
   ```
 
-  In the configuration above, the indexNode and queryNode share two GPUs. To assign different GPUs to the indexNode and the queryNode, you can modify the configuration accordingly by setting extraEnv in the configuration file as follows:
+  In the configuration above, the dataNode and queryNode share two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting extraEnv in the configuration file as follows:
 
   ```bash
   cat <<EOF > custom-values.yaml
-  indexNode:
+  dataNode:
     resources:
       requests:
         nvidia.com/gpu: "1"

--- a/site/en/getstarted/run-milvus-gpu/install_cluster-helm-gpu.md
+++ b/site/en/getstarted/run-milvus-gpu/install_cluster-helm-gpu.md
@@ -141,7 +141,7 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
   EOF
   ```
 
-  In the configuration above, the dataNode and queryNode share two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting `extraEnv` in the configuration file as follows:
+  In the configuration above, there are four CPUs available, and each dataNode and queryNode uses two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting `extraEnv` in the configuration file as follows:
 
   ```bash
   cat <<EOF > custom-values.yaml
@@ -199,7 +199,7 @@ In addition to a single GPU device, you can also assign multiple GPU devices to 
   EOF
   ```
 
-  In the configuration above, the dataNode and queryNode share two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting extraEnv in the configuration file as follows:
+  In the configuration above, there are four CPUs available, and each dataNode and queryNode uses two GPUs. To assign different GPUs to the dataNode and the queryNode, you can modify the configuration accordingly by setting extraEnv in the configuration file as follows:
 
   ```bash
   cat <<EOF > custom-values.yaml
@@ -242,28 +242,31 @@ After Milvus starts, the `READY` column displays `1/1` for all pods.
 
   ```shell
   NAME                                             READY  STATUS   RESTARTS  AGE
-  my-release-etcd-0                                1/1    Running   0        3m23s
-  my-release-etcd-1                                1/1    Running   0        3m23s
-  my-release-etcd-2                                1/1    Running   0        3m23s
-  my-release-milvus-datacoord-6fd4bd885c-gkzwx     1/1    Running   0        3m23s
-  my-release-milvus-datanode-68cb87dcbd-4khpm      1/1    Running   0        3m23s
-  my-release-milvus-indexcoord-5bfcf6bdd8-nmh5l    1/1    Running   0        3m23s
-  my-release-milvus-indexnode-5c5f7b5bd9-l8hjg     1/1    Running   0        3m24s
-  my-release-milvus-proxy-6bd7f5587-ds2xv          1/1    Running   0        3m24s
-  my-release-milvus-querycoord-579cd79455-xht5n    1/1    Running   0        3m24s
-  my-release-milvus-querynode-5cd8fff495-k6gtg     1/1    Running   0        3m24s
-  my-release-milvus-rootcoord-7fb9488465-dmbbj     1/1    Running   0        3m23s
-  my-release-minio-0                               1/1    Running   0        3m23s
-  my-release-minio-1                               1/1    Running   0        3m23s
-  my-release-minio-2                               1/1    Running   0        3m23s
-  my-release-minio-3                               1/1    Running   0        3m23s
-  my-release-pulsar-autorecovery-86f5dbdf77-lchpc  1/1    Running   0        3m24s
-  my-release-pulsar-bookkeeper-0                   1/1    Running   0        3m23s
-  my-release-pulsar-bookkeeper-1                   1/1    Running   0        98s
-  my-release-pulsar-broker-556ff89d4c-2m29m        1/1    Running   0        3m23s
-  my-release-pulsar-proxy-6fbd75db75-nhg4v         1/1    Running   0        3m23s
-  my-release-pulsar-zookeeper-0                    1/1    Running   0        3m23s
-  my-release-pulsar-zookeeper-metadata-98zbr       0/1   Completed  0        3m24s
+  my-release-etcd-0                                  1/1     Running     0             3m24s
+  my-release-etcd-1                                  1/1     Running     0             3m24s
+  my-release-etcd-2                                  1/1     Running     0             3m24s
+  my-release-milvus-datanode-698dbf7d77-rjkkq        1/1     Running     0             3m24s
+  my-release-milvus-mixcoord-856d666559-rpj8z        1/1     Running     0             3m24s
+  my-release-milvus-proxy-7f7cf47689-pzltw           1/1     Running     0             3m24s
+  my-release-milvus-querynode-7fb6d5b5f8-92phj       1/1     Running     0             3m24s
+  my-release-milvus-streamingnode-5867bfbcbf-cg9xx   1/1     Running     0             3m24s
+  my-release-minio-0                                 1/1     Running     0             3m24s
+  my-release-minio-1                                 1/1     Running     0             3m24s
+  my-release-minio-2                                 1/1     Running     0             3m24s
+  my-release-minio-3                                 1/1     Running     0             3m24s
+  my-release-pulsarv3-bookie-0                       1/1     Running     0             3m24s
+  my-release-pulsarv3-bookie-1                       1/1     Running     0             3m24s
+  my-release-pulsarv3-bookie-2                       1/1     Running     0             3m24s
+  my-release-pulsarv3-bookie-init-p8hcq              0/1     Completed   0             3m24s
+  my-release-pulsarv3-broker-0                       1/1     Running     0             3m24s
+  my-release-pulsarv3-broker-1                       1/1     Running     0             3m24s
+  my-release-pulsarv3-proxy-0                        1/1     Running     0             3m24s
+  my-release-pulsarv3-proxy-1                        1/1     Running     0             3m24s
+  my-release-pulsarv3-pulsar-init-8kjsj              0/1     Completed   0             3m24s
+  my-release-pulsarv3-recovery-0                     1/1     Running     0             3m24s
+  my-release-pulsarv3-zookeeper-0                    1/1     Running     0             3m24s
+  my-release-pulsarv3-zookeeper-1                    1/1     Running     0             3m24s
+  my-release-pulsarv3-zookeeper-2                    1/1     Running     0             3m24s
   ```
 
 - Milvus standalone


### PR DESCRIPTION
Updated configuration examples to use 'dataNode' instead of 'indexNode' for GPU resource allocation.