### PR TITLE
remove drop_ratio_search param from user guides

### DIFF
--- a/site/en/userGuide/indexes/sparse/sparse-inverted-index.md
+++ b/site/en/userGuide/indexes/sparse/sparse-inverted-index.md
@@ -1,7 +1,7 @@
 ---
 id: sparse-inverted-index.md
 title: "SPARSE_INVERTED_INDEX"
-summary: "The SPARSE_INVERTED_INDEX index is an index type used by Milvus to efficiently store and search sparse vectors. This index type leverages the principles of inverted indexing to create a highly efficient search structure for sparse data. For more information, refer to INVERTED."
+summary: "The SPARSE_INVERTED_INDEX index is an index type used by Milvus to efficiently store and search sparse vectors. This index type leverages the principles of inverted indexing to create a highly efficient search structure for sparse data."
 ---
 
 # SPARSE_INVERTED_INDEX
@@ -56,11 +56,6 @@ Once the index parameters are configured, you can create the index by using the 
 Once the index is built and entities are inserted, you can perform similarity searches on the index.
 
 ```python
-# Prepare search parameters
-search_params = {
-    "params": {"drop_ratio_search": 0.2},  # Additional optional search parameters
-}
-
 # Prepare the query vector
 query_vector = [{1: 0.2, 50: 0.4, 1000: 0.7}]
 
@@ -69,17 +64,10 @@ res = MilvusClient.search(
     anns_field="vector_field",  # Vector field name
     data=query_vector,  # Query vector
     limit=3,  # TopK results to return
-    search_params=search_params
 )
 ```
 
-In this configuration:
-
-- `params`: Additional configuration options for searching on the index.
-
-    - `drop_ratio_search`: Fine-tunes search performance by specifying what proportion of small vector values to ignore during the search process. For example, with `{"drop_ratio_search": 0.2}`, the smallest 20% of values in the query vector will be ignored during the search.
-
-    To learn more search parameters available for the `SPARSE_INVERTED_INDEX` index, refer to [Index-specific search params](ivf-flat.md#share-KDWodFEx6oCm2yxgEUAcXaUDnwg).
+To learn more search parameters available for the `SPARSE_INVERTED_INDEX` index, refer to [Index-specific search params](ivf-flat.md#share-KDWodFEx6oCm2yxgEUAcXaUDnwg).
 
 ## Index params
 
@@ -100,9 +88,7 @@ The following table lists the parameters that can be configured in `params` when
      <td><p><code>inverted_index_algo</code></p></td>
      <td><p>The algorithm used for building and querying the index. It determines how the index processes queries.</p></td>
      <td><p><code>"DAAT_MAXSCORE"</code> (default), <code>"DAAT_WAND"</code>, <code>"TAAT_NAIVE"</code></p></td>
-     <td><p>Use <code>"DAAT_MAXSCORE"</code> for scenarios with high k values or queries with many terms, which can benefit from skipping non-competitive documents. 
- Choose <code>"DAAT_WAND"</code> for queries with small k values or short queries to leverage more efficient skipping.</p>
-<p>Use <code>"TAAT_NAIVE"</code> if dynamic adjustment to collection changes (e.g., avgdl) is required.</p></td>
+     <td><p>Use <code>"DAAT_MAXSCORE"</code> for scenarios with high k values or queries with many terms, which can benefit from skipping non-competitive documents. </p><p>Choose <code>"DAAT_WAND"</code> for queries with small k values or short queries to leverage more efficient skipping.</p><p>Use <code>"TAAT_NAIVE"</code> if dynamic adjustment to collection changes (e.g., avgdl) is required.</p></td>
    </tr>
 </table>
 
@@ -121,7 +107,7 @@ The following table lists the parameters that can be configured in `search_param
      <td><p><code>drop_ratio_search</code></p></td>
      <td><p>The proportion of the smallest values to ignore during search, helping to reduce noise.</p></td>
      <td><p>Fraction between 0.0 and 1.0 (e.g., 0.2 ignores the smallest 20% of values)</p></td>
-     <td><p>Tune this parameter based on the sparsity and noise level of your query vectors. For example, setting it to 0.2 can help focus on more significant values during the search, potentially improving accuracy.</p></td>
+     <td><p>Tune this parameter based on the sparsity and noise level of your query vectors.</p><p>This parameter controls the proportion of low-magnitude values dropped during search. Increasing this value (for example, to <code>0.2</code>) can reduce noise and focus the search on more significant components, which may improve precision and efficiency. However, dropping more values can also reduce recall by excluding potentially relevant signals. Choose a value that balances recall and accuracy for your workload.</p></td>
    </tr>
 </table>
 

--- a/site/en/userGuide/search-query-get/elasticsearch-queries-to-milvus.md
+++ b/site/en/userGuide/search-query-get/elasticsearch-queries-to-milvus.md
@@ -485,7 +485,7 @@ search_params_dense = {
     "anns_field": "vector",
     "param": {
         "metric_type": "IP",
-        "params": {"nprobe": 10}, 
+        "params": {"nprobe": 10},
     },
     "limit": 100
 }
@@ -497,7 +497,6 @@ search_params_sparse = {
     "anns_field": "text_sparse",
     "param": {
         "metric_type": "BM25",
-        "params": {"drop_ratio_search": 0.2}
     }
 }
 
@@ -515,7 +514,7 @@ This example demonstrates a hybrid search in Milvus that combines:
 
 1. **Dense vector search**: Using the inner product (IP) metric with `nprobe` set to 10 for approximate nearest neighbor (ANN) search on the `vector` field.
 
-1. **Sparse vector search**: Using the BM25 similarity metric with a `drop_ratio_search` parameter of 0.2 on the `text_sparse` field.
+1. **Sparse vector search**: Using the BM25 similarity metric on the `text_sparse` field.
 
 The results from these searches are executed separately, combined, and reranked using the Reciprocal Rank Fusion (RRF) ranker. The hybrid search returns the top 10 entities from the reranked list.
 

--- a/site/en/userGuide/search-query-get/full-text-search.md
+++ b/site/en/userGuide/search-query-get/full-text-search.md
@@ -601,11 +601,7 @@ Once you've inserted data into your collection, you can perform full text search
 </div>
 
 ```python
-search_params = {
-    'params': {'drop_ratio_search': 0.2},
-}
-
-client.search(
+res = client.search(
     collection_name='my_collection', 
     # highlight-start
     data=['whats the focus of information retrieval?'],
@@ -613,8 +609,9 @@ client.search(
     output_fields=['text'], # Fields to return in search results; sparse field cannot be output
     # highlight-end
     limit=3,
-    search_params=search_params
 )
+
+print(res)
 ```
 
 ```java
@@ -623,7 +620,7 @@ import io.milvus.v2.service.vector.request.data.EmbeddedText;
 import io.milvus.v2.service.vector.response.SearchResp;
 
 Map<String,Object> searchParams = new HashMap<>();
-searchParams.put("drop_ratio_search", 0.2);
+
 SearchResp searchResp = client.search(SearchReq.builder()
         .collectionName("my_collection")
         .data(Collections.singletonList(new EmbeddedText("whats the focus of information retrieval?")))
@@ -636,7 +633,6 @@ SearchResp searchResp = client.search(SearchReq.builder()
 
 ```go
 annSearchParams := index.NewCustomAnnParam()
-annSearchParams.WithExtraParam("drop_ratio_search", 0.2)
 resultSets, err := client.Search(ctx, milvusclient.NewSearchOption(
     "my_collection", // collectionName
     3,               // limit
@@ -664,7 +660,6 @@ await client.search(
     anns_field: 'sparse',
     output_fields: ['text'],
     limit: 3,
-    params: {'drop_ratio_search': 0.2},
 )
 ```
 
@@ -684,9 +679,7 @@ curl --request POST \
         "text"
     ],
     "searchParams":{
-        "params":{
-            "drop_ratio_search":0.2
-        }
+        "params":{}
     }
 }'
 ```

--- a/site/en/userGuide/search-query-get/multi-vector-search.md
+++ b/site/en/userGuide/search-query-get/multi-vector-search.md
@@ -696,7 +696,6 @@ request_1 = AnnSearchRequest(**search_param_1)
 search_param_2 = {
     "data": [query_text],
     "anns_field": "text_sparse",
-    "param": {"drop_ratio_search": 0.2},
     "limit": 2
 }
 request_2 = AnnSearchRequest(**search_param_2)
@@ -738,7 +737,6 @@ searchRequests.add(AnnSearchReq.builder()
 searchRequests.add(AnnSearchReq.builder()
         .vectorFieldName("text_sparse")
         .vectors(queryTexts)
-        .params("{\"drop_ratio_search\": 0.2}")
         .topK(2)
         .build());
 searchRequests.add(AnnSearchReq.builder()
@@ -781,7 +779,6 @@ const search_param_1 = {
 const search_param_2 = {
     "data": query_text, 
     "anns_field": "text_sparse", 
-    "param": {"drop_ratio_search": 0.2},
     "limit": 2
 }
 
@@ -804,7 +801,6 @@ export req='[
     {
         "data": ["white headphones, quiet and comfortable"],
         "annsField": "text_sparse",
-        "params": {"drop_ratio_search": 0.2},
         "limit": 2
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Core Invariant:** The `drop_ratio_search` parameter remains a valid, documented option in the API (evidenced by its preservation in `reference/index.md` and `sparse_vector.md`), but this PR removes it from user guide code examples, treating it as an optional advanced parameter that should not clutter introductory/practical documentation.

**Removed Logic:** Explicit `drop_ratio_search` assignments are deleted from all practical code examples across four user guide documents (full-text-search.md, multi-vector-search.md, sparse-inverted-index.md, elasticsearch-queries-to-milvus.md). This includes removing:
- Search parameter dictionary entries like `{"params": {"drop_ratio_search": 0.2}}`
- Language-specific parameter binding code (Java's `searchParams.put()`, Go's `WithExtraParam()`, JavaScript's parameter object)
- Related explanatory narrative about the parameter's tuning behavior

**Rationale for Removal:** The parameter is optional with a reasonable default behavior. By removing it from user guides, the documentation reduces cognitive load and emphasizes the common case (relying on defaults) while keeping the parameter documented in the API reference for advanced users who need fine-grained control.

**No Behavior Regression:** Search functionality is unaffected because the API continues to accept omitted optional parameters with sensible defaults. The sparse vector search operations (BM25, inverted-index, full-text) execute identically whether the parameter is explicitly set or implicitly defaulted—only the filtering threshold for small values changes, not the retrieval logic or result cardinality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->