### PR TITLE
Add NATS (natsmq) deprecation notices to v2.5.x docs

### DIFF
--- a/site/en/adminGuide/deploy_pulsar.md
+++ b/site/en/adminGuide/deploy_pulsar.md
@@ -125,6 +125,8 @@ Changing the message store is not recommended. If this is you want to do this, s
 
 </div>
 
+> **Deprecated**: NATS (natsmq) is deprecated and will be removed in Milvus v2.6. Please use RocksMQ, Pulsar, or Kafka instead.
+
 ## Configure NATS with Helm
 
 NATS is an experimental message store alternative to RocksMQ. For detailed steps on how to configure Milvus with Helm, refer to [Configure Milvus with Helm Charts](configure-helm.md). For details on RocksMQ-related configuration items, refer to [NATS-related configurations](configure_natsmq.md).

--- a/site/en/adminGuide/message_storage_operator.md
+++ b/site/en/adminGuide/message_storage_operator.md
@@ -83,6 +83,8 @@ spec:
 * `storageClassName`: Your cluster's storage class
 * `storage`: Size of the persistent volume
 
+> **Deprecated**: NATS (natsmq) is deprecated and will be removed in Milvus v2.6. Please use RocksMQ, Pulsar, or Kafka instead.
+
 ## Configure NATS
 
 NATS is an alternative message storage for NATS.

--- a/site/en/reference/sys_config/configure_mq.md
+++ b/site/en/reference/sys_config/configure_mq.md
@@ -5,6 +5,8 @@ group: system_configuration.md
 summary: Learn how to configure mq for Milvus.
 ---
 
+> **Deprecated**: NATS (natsmq) is deprecated and will be removed in Milvus v2.6. Please use RocksMQ, Pulsar, or Kafka instead.
+
 # mq-related Configurations
 
 Milvus supports four MQ: rocksmq(based on RockDB), natsmq(embedded nats-server), Pulsar and Kafka.

--- a/site/en/reference/sys_config/configure_natsmq.md
+++ b/site/en/reference/sys_config/configure_natsmq.md
@@ -5,6 +5,8 @@ group: system_configuration.md
 summary: Learn how to configure natsmq for Milvus.
 ---
 
+> **Deprecated**: NATS (natsmq) is deprecated and will be removed in Milvus v2.6. Please use RocksMQ, Pulsar, or Kafka instead.
+
 # natsmq-related Configurations
 
 natsmq configuration.

--- a/site/en/reference/sys_config/system_configuration.md
+++ b/site/en/reference/sys_config/system_configuration.md
@@ -109,6 +109,8 @@ kafka:
 
 See [rocksmq-related Configurations](configure_rocksmq.md) for detailed description for each parameter under this section.
 
+> **Deprecated**: NATS (natsmq) is deprecated and will be removed in Milvus v2.6. Please use RocksMQ, Pulsar, or Kafka instead.
+
 ### `natsmq`
 
 natsmq configuration.


### PR DESCRIPTION
NATS is being removed from Milvus in v2.6. This commit adds deprecation notices to all NATS-related documentation in v2.5.x.