### PR TITLE
fix(ci): stop overwriting root version.json in web-content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
           git clone https://.:${{ secrets.P_GITHUB_TOKEN }}@github.com/milvus-io/web-content.git target
           git config --global user.email "Milvus-doc-bot@zilliz.com"
           git config --global user.name "Milvus-doc-bot"
-          cp ./milvus-docs/version.json ./target
+          VERSION=$(jq -r .version ./milvus-docs/version.json)
           cd target
-          rm -rf `cat version.json | jq -r .version`
-          mkdir `cat version.json | jq -r .version`
-          cp -avr ../milvus-docs/** ./`cat version.json | jq -r .version`
+          rm -rf "$VERSION"
+          mkdir "$VERSION"
+          cp -avr ../milvus-docs/** "./$VERSION"
           git add .
           git commit -m "Release new docs "
           git push -f origin master

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -39,7 +39,6 @@ jobs:
           git clone https://.:${{ secrets.P_GITHUB_TOKEN }}@github.com/milvus-io/web-content.git target
           git config --global user.email "Milvus-doc-bot@zilliz.com"
           git config --global user.name "Milvus-doc-bot"
-          cp ./milvus-docs/version.json ./target
           cd target
           rm -rf preview
           mkdir preview


### PR DESCRIPTION
## Summary
- Remove `cp ./milvus-docs/version.json ./target` from both `ci.yml` and `pre.yml` to prevent overwriting the root `version.json` in the web-content repo
- In `ci.yml`, read the version directly from the source repo using `VERSION=$(jq -r .version ./milvus-docs/version.json)` instead of copying then reading from target
- Fixes race condition where concurrent CI runs from different version branches (v2.4.x, v2.5.x, v2.6.x) would overwrite each other's root `version.json`

## Test plan
- [ ] Verify CI workflow triggers correctly on v2.4.x branch push
- [ ] Confirm version directory is created correctly in web-content without touching root version.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)