### PR TITLE
Fix field name in Milvus CRD in monitor.md

### DIFF
--- a/site/en/adminGuide/monitor/monitor.md
+++ b/site/en/adminGuide/monitor/monitor.md
@@ -86,13 +86,13 @@ You can enable the ServiceMonitor as follows if you have installed Milvus using 
     $ kubectl edit milvus my-release
     ```
 
-2. Edit the `spec.components.disableMetrics` field to `false`.
+2. Edit the `spec.components.disableMetric` field to `false`.
 
     ```yaml
     ...
     spec:
       components:
-        disableMetrics: false # set to true to disable metrics
+        disableMetric: false # set to true to disable metrics
     ...
     ```
 


### PR DESCRIPTION
This PR is a update of docs to match the name of `disableMetric` field in Milvus CRD
https://github.com/zilliztech/milvus-operator/blob/f90895907da2891e453926ee2d9f6c47e0dab322/apis/milvus.io/v1alpha1/components_types.go#L59.

I'm also not sure about the 
> Wait for the operator to reconcile the changes. You can check the status of the Milvus custom resource by running the following command.
> $ kubectl get milvus my-release -o yaml
> The status.components.metrics.serviceMonitor.enabled field should be true.

section, in my case, with milvus operator 1.3.3 and milvus (standalone) 2.5.10 i don't see that field and PodMonitor was created instead of ServiceMonitor, so i suppose that section is also outdated?

```
❯ kg milvus milvus -oyaml
[...]
status:
  componentsDeployStatus:
    standalone:
      generation: 2
      image: milvusdb/milvus:v2.5.10
      status:
        availableReplicas: 1
        conditions:
        - lastTransitionTime: "2025-07-11T17:08:18Z"
          lastUpdateTime: "2025-07-12T21:50:12Z"
          message: ReplicaSet "milvus-milvus-standalone-ffc896c76" has successfully
            progressed.
          reason: NewReplicaSetAvailable
          status: "True"
          type: Progressing
        - lastTransitionTime: "2025-10-21T17:15:03Z"
          lastUpdateTime: "2025-10-21T17:15:03Z"
          message: Deployment has minimum availability.
          reason: MinimumReplicasAvailable
          status: "True"
          type: Available
        observedGeneration: 2
        readyReplicas: 1
        replicas: 1
        updatedReplicas: 1
  conditions:
  - lastTransitionTime: "2025-10-21T17:15:12Z"
    message: All Milvus components are healthy
    reason: ReasonMilvusHealthy
    status: "True"
    type: MilvusReady
  - lastTransitionTime: "2025-10-21T17:01:35Z"
    message: Milvus components are all updated
    reason: MilvusComponentsUpdated
    status: "True"
    type: MilvusUpdated
  - lastTransitionTime: "2025-10-21T17:14:42Z"
    message: Etcd endpoints is healthy
    reason: EtcdReady
    status: "True"
    type: EtcdReady
  - lastTransitionTime: "2025-08-04T10:39:10Z"
    reason: StorageReady
    status: "True"
    type: StorageReady
  - lastTransitionTime: "2025-07-11T17:08:18Z"
    reason: MsgStreamReady
    status: "True"
    type: MsgStreamReady
  currentImage: milvusdb/milvus:v2.5.10
  endpoint: milvus-milvus.milvus:19530
  ingress:
    loadBalancer: {}
  observedGeneration: 6
  rollingModeVersion: 2
  status: Healthy

```