### PR TITLE
Update Milvus CLI documentation for v1.2.1

### DIFF
--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -14,17 +14,21 @@ This topic introduces all supported commands and the corresponding options. Some
 
 Milvus CLI commands are organized into the following groups:
 
-- `create`: Create collection, database, partition, user, role, or index
-- `delete`: Delete collection, database, partition, alias, user, role, or index
-- `list`: List collections, databases, partitions, users, roles, grants, or indexes
-- `show`: Show connection, database, collection, loading_progress, or index_progress
-- `grant`: Grant role or privilege
-- `revoke`: Revoke role or privilege
+- `create`: Create collection, database, partition, user, role, alias, index, privilege_group, or resource_group
+- `delete`: Delete collection, database, partition, alias, user, role, index, entities, IDs, privilege_group, resource_group, connection_history, or collection_properties
+- `list`: List collections, databases, partitions, users, roles, grants, indexes, aliases, connections, connection_history, privilege_groups, resource_groups, or bulk_insert_tasks
+- `show`: Show collection, collection_stats, database, partition, partition_stats, index, index_progress, loading_progress, load_state, flush_state, compaction_state, compaction_plans, replicas, query_segment_info, role, user, alias, output, resource_group, or bulk_insert_state
+- `grant`: Grant role, privilege, or privilege_group
+- `revoke`: Revoke role, privilege, or privilege_group
 - `load`: Load collection or partition
 - `release`: Release collection or partition
 - `use`: Use database
 - `rename`: Rename collection
 - `insert`: Insert entities (file or row)
+- `upsert`: Upsert entities (file or row)
+- `set`: Set output format
+- `alter`: Alter database, collection_properties, or collection_field
+- `update`: Update password or resource_group
 
 ## clear
 
@@ -36,12 +40,6 @@ Clears the screen.
 clear
 ```
 
-<h3 id="clear">Options</h3>
-
-| Option | Full name | Description                          |
-| :----- | :-------- | :----------------------------------- |
-| --help | n/a       | Displays help for using the command. |
-
 ## connect
 
 Connects to Milvus.
@@ -49,29 +47,43 @@ Connects to Milvus.
 <h3 id="connect">Syntax</h3>
 
 ```shell
-connect [-uri (text)] [-t (text)]
-connect [-uri (text)] [-t (text)] [-tls (0|1)] [-cert (text)]
+connect [-uri (text)] [-t (text)] [-tls (0|1|2)] [-cert (text)] [--save-as (text)]
 ```
 
 <h3 id="connect">Options</h3>
 
-| Option | Full name | Description                                                                                                              |
-| :----- | :-------- | :----------------------------------------------------------------------------------------------------------------------- |
-| -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                                        |
-| -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                                          |
-| -tls   | --tlsmode | (Optional) Set TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption not support yet). Default is 0 |
-| -cert  | --cert    | (Optional) Path to the client certificate file. Work with One-way encryption                                             |
-| --help | n/a       | Displays help for using the command.                                                                                     |
+| Option   | Full name | Description                                                                                                              |
+| :------- | :-------- | :----------------------------------------------------------------------------------------------------------------------- |
+| -uri     | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530". Can also be set via `ZILLIZ_URI` environment variable. |
+| -t       | --token   | (Optional) The zilliz cloud apikey or `username:password`. Can also be set via `ZILLIZ_TOKEN` environment variable.      |
+| -tls     | --tlsmode | (Optional) Set TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). Default is 0.               |
+| -cert    | --cert    | (Optional) Path to the client certificate file. Works with one-way encryption.                                           |
+| --save-as| n/a       | (Optional) Save connection with custom alias for later use.                                                              |
+| --help   | n/a       | Displays help for using the command.                                                                                     |
 
-<h3 id="connect">Example</h3>
+<h3 id="connect">Examples</h3>
 
 ```shell
 milvus_cli > connect -uri http://127.0.0.1:19530
+
+milvus_cli > connect -uri http://192.168.1.100:19530 -t root:milvus
+
+milvus_cli > connect -uri https://xxx.zillizcloud.com -t <api_key>
 ```
 
-## create Database
+## disconnect
 
-Create Database in Milvus
+Disconnects from Milvus.
+
+<h3 id="disconnect">Syntax</h3>
+
+```shell
+disconnect
+```
+
+## create database
+
+Creates a database in Milvus.
 
 <h3 id="create-database">Syntax</h3>
 
@@ -79,26 +91,22 @@ Create Database in Milvus
 create database -db (text)
 ```
 
-### Options
+<h3 id="create-database">Options</h3>
 
 | Option | Full name | Description                             |
 | :----- | :-------- | :-------------------------------------- |
 | -db    | --db_name | [Required] The database name in milvus. |
 | --help | n/a       | Displays help for using the command.    |
 
-### Examples
-
-#### Example 1
-
-The following example create the database <code>testdb</code> in milvus.
+<h3 id="create-database">Example</h3>
 
 ```shell
 milvus_cli > create database -db testdb
 ```
 
-## use Database
+## use database
 
-Use Database in Milvus
+Uses a database in Milvus.
 
 <h3 id="use-database">Syntax</h3>
 
@@ -106,26 +114,22 @@ Use Database in Milvus
 use database -db (text)
 ```
 
-### Options
+<h3 id="use-database">Options</h3>
 
 | Option | Full name | Description                             |
 | :----- | :-------- | :-------------------------------------- |
 | -db    | --db_name | [Required] The database name in milvus. |
 | --help | n/a       | Displays help for using the command.    |
 
-### Examples
-
-#### Example 1
-
-The following example use the database <code>testdb</code> in milvus.
+<h3 id="use-database">Example</h3>
 
 ```shell
 milvus_cli > use database -db testdb
 ```
 
-## list Databases
+## list databases
 
-List Databases in Milvus
+Lists all databases in Milvus.
 
 <h3 id="list-database">Syntax</h3>
 
@@ -133,140 +137,74 @@ List Databases in Milvus
 list databases
 ```
 
-### Examples
+## show database
 
-#### Example 1
+Shows details and properties of a database.
 
-The following example list the databases in milvus.
-
-```shell
-milvus_cli > list databases
-```
-
-## delete Database
-
-Delete Database in Milvus
-
-<h3 id="delete-database">Syntax</h3>
+<h3 id="show-database">Syntax</h3>
 
 ```shell
-delete database -db (text)
+show database [-db (text)]
 ```
 
-### Options
+<h3 id="show-database">Options</h3>
+
+| Option | Full name | Description                                       |
+| :----- | :-------- | :------------------------------------------------ |
+| -db    | --db_name | (Optional) The database name. Defaults to current.|
+| --help | n/a       | Displays help for using the command.               |
+
+## alter database
+
+Alters database properties.
+
+<h3 id="alter-database">Syntax</h3>
+
+```shell
+alter database -db (text)
+```
+
+<h3 id="alter-database">Options</h3>
 
 | Option | Full name | Description                             |
 | :----- | :-------- | :-------------------------------------- |
 | -db    | --db_name | [Required] The database name in milvus. |
 | --help | n/a       | Displays help for using the command.    |
 
-### Examples
+<h3 id="alter-database">Interactive Example</h3>
 
-#### Example 1
+```shell
+milvus_cli > alter database -db testdb
 
-The following example delete the database <code>testdb</code> in milvus.
+Property key: collection.ttl.seconds
+Property value: 86400
+```
+
+## delete database
+
+Deletes a database in Milvus.
+
+<h3 id="delete-database">Syntax</h3>
+
+```shell
+delete database -db (text) [--yes]
+```
+
+<h3 id="delete-database">Options</h3>
+
+| Option | Full name | Description                             |
+| :----- | :-------- | :-------------------------------------- |
+| -db    | --db_name | [Required] The database name in milvus. |
+| --yes  | -y        | (Optional) Skip confirmation prompt.    |
+| --help | n/a       | Displays help for using the command.    |
+
+<h3 id="delete-database">Example</h3>
 
 ```shell
 milvus_cli > delete database -db testdb
 
 Warning! You are trying to delete the database. This action cannot be undone!
 Do you want to continue? [y/N]: y
-```
-
-## create user
-
-Create user in Milvus
-
-<h3 id="create-user">Syntax</h3>
-
-```shell
-create user -u (text) -p (text)
-```
-
-### Options
-
-| Option | Full name  | Description                                         |
-| :----- | :--------- | :-------------------------------------------------- |
-| -p     | --password | The user password in milvus. The default is "None". |
-| -u     | --username | The username in milvus. The default is "None".      |
-| --help | n/a        | Displays help for using the command.                |
-
-### Examples
-
-#### Example 1
-
-The following example create the user <code>zilliz</code> and password <code>zilliz</code> in milvus.
-
-```shell
-milvus_cli > create user -u zilliz -p zilliz
-```
-
-## create role
-
-Create role in Milvus
-
-<h3 id="create-role">Syntax</h3>
-
-```shell
-create role -r (text)
-```
-
-### Options
-
-| Option | Full name  | Description                          |
-| :----- | :--------- | :----------------------------------- |
-| -r     | --roleName | The role name of milvus role.        |
-| --help | n/a        | Displays help for using the command. |
-
-### Examples
-
-#### Example 1
-
-The following example create the role <code>role1</code> in milvus.
-
-```shell
-milvus_cli > create role -r role1
-```
-
-## create alias
-
-Specifies unique aliases for a collection.
-
-<div class="alert note">A collection can have multiple aliases. However, an alias corresponds to a maximum of one collection.</div>
-
-<h3 id="create-alias">Syntax</h3>
-
-```shell
-create alias -c (text) -a (text) [-A]
-```
-
-<h3 id="create-alias">Options</h3>
-
-| Option | Full name         | Description                                                      |
-| :----- | :---------------- | :--------------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection.                                      |
-| -a     | --alias-name      | The alias.                                                       |
-| -A     | --alter           | (Optional) Flag to transfer the alias to a specified collection. |
-| --help | n/a               | Displays help for using the command.                             |
-
-<h3 id="create-alias">Examples</h3>
-
-<h4>Example 1</h4>
-
-The following example creates the <code>carAlias1</code> and <code>carAlias2</code> aliases for the <code>car</code> collection.
-
-```shell
-milvus_cli > create alias -c car -a carAlias1
-```
-
-<h4>Example 2</h4>
-
-<div class="alert note">Example 2 is based on Example 1.</div>
-
-The following example transfers the <code>carAlias1</code> alias from the <code>car</code> collection to the <code>car2</code> collection.
-
-```shell
-milvus_cli > create alias -c car2 -A -a carAlias1
 ```
 
 ## create collection
@@ -276,8 +214,15 @@ Creates a collection.
 <h3 id="create-collection">Syntax</h3>
 
 ```shell
-create collection
+create collection [--schema-file (text)]
 ```
+
+<h3 id="create-collection">Options</h3>
+
+| Option        | Full name     | Description                                     |
+| :------------ | :------------ | :---------------------------------------------- |
+| --schema-file | --schema-file | (Optional) Path to JSON file with schema definition. |
+| --help        | n/a           | Displays help for using the command.             |
 
 <h3 id="create-collection">Interactive Example</h3>
 
@@ -301,133 +246,72 @@ Field type (INT64, VARCHAR, FLOAT_VECTOR, etc.): FLOAT_VECTOR
 Field description []: vector field
 Dimension: 128
 
-Field name: color
-Field type (INT64, VARCHAR, FLOAT_VECTOR, etc.): INT64
-Field description []: color field
-Nullable [False]: False
-Default value (type: INT64) [Not set]: 0
+Field name:
 
 Do you want to add embedding function? [y/N]: n
 ```
 
-## create partition
+## list collections
 
-Creates a partition.
+Lists all collections in the current database.
 
-<h3 id="creat-partition">Syntax</h3>
-
-```shell
-create partition -c (text) -p (text) [-d (text)]
-```
-
-<h3 id="creat-partition">Options</h3>
-
-| Option | Full name         | Description                                  |
-| :----- | :---------------- | :------------------------------------------- |
-| -c     | --collection-name | The name of the collection.                  |
-| -p     | --partition       | The partition name.                          |
-| -d     | --description     | (Optional) The description of the partition. |
-| --help | n/a               | Displays help for using the command.         |
-
-<h3 id="creat-partition">Example</h3>
+<h3 id="list-collections">Syntax</h3>
 
 ```shell
-milvus_cli > create partition -c car -p new_partition -d test_add_partition
+list collections
 ```
 
-## create index
+## show collection
 
-Creates an index for a field.
+Shows the detailed information of a collection.
 
-<div class="alert note"> Currently, a collection supports a maximum of one index.</div>
-
-<h3 id="creat-index">Syntax</h3>
+<h3 id="show-collection">Syntax</h3>
 
 ```shell
-create index
+show collection -c (text)
 ```
 
-<h3 id="creat-index">Interactive Example</h3>
+<h3 id="show-collection">Options</h3>
+
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | The name of the collection.          |
+| --help | n/a               | Displays help for using the command. |
+
+## show collection_stats
+
+Shows collection statistics.
+
+<h3 id="show-collection-stats">Syntax</h3>
 
 ```shell
-milvus_cli > create index
-
-Collection name (car, car2): car2
-The name of the field to create an index for (vector): vector
-Index name: vectorIndex
-Index type (FLAT, IVF_FLAT, IVF_SQ8, IVF_PQ, RNSG, HNSW, ANNOY, AUTOINDEX, DISKANN, GPU_IVF_FLAT, GPU_IVF_PQ, SPARSE_INVERTED_INDEX, SCANN, STL_SORT, Trie, INVERTED): IVF_FLAT
-Vector Index metric type (L2, IP, HAMMING, TANIMOTO, COSINE): L2
-Index params nlist: 2
-Timeout []:
+show collection_stats -c (text)
 ```
 
-## delete user
+<h3 id="show-collection-stats">Options</h3>
 
-Deletes a user
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection.|
+| --help | n/a               | Displays help for using the command. |
 
-### Syntax
+## rename collection
+
+Renames a collection.
+
+<h3 id="rename-collection">Syntax</h3>
 
 ```shell
-delete user -u (text)
+rename collection -old (text) -new (text)
 ```
 
-### Options
+<h3 id="rename-collection">Options</h3>
 
-| Option | Full name  | Description                          |
-| :----- | :--------- | :----------------------------------- |
-| -u     | --username | The username.                        |
-| --help | n/a        | Displays help for using the command. |
-
-### Example
-
-```shell
-milvus_cli > delete user -u zilliz
-
-Warning! You are trying to delete the user in milvus. This action cannot be undone!
-Do you want to continue? [y/N]: y
-```
-
-## delete role
-
-Delete role in Milvus
-
-<h3 id="delete-role">Syntax</h3>
-
-```shell
-delete role -r (text)
-```
-
-### Options
-
-| Option | Full name  | Description                          |
-| :----- | :--------- | :----------------------------------- |
-| -r     | --roleName | The role name of milvus role.        |
-| --help | n/a        | Displays help for using the command. |
-
-### Examples
-
-The following example delete the role <code>role1</code> in milvus.
-
-```shell
-milvus_cli > delete role -r role1
-```
-
-## delete alias
-
-Deletes an alias.
-
-<h3 id="delete-alias">Syntax</h3>
-
-```shell
-delete alias -a (text)
-```
-
-<h3 id="delete-alias">Options</h3>
-
-| Option | Full name    | Description                          |
-| :----- | :----------- | :----------------------------------- |
-| -a     | --alias-name | The alias.                           |
-| --help | n/a          | Displays help for using the command. |
+| Option | Full name              | Description                          |
+| :----- | :--------------------- | :----------------------------------- |
+| -old   | --old-collection-name  | [Required] The old collection name.  |
+| -new   | --new-collection-name  | [Required] The new collection name.  |
+| --help | n/a                    | Displays help for using the command. |
 
 ## delete collection
 
@@ -436,14 +320,15 @@ Deletes a collection.
 <h3 id="delete-collection">Syntax</h3>
 
 ```shell
-delete collection -c (text)
+delete collection -c (text) [--yes]
 ```
 
 <h3 id="delete-collection">Options</h3>
 
 | Option | Full name         | Description                               |
 | :----- | :---------------- | :---------------------------------------- |
-| -c     | --collection-name | The name of the collection to be deleted. |
+| -c     | --collection-name | [Required] The name of the collection.    |
+| --yes  | -y                | (Optional) Skip confirmation prompt.      |
 | --help | n/a               | Displays help for using the command.      |
 
 <h3 id="delete-collection">Example</h3>
@@ -455,34 +340,390 @@ Warning! You are trying to delete the collection. This action cannot be undone!
 Do you want to continue? [y/N]: y
 ```
 
-## delete entities
+## load collection
 
-Deletes entities.
+Loads a collection into RAM.
 
-<h3 id="delete-entities">Syntax</h3>
+<h3 id="load-collection">Syntax</h3>
 
+```shell
+load collection -c (text)
 ```
-delete entities -c (text) -p (text)
+
+<h3 id="load-collection">Options</h3>
+
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | The name of the collection.          |
+| --help | n/a               | Displays help for using the command. |
+
+## release collection
+
+Releases a collection from RAM.
+
+<h3 id="release-collection">Syntax</h3>
+
+```shell
+release collection -c (text)
 ```
 
-<h3 id="delete-entities">Options</h3>
+<h3 id="release-collection">Options</h3>
 
-| Option | Full name         | Description                                                        |
-| :----- | :---------------- | :----------------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection that entities to be deleted belongs to. |
-| -p     | --partition       | (Optional) The name of the partition to be deleted.                |
-| --help | n/a               | Displays help for using the command.                               |
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | The name of the collection.          |
+| --help | n/a               | Displays help for using the command. |
 
-<h3 id="delete-entities">Example</h3>
+## truncate
 
+Removes all data from a collection but keeps the schema.
+
+<h3 id="truncate">Syntax</h3>
+
+```shell
+truncate -c (text) [--yes]
 ```
-milvus_cli > delete entities -c car
 
-The expression to specify entities to be deleted, such as "film_id in [ 0, 1 ]": film_id in [ 0, 1 ]
+<h3 id="truncate">Options</h3>
 
-Warning! You are trying to delete the entities of collection. This action cannot be undone!
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| --yes  | -y                | (Optional) Skip confirmation prompt.   |
+| --help | n/a               | Displays help for using the command.   |
+
+<h3 id="truncate">Example</h3>
+
+```shell
+milvus_cli > truncate -c car
+
+Warning!
+You are trying to remove all data in the collection. This action cannot be undone!
 Do you want to continue? [y/N]: y
 ```
+
+## flush
+
+Flushes collection data to storage.
+
+<h3 id="flush">Syntax</h3>
+
+```shell
+flush -c (text) [-t (number)]
+```
+
+<h3 id="flush">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| -t     | --timeout         | (Optional) Timeout in seconds.         |
+| --help | n/a               | Displays help for using the command.   |
+
+## flush_all
+
+Flushes all collections to storage.
+
+<h3 id="flush-all">Syntax</h3>
+
+```shell
+flush_all [-t (number)]
+```
+
+<h3 id="flush-all">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -t     | --timeout | (Optional) Timeout in seconds.       |
+| --help | n/a       | Displays help for using the command. |
+
+## show flush_state
+
+Shows flush state for a collection.
+
+<h3 id="show-flush-state">Syntax</h3>
+
+```shell
+show flush_state -c (text)
+```
+
+<h3 id="show-flush-state">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| --help | n/a               | Displays help for using the command.   |
+
+## compact
+
+Compacts a collection to merge small segments and remove deleted data.
+
+<h3 id="compact">Syntax</h3>
+
+```shell
+compact -c (text) [-t (number)]
+```
+
+<h3 id="compact">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| -t     | --timeout         | (Optional) Timeout in seconds.         |
+| --help | n/a               | Displays help for using the command.   |
+
+## show compaction_state
+
+Shows compaction state.
+
+<h3 id="show-compaction-state">Syntax</h3>
+
+```shell
+show compaction_state -id (number)
+```
+
+<h3 id="show-compaction-state">Options</h3>
+
+| Option | Full name       | Description                           |
+| :----- | :-------------- | :------------------------------------ |
+| -id    | --compaction-id | [Required] The compaction ID.         |
+| --help | n/a             | Displays help for using the command.  |
+
+## show compaction_plans
+
+Shows compaction plans.
+
+<h3 id="show-compaction-plans">Syntax</h3>
+
+```shell
+show compaction_plans -c (text) -id (number)
+```
+
+<h3 id="show-compaction-plans">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| -id    | --compaction-id   | [Required] The compaction ID.          |
+| --help | n/a               | Displays help for using the command.   |
+
+## show loading_progress
+
+Displays the progress of loading a collection.
+
+<h3 id="show-loading-progress">Syntax</h3>
+
+```shell
+show loading_progress -c (text)
+```
+
+<h3 id="show-loading-progress">Options</h3>
+
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | The name of the collection.          |
+| --help | n/a               | Displays help for using the command. |
+
+## show load_state
+
+Shows the load state of a collection or partition.
+
+<h3 id="show-load-state">Syntax</h3>
+
+```shell
+show load_state -c (text) [-p (text)]
+```
+
+<h3 id="show-load-state">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| -p     | --partition       | (Optional) The name of the partition.  |
+| --help | n/a               | Displays help for using the command.   |
+
+## show replicas
+
+Shows replicas information for a collection.
+
+<h3 id="show-replicas">Syntax</h3>
+
+```shell
+show replicas -c (text)
+```
+
+<h3 id="show-replicas">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| --help | n/a               | Displays help for using the command.   |
+
+## show query_segment_info
+
+Shows query segment information for a collection.
+
+<h3 id="show-query-segment-info">Syntax</h3>
+
+```shell
+show query_segment_info -c (text)
+```
+
+<h3 id="show-query-segment-info">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| --help | n/a               | Displays help for using the command.   |
+
+## alter collection_properties
+
+Alters collection properties like TTL, mmap, etc.
+
+<h3 id="alter-collection-properties">Syntax</h3>
+
+```shell
+alter collection_properties -c (text)
+```
+
+<h3 id="alter-collection-properties">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| --help | n/a               | Displays help for using the command.   |
+
+<h3 id="alter-collection-properties">Interactive Example</h3>
+
+```shell
+milvus_cli > alter collection_properties -c car
+
+Property key: collection.ttl.seconds
+Property value: 86400
+```
+
+## delete collection_properties
+
+Drops collection properties by key.
+
+<h3 id="delete-collection-properties">Syntax</h3>
+
+```shell
+delete collection_properties -c (text) -k (text)
+```
+
+<h3 id="delete-collection-properties">Options</h3>
+
+| Option | Full name      | Description                            |
+| :----- | :------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The target collection.   |
+| -k     | --property-key | [Required] The property key to delete. |
+| --help | n/a            | Displays help for using the command.   |
+
+## alter collection_field
+
+Alters collection field properties.
+
+<h3 id="alter-collection-field">Syntax</h3>
+
+```shell
+alter collection_field -c (text) -f (text)
+```
+
+<h3 id="alter-collection-field">Options</h3>
+
+| Option | Full name         | Description                               |
+| :----- | :---------------- | :---------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection.    |
+| -f     | --field-name      | [Required] The name of the field to alter.|
+| --help | n/a               | Displays help for using the command.      |
+
+<h3 id="alter-collection-field">Interactive Example</h3>
+
+```shell
+milvus_cli > alter collection_field -c car -f color
+
+Property key: max_length
+Property value: 256
+```
+
+## create partition
+
+Creates a partition.
+
+<h3 id="create-partition">Syntax</h3>
+
+```shell
+create partition -c (text) -p (text) [-d (text)]
+```
+
+<h3 id="create-partition">Options</h3>
+
+| Option | Full name         | Description                                  |
+| :----- | :---------------- | :------------------------------------------- |
+| -c     | --collection-name | The name of the collection.                  |
+| -p     | --partition       | The partition name.                          |
+| -d     | --description     | (Optional) The description of the partition. |
+| --help | n/a               | Displays help for using the command.         |
+
+<h3 id="create-partition">Example</h3>
+
+```shell
+milvus_cli > create partition -c car -p new_partition -d test_add_partition
+```
+
+## list partitions
+
+Lists all partitions of a collection.
+
+<h3 id="list-partitions">Syntax</h3>
+
+```shell
+list partitions -c (text)
+```
+
+<h3 id="list-partitions">Options</h3>
+
+| Option | Full name         | Description                          |
+| :----- | :---------------- | :----------------------------------- |
+| -c     | --collection-name | The name of the collection.          |
+| --help | n/a               | Displays help for using the command. |
+
+## show partition
+
+Shows the detailed information of a partition.
+
+<h3 id="show-partition">Syntax</h3>
+
+```shell
+show partition -c (text) -p (text)
+```
+
+<h3 id="show-partition">Options</h3>
+
+| Option | Full name         | Description                                               |
+| :----- | :---------------- | :-------------------------------------------------------- |
+| -c     | --collection-name | The name of the collection that the partition belongs to. |
+| -p     | --partition       | The name of the partition.                                |
+| --help | n/a               | Displays help for using the command.                      |
+
+## show partition_stats
+
+Shows partition statistics.
+
+<h3 id="show-partition-stats">Syntax</h3>
+
+```shell
+show partition_stats -c (text) -p (text)
+```
+
+<h3 id="show-partition-stats">Options</h3>
+
+| Option | Full name         | Description                            |
+| :----- | :---------------- | :------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection. |
+| -p     | --partition       | [Required] The name of the partition.  |
+| --help | n/a               | Displays help for using the command.   |
 
 ## delete partition
 
@@ -502,179 +743,82 @@ delete partition -c (text) -p (text)
 | -p     | --partition       | The name of the partition to be deleted.                                |
 | --help | n/a               | Displays help for using the command.                                    |
 
-<h3 id="delete-partition">Example</h3>
+## load partition
+
+Loads a partition into RAM.
+
+<h3 id="load-partition">Syntax</h3>
 
 ```shell
-milvus_cli > delete partition -c car -p new_partition
+load partition -c (text) -p (text)
 ```
 
-## delete index
-
-Deletes an index and the corresponding index files.
-
-<div class="alert note"> Currently, a collection supports a maximum of one index.</div>
-
-<h3 id="delete-index">Syntax</h3>
-
-```shell
-delete index -c (text) -in (text)
-```
-
-<h3 >Options</h3>
+<h3 id="load-partition">Options</h3>
 
 | Option | Full name         | Description                          |
 | :----- | :---------------- | :----------------------------------- |
 | -c     | --collection-name | The name of the collection.          |
-| -in    | --index-name      | The name of the index name.          |
+| -p     | --partition       | The name of the partition.           |
 | --help | n/a               | Displays help for using the command. |
 
-<h3 >Example</h3>
+## release partition
+
+Releases a partition from RAM.
+
+<h3 id="release-partition">Syntax</h3>
 
 ```shell
-milvus_cli > delete index -c car -in indexName
-
-Warning! You are trying to delete the index of collection. This action cannot be undone!
-Do you want to continue? [y/N]: y
+release partition -c (text) -p (text)
 ```
 
-## grant role
-
-Grant role to user
-
-<h3 id="grant-user">Syntax</h3>
-
-```shell
-grant role -r (text) -u (text)
-```
-
-<h3 >Options</h3>
-
-| Option | Full name  | Description                          |
-| :----- | :--------- | :----------------------------------- |
-| -r     | --roleName | The role name of milvus role.        |
-| -u     | --username | The username of milvus user.         |
-| --help | n/a        | Displays help for using the command. |
-
-<h3 >Example</h3>
-
-```shell
-milvus_cli > grant role -r role1 -u user1
-```
-
-## grant privilege
-
-Assigns a privilege to a role.
-
-<h3 id="assign-privilege">Syntax</h3>
-
-```shell
-grant privilege
-```
-
-<h3 id="assign-privilege">Interactive Example</h3>
-
-```shell
-milvus_cli > grant privilege
-
-Role name: role1
-The type of object for which the privilege is to be assigned. (Global, Collection, User): Collection
-The name of the object to control access for: object1
-The name of the privilege to assign. (CreateCollection, DropCollection, etc.): CreateCollection
-The name of the database to which the object belongs. [default]: default
-```
-
-## revoke role
-
-Revokes the role assigned to a user.
-
-<h3 id="grant-user">Syntax</h3>
-
-```shell
-revoke role -r (text) -u (text)
-```
-
-<h3 >Options</h3>
-
-| Option | Full name  | Description                          |
-| :----- | :--------- | :----------------------------------- |
-| -r     | --roleName | The role name of milvus role.        |
-| -u     | --username | The username of milvus user.         |
-| --help | n/a        | Displays help for using the command. |
-
-<h3 >Example</h3>
-
-```shell
-milvus_cli > revoke role -r role1 -u user1
-```
-
-## revoke privilege
-
-Revokes a privilege already assigned to a role.
-
-<h3 id="revoke-privilege">Syntax</h3>
-
-```shell
-revoke privilege
-```
-
-<h3 id="revoke-privilege">Interactive Example</h3>
-
-```shell
-milvus_cli > revoke privilege
-
-Role name: role1
-The type of object for which the privilege is to be assigned. (Global, Collection, User): Collection
-The name of the object to control access for: object1
-The name of the privilege to assign. (CreateCollection, DropCollection, etc.): CreateCollection
-The name of the database to which the object belongs. [default]: default
-```
-
-## show collection
-
-Shows the detailed information of a collection.
-
-<h3 id="show-collection">Syntax</h3>
-
-```shell
-show collection -c (text)
-```
-
-<h3>Options</h3>
+<h3 id="release-partition">Options</h3>
 
 | Option | Full name         | Description                          |
 | :----- | :---------------- | :----------------------------------- |
 | -c     | --collection-name | The name of the collection.          |
+| -p     | --partition       | The name of the partition.           |
 | --help | n/a               | Displays help for using the command. |
 
-<h3>Example</h3>
+## create index
+
+Creates an index for a field.
+
+<h3 id="create-index">Syntax</h3>
 
 ```shell
-milvus_cli > show collection -c test_collection_insert
+create index
 ```
 
-## show partition
-
-Shows the detailed information of a partition.
-
-<h3 id="show-partition">Syntax</h3>
+<h3 id="create-index">Interactive Example</h3>
 
 ```shell
-show partition -c (text) -p (text)
+milvus_cli > create index
+
+Collection name (car, car2): car
+The name of the field to create an index for (vector): vector
+Index name: vectorIndex
+Index type (FLAT, IVF_FLAT, IVF_SQ8, IVF_PQ, HNSW, AUTOINDEX, DISKANN, GPU_IVF_FLAT, GPU_IVF_PQ, SPARSE_INVERTED_INDEX, SCANN, STL_SORT, Trie, INVERTED): IVF_FLAT
+Vector Index metric type (L2, IP, HAMMING, TANIMOTO, COSINE): L2
+Index params nlist: 2
+Timeout []:
 ```
 
-<h3>Options</h3>
+## list indexes
 
-| Option | Full name         | Description                                               |
-| :----- | :---------------- | :-------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection that the partition belongs to. |
-| -p     | --partition       | The name of the partition.                                |
-| --help | n/a               | Displays help for using the command.                      |
+Lists all indexes for a collection.
 
-<h3>Example</h3>
+<h3 id="list-indexes">Syntax</h3>
 
 ```shell
-milvus_cli > show partition -c test_collection_insert -p _default
+list indexes -c (text)
 ```
+
+<h3 id="list-indexes">Options</h3>
+
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -c     | --collection | The name of the collection.          |
+| --help | n/a          | Displays help for using the command. |
 
 ## show index
 
@@ -686,91 +830,89 @@ Shows the detailed information of an index.
 show index -c (text) -in (text)
 ```
 
-<h3 >Options</h3>
+<h3 id="show-index">Options</h3>
 
-| Option | Full name         | Description                 |
-| :----- | :---------------- | :-------------------------- |
-| -c     | --collection-name | The name of the collection. |
-| -in    | --index-name      | The name of the index.      |
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -c     | --collection | The name of the collection.          |
+| -in    | --index-name | The name of the index.               |
+| --help | n/a          | Displays help for using the command. |
 
-| --help | n/a | Displays help for using the command. |
+## show index_progress
 
-<h3 >Example</h3>
+Shows the progress of entity indexing.
 
-```shell
-milvus_cli > show index -c test_collection -in index_name
-```
-
-## exit
-
-Closes the command line window.
-
-<h3 id="exit">Syntax</h3>
+<h3 id="show-index-progress">Syntax</h3>
 
 ```shell
-exit
+show index_progress -c (text) [-in (text)]
 ```
 
-<h3 id="exit">Options</h3>
+<h3 id="show-index-progress">Options</h3>
 
-| Option | Full name | Description                          |
-| :----- | :-------- | :----------------------------------- |
-| --help | n/a       | Displays help for using the command. |
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -c     | --collection | The name of the collection.          |
+| -in    | --index-name | (Optional) The name of the index.    |
+| --help | n/a          | Displays help for using the command. |
 
-## help
+## delete index
 
-Displays help for using a command.
+Deletes an index.
 
-<h3 id="help">Syntax</h3>
+<h3 id="delete-index">Syntax</h3>
 
 ```shell
-help <command>
+delete index -c (text) -in (text)
 ```
 
-<h3 id="help">Commands</h3>
+<h3 id="delete-index">Options</h3>
 
-| Command | Description                                                               |
-| :------ | :------------------------------------------------------------------------ |
-| clear   | Clears the screen.                                                        |
-| connect | Connects to Milvus.                                                       |
-| create  | Create collection, database, partition,user,role and index.               |
-| grant   | Grant role, privilege .                                                   |
-| revoke  | Revoke role, privilege .                                                  |
-| delete  | Delete collection, database, partition,alias,user,role or index.          |
-| exit    | Closes the command line window.                                           |
-| help    | Displays help for using a command.                                        |
-| insert  | Imports data into a partition.                                            |
-| list    | List collections,databases, partitions,users,roles,grants or indexes.     |
-| load    | Loads a collection or partition.                                          |
-| query   | Shows query results that match all the criteria that you enter.           |
-| release | Releases a collection or partition.                                       |
-| search  | Performs a vector similarity search or hybrid search.                     |
-| show    | Show connection, database,collection, loading_progress or index_progress. |
-| rename  | Rename collection                                                         |
-| use     | Use database                                                              |
-| version | Shows the version of Milvus_CLI.                                          |
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -c     | --collection | The name of the collection.          |
+| -in    | --index-name | The name of the index.               |
+| --help | n/a          | Displays help for using the command. |
 
-## insert
+## wait_for_index
 
-Imports local or remote data into a partition.
+Waits for index building to complete.
 
-<h3 id="insert">Syntax</h3>
+<h3 id="wait-for-index">Syntax</h3>
 
 ```shell
-insert file -c (text) [-p (text)] [-t (text)] <file_path>
+wait_for_index -c (text) [-in (text)] [-t (number)]
 ```
 
-<h3 id="insert">Options</h3>
+<h3 id="wait-for-index">Options</h3>
 
-| Option | Full name         | Description                                                                                                                                                            |
-| :----- | :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection that the data are inserted into.                                                                                                            |
-| -p     | --partition       | (Optional) The name of the partition that the data are inserted into. Not passing this partition option indicates choosing the "\_default" partition.                  |
-| -t     | --timeout         | (Optional) An optional duration of time in seconds to allow for the RPC. If timeout is not set, the client keeps waiting until the server responds or an error occurs. |
-| --help | n/a               | Displays help for using the command.                                                                                                                                   |
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -c     | --collection | [Required] The name of the collection.|
+| -in    | --index-name | (Optional) The name of the index.    |
+| -t     | --timeout    | (Optional) Timeout in seconds.       |
+| --help | n/a          | Displays help for using the command. |
 
-<h3 id="insert">Example 1</h3>
-The following example imports a local CSV file.
+## insert file
+
+Imports data from a CSV file into a collection.
+
+<h3 id="insert-file">Syntax</h3>
+
+```shell
+insert file -c (text) [-p (text)] [-t (number)] <file_path>
+```
+
+<h3 id="insert-file">Options</h3>
+
+| Option | Full name         | Description                                                                     |
+| :----- | :---------------- | :------------------------------------------------------------------------------ |
+| -c     | --collection-name | The name of the collection that the data are inserted into.                     |
+| -p     | --partition       | (Optional) The partition name. Default is "\_default".                          |
+| -t     | --timeout         | (Optional) Timeout in seconds.                                                 |
+| --help | n/a               | Displays help for using the command.                                            |
+
+<h3 id="insert-file">Example</h3>
 
 ```shell
 milvus_cli > insert file -c car 'examples/import_csv/vectors.csv'
@@ -784,32 +926,6 @@ Processed 50001 lines.
 Inserting ...
 
 Insert successfully.
---------------------------  ------------------
-Total insert entities:                   50000
-Total collection entities:              150000
-Milvus timestamp:           428849214449254403
---------------------------  ------------------
-```
-
-<h3 id="insert">Example 2</h3>
-The following example imports a remote CSV file.
-
-```shell
-milvus_cli > insert file -c car 'https://raw.githubusercontent.com/milvus-
-io/milvus_cli/main/examples/import_csv/vectors.csv'
-
-Reading file from remote URL.
-
-Reading csv file...  [####################################]  100%
-
-Column names are ['vector', 'color', 'brand']
-
-Processed 50001 lines.
-
-Inserting ...
-
-Insert successfully.
-
 --------------------------  ------------------
 Total insert entities:                   50000
 Total collection entities:              150000
@@ -842,135 +958,128 @@ Enter value for brand (VARCHAR): Toyota
 Inserted successfully.
 ```
 
-## list users
+## upsert file
 
-Lists all users.
+Upserts data from a CSV file into a collection.
 
-### Syntax
-
-```shell
-list users
-```
-
-### Options
-
-| Option | Full name | Description |
-| --help | n/a | Displays help for using the command. |
-
-## List roles
-
-List roles in Milvus
-
-<h3 id="list-role">Syntax</h3>
+<h3 id="upsert-file">Syntax</h3>
 
 ```shell
-list roles
+upsert file -c (text) [-p (text)] [-t (number)] <file_path>
 ```
 
-### Options
+<h3 id="upsert-file">Options</h3>
 
-| Option | Full name | Description                          |
-| :----- | :-------- | :----------------------------------- |
-| --help | n/a       | Displays help for using the command. |
+| Option | Full name         | Description                                                     |
+| :----- | :---------------- | :-------------------------------------------------------------- |
+| -c     | --collection-name | The name of the collection to upsert into.                      |
+| -p     | --partition       | (Optional) The partition name. Default is "\_default".          |
+| -t     | --timeout         | (Optional) Timeout in seconds.                                  |
+| --help | n/a               | Displays help for using the command.                            |
 
-### Examples
+## upsert row
+
+Upserts a row of data into a collection.
+
+<h3 id="upsert-row">Syntax</h3>
 
 ```shell
-milvus_cli > list roles
+upsert row
 ```
 
-## List grants
-
-List grants in Milvus
-
-### Options
-
-| Option | Full name    | Description                          |
-| :----- | :----------- | :----------------------------------- |
-| -r     | --roleName   | The role name of milvus role.        |
-| -o     | --objectName | The object name of milvus object.    |
-| -t     | --objectType | Global, Collection or User.          |
-| --help | n/a          | Displays help for using the command. |
-
-### Examples
+<h3 id="upsert-row">Interactive Example</h3>
 
 ```shell
-milvus_cli > list grants -r role1 -o object1 -t Collection
+milvus_cli > upsert row
+
+Collection name: car
+Partition name [_default]: _default
+Enter value for id (INT64): 1
+Enter value for vector (FLOAT_VECTOR): [1.0, 2.0, 3.0]
+Enter value for color (INT64): 200
+Enter value for brand (VARCHAR): Honda
+
+Upserted successfully.
 ```
 
-## list collections
+## delete entities
 
-Lists all collections.
+Deletes entities using a filter expression.
 
-<h3 id="list-collections">Syntax<h3>
+<h3 id="delete-entities">Syntax</h3>
 
 ```shell
-list collections
+delete entities -c (text) [-p (text)]
 ```
 
-<h3 id="list-collections">Options<h3>
+<h3 id="delete-entities">Options</h3>
 
-| Option | Full name | Description                          |
-| :----- | :-------- | :----------------------------------- |
-| --help | n/a       | Displays help for using the command. |
+| Option | Full name         | Description                                                        |
+| :----- | :---------------- | :----------------------------------------------------------------- |
+| -c     | --collection-name | The name of the collection that entities to be deleted belongs to. |
+| -p     | --partition       | (Optional) The name of the partition.                              |
+| --help | n/a               | Displays help for using the command.                               |
 
-## list indexes
-
-Lists all indexes for a collection.
-
-<div class="alert note"> Currently, a collection supports a maximum of one index. </div>
-
-<h3 id="list-indexes">Syntax</h3>
+<h3 id="delete-entities">Interactive Example</h3>
 
 ```shell
-list indexes -c (text)
+milvus_cli > delete entities -c car
+
+The expression to specify entities to be deleted, such as "film_id in [ 0, 1 ]": film_id in [ 0, 1 ]
+
+Warning! You are trying to delete the entities of collection. This action cannot be undone!
+Do you want to continue? [y/N]: y
 ```
 
-<h3 id="list-indexes">Options</h3>
+## delete ids
+
+Deletes entities by IDs.
+
+<h3 id="delete-ids">Syntax</h3>
+
+```shell
+delete ids -c (text) [-p (text)]
+```
+
+<h3 id="delete-ids">Options</h3>
 
 | Option | Full name         | Description                          |
 | :----- | :---------------- | :----------------------------------- |
 | -c     | --collection-name | The name of the collection.          |
+| -p     | --partition       | (Optional) The name of the partition.|
 | --help | n/a               | Displays help for using the command. |
 
-## list partitions
-
-Lists all partitions of a collection.
-
-<h3 id="list-partitions">Syntax</h3>
+<h3 id="delete-ids">Interactive Example</h3>
 
 ```shell
-list partitions -c (text)
+milvus_cli > delete ids -c car
+
+IDs to delete (comma-separated): 1, 2, 3
 ```
 
-<h3 id="list-partitions">Options</h3>
+## get
 
-| Option | Full name         | Description                          |
-| :----- | :---------------- | :----------------------------------- |
-| -c     | --collection-name | The name of the collection.          |
-| --help | n/a               | Displays help for using the command. |
+Gets entities by IDs.
 
-## load
-
-Loads a collection or partition from hard drive space into RAM.
-
-<h3 id="load">Syntax</h3>
+<h3 id="get">Syntax</h3>
 
 ```shell
-load collection -c (text) [-p (text)]
+get
 ```
 
-<h3 id="load">Options</h3>
+<h3 id="get">Interactive Example</h3>
 
-| Option | Full name         | Description                                               |
-| :----- | :---------------- | :-------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection that the partition belongs to. |
-| -p     | --partition       | (Optional/Multiple) The name of the partition.            |
-| --help | n/a               | Displays help for using the command.                      |
+```shell
+milvus_cli > get
+
+Collection name: car
+IDs (comma-separated): 1, 2, 3
+Output fields (comma-separated, or * for all) []: color, brand
+```
 
 ## query
 
-Shows query results that match all the criteria that you enter.
+Shows query results that match all the criteria you enter.
 
 <h3 id="query">Syntax</h3>
 
@@ -985,7 +1094,7 @@ milvus_cli > query
 
 Collection name: car
 
-The query expression: id in [ 428960801420883491, 428960801420883492, 428960801420883493 ]
+The query expression: id in [ 428960801420883491, 428960801420883492 ]
 
 Name of partitions that contain entities(split by "," if multiple) []: default
 
@@ -993,32 +1102,14 @@ A list of fields to return(split by "," if multiple) []: color, brand
 
 timeout []:
 
-Guarantee timestamp. This instructs Milvus to see all operations performed before a provided timestamp. If no such timestamp is provided, then Milvus will search all operations performed to date. [0]:
+Guarantee timestamp. This instructs Milvus to see all operations performed before a provided timestamp. [0]:
 
-Graceful time. Only used in bounded consistency level. If graceful_time is set, PyMilvus will use current timestamp minus the graceful_time as the guarantee_timestamp. This option is 5s by default if not set. [5]:
+Graceful time. Only used in bounded consistency level. [5]:
 ```
-
-## release
-
-Releases a collection or partition from RAM.
-
-<h3 id="release">Syntax</h3>
-
-```shell
-release collection -c (text) [-p (text)]
-```
-
-<h3 id="release">Options</h3>
-
-| Option | Full name         | Description                                               |
-| :----- | :---------------- | :-------------------------------------------------------- |
-| -c     | --collection-name | The name of the collection that the partition belongs to. |
-| -p     | --partition       | (Optional/Multiple) The name of the partition.            |
-| --help | n/a               | Displays help for using the command.                      |
 
 ## search
 
-Performs a vector similarity search or hybrid search.
+Performs a vector similarity search.
 
 <h3 id="search">Syntax</h3>
 
@@ -1033,7 +1124,7 @@ milvus_cli > search
 
 Collection name (car, test_collection): car
 
-The vectors of search data(the length of data is number of query (nq), the dim of every vector in data must be equal to vector field's of collection. You can also import a csv file without headers): examples/import_csv/search_vectors.csv
+The vectors of search data: examples/import_csv/search_vectors.csv
 
 The vector field used to search of collection (vector): vector
 
@@ -1047,74 +1138,762 @@ The names of partitions to search (split by "," if multiple) ['_default'] []: _d
 
 timeout []:
 
-Guarantee Timestamp(It instructs Milvus to see all operations performed before a provided timestamp. If no such timestamp is provided, then Milvus will search all operations performed to date) [0]:
+Guarantee Timestamp [0]:
 ```
 
-## list connection
+## hybrid_search
 
-List connections.
+Performs a hybrid search (multi-vector search) with reranking.
 
-<h3 id="show-connection">Syntax</h3>
+<h3 id="hybrid-search">Syntax</h3>
+
+```shell
+hybrid_search
+```
+
+<h3 id="hybrid-search">Interactive Example</h3>
+
+```shell
+milvus_cli > hybrid_search
+
+Collection name: car
+
+Enter search requests (one per line, empty line to finish):
+  Vector field, search vector, metric type, top K, filter expression...
+
+Rerank strategy (rrf, weighted, etc.): rrf
+
+Output fields (comma-separated) []: color, brand
+```
+
+## query_iterator
+
+Queries entities with iterator for large result sets.
+
+<h3 id="query-iterator">Syntax</h3>
+
+```shell
+query_iterator
+```
+
+<h3 id="query-iterator">Interactive Example</h3>
+
+```shell
+milvus_cli > query_iterator
+
+Collection name: car
+Filter expression []: id > 0
+Output fields (comma-separated, or * for all) []: color, brand
+Batch size [1000]: 1000
+Limit [10]: 100
+```
+
+## search_iterator
+
+Searches with iterator for large result sets.
+
+<h3 id="search-iterator">Syntax</h3>
+
+```shell
+search_iterator
+```
+
+<h3 id="search-iterator">Interactive Example</h3>
+
+```shell
+milvus_cli > search_iterator
+
+Collection name: car
+Vector field name: vector
+Search vector (comma-separated floats): 1.0, 2.0, 3.0, ...
+Batch size [1000]: 1000
+Limit [10]: 100
+Filter expression []:
+Output fields (comma-separated) []: color, brand
+```
+
+## bulk_insert
+
+Bulk inserts data from remote storage (S3, MinIO, etc.).
+
+<h3 id="bulk-insert">Syntax</h3>
+
+```shell
+bulk_insert -c (text) [-p (text)] -f (text)
+```
+
+<h3 id="bulk-insert">Options</h3>
+
+| Option | Full name         | Description                                    |
+| :----- | :---------------- | :--------------------------------------------- |
+| -c     | --collection-name | [Required] The name of the collection.         |
+| -p     | --partition       | (Optional) The partition name.                 |
+| -f     | --files           | [Required] File paths (comma separated).       |
+| --help | n/a               | Displays help for using the command.           |
+
+## show bulk_insert_state
+
+Shows bulk insert task state.
+
+<h3 id="show-bulk-insert-state">Syntax</h3>
+
+```shell
+show bulk_insert_state -id (number)
+```
+
+<h3 id="show-bulk-insert-state">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -id    | --task-id | [Required] The bulk insert task ID.  |
+| --help | n/a       | Displays help for using the command. |
+
+## list bulk_insert_tasks
+
+Lists bulk insert tasks.
+
+<h3 id="list-bulk-insert-tasks">Syntax</h3>
+
+```shell
+list bulk_insert_tasks [-l (number)] [-c (text)]
+```
+
+<h3 id="list-bulk-insert-tasks">Options</h3>
+
+| Option | Full name         | Description                                    |
+| :----- | :---------------- | :--------------------------------------------- |
+| -l     | --limit           | (Optional) Maximum number of tasks to return.  |
+| -c     | --collection-name | (Optional) Filter by collection name.          |
+| --help | n/a               | Displays help for using the command.           |
+
+## create user
+
+Creates a user in Milvus.
+
+<h3 id="create-user">Syntax</h3>
+
+```shell
+create user -u (text) -p (text)
+```
+
+<h3 id="create-user">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -u     | --username | The username.                        |
+| -p     | --password | The password.                        |
+| --help | n/a        | Displays help for using the command. |
+
+<h3 id="create-user">Example</h3>
+
+```shell
+milvus_cli > create user -u zilliz -p zilliz
+```
+
+## list users
+
+Lists all users.
+
+<h3 id="list-users">Syntax</h3>
+
+```shell
+list users
+```
+
+## show user
+
+Shows user details and assigned roles.
+
+<h3 id="show-user">Syntax</h3>
+
+```shell
+show user -u (text)
+```
+
+<h3 id="show-user">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -u     | --username | [Required] The username to describe. |
+| --help | n/a        | Displays help for using the command. |
+
+## delete user
+
+Deletes a user.
+
+<h3 id="delete-user">Syntax</h3>
+
+```shell
+delete user -u (text)
+```
+
+<h3 id="delete-user">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -u     | --username | The username.                        |
+| --help | n/a        | Displays help for using the command. |
+
+## update password
+
+Updates a user's password.
+
+<h3 id="update-password">Syntax</h3>
+
+```shell
+update password -u (text)
+```
+
+<h3 id="update-password">Options</h3>
+
+| Option | Full name  | Description                               |
+| :----- | :--------- | :---------------------------------------- |
+| -u     | --username | [Required] The username to update.        |
+| --help | n/a        | Displays help for using the command.      |
+
+<h3 id="update-password">Interactive Example</h3>
+
+```shell
+milvus_cli > update password -u zilliz
+
+Old password:
+New password:
+Confirm new password:
+```
+
+## create role
+
+Creates a role in Milvus.
+
+<h3 id="create-role">Syntax</h3>
+
+```shell
+create role -r (text)
+```
+
+<h3 id="create-role">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -r     | --roleName | The role name.                       |
+| --help | n/a        | Displays help for using the command. |
+
+## list roles
+
+Lists all roles.
+
+<h3 id="list-roles">Syntax</h3>
+
+```shell
+list roles
+```
+
+## show role
+
+Shows role details and granted privileges.
+
+<h3 id="show-role">Syntax</h3>
+
+```shell
+show role -r (text)
+```
+
+<h3 id="show-role">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -r     | --roleName | [Required] The role name.            |
+| --help | n/a        | Displays help for using the command. |
+
+## delete role
+
+Deletes a role.
+
+<h3 id="delete-role">Syntax</h3>
+
+```shell
+delete role -r (text)
+```
+
+<h3 id="delete-role">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -r     | --roleName | The role name.                       |
+| --help | n/a        | Displays help for using the command. |
+
+## grant role
+
+Assigns a user to a role.
+
+<h3 id="grant-role">Syntax</h3>
+
+```shell
+grant role -r (text) -u (text)
+```
+
+<h3 id="grant-role">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -r     | --roleName | The role name.                       |
+| -u     | --username | The username.                        |
+| --help | n/a        | Displays help for using the command. |
+
+## revoke role
+
+Removes a user from a role.
+
+<h3 id="revoke-role">Syntax</h3>
+
+```shell
+revoke role -r (text) -u (text)
+```
+
+<h3 id="revoke-role">Options</h3>
+
+| Option | Full name  | Description                          |
+| :----- | :--------- | :----------------------------------- |
+| -r     | --roleName | The role name.                       |
+| -u     | --username | The username.                        |
+| --help | n/a        | Displays help for using the command. |
+
+## grant privilege
+
+Grants a privilege to a role.
+
+<h3 id="grant-privilege">Syntax</h3>
+
+```shell
+grant privilege
+```
+
+<h3 id="grant-privilege">Interactive Example</h3>
+
+```shell
+milvus_cli > grant privilege
+
+Role name: role1
+The type of object for which the privilege is to be assigned. (Global, Collection, User): Collection
+The name of the object to control access for: object1
+The name of the privilege to assign. (CreateCollection, DropCollection, etc.): CreateCollection
+The name of the database to which the object belongs. [default]: default
+```
+
+## revoke privilege
+
+Revokes a privilege from a role.
+
+<h3 id="revoke-privilege">Syntax</h3>
+
+```shell
+revoke privilege
+```
+
+<h3 id="revoke-privilege">Interactive Example</h3>
+
+```shell
+milvus_cli > revoke privilege
+
+Role name: role1
+The type of object for which the privilege is to be assigned. (Global, Collection, User): Collection
+The name of the object to control access for: object1
+The name of the privilege to assign. (CreateCollection, DropCollection, etc.): CreateCollection
+The name of the database to which the object belongs. [default]: default
+```
+
+## list grants
+
+Lists grants for a role.
+
+<h3 id="list-grants">Syntax</h3>
+
+```shell
+list grants -r (text) -o (text) -t (text)
+```
+
+<h3 id="list-grants">Options</h3>
+
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -r     | --roleName   | The role name.                       |
+| -o     | --objectName | The object name.                     |
+| -t     | --objectType | Global, Collection, or User.         |
+| --help | n/a          | Displays help for using the command. |
+
+## create alias
+
+Specifies an alias for a collection.
+
+<div class="alert note">A collection can have multiple aliases. However, an alias corresponds to a maximum of one collection.</div>
+
+<h3 id="create-alias">Syntax</h3>
+
+```shell
+create alias -c (text) -a (text) [-A]
+```
+
+<h3 id="create-alias">Options</h3>
+
+| Option | Full name         | Description                                                      |
+| :----- | :---------------- | :--------------------------------------------------------------- |
+| -c     | --collection-name | The name of the collection.                                      |
+| -a     | --alias-name      | The alias.                                                       |
+| -A     | --alter           | (Optional) Flag to transfer the alias to a specified collection. |
+| --help | n/a               | Displays help for using the command.                             |
+
+<h3 id="create-alias">Example</h3>
+
+```shell
+milvus_cli > create alias -c car -a carAlias1
+```
+
+## list aliases
+
+Lists aliases in the database.
+
+<h3 id="list-aliases">Syntax</h3>
+
+```shell
+list aliases [-c (text)]
+```
+
+<h3 id="list-aliases">Options</h3>
+
+| Option | Full name         | Description                                      |
+| :----- | :---------------- | :----------------------------------------------- |
+| -c     | --collection-name | (Optional) Filter aliases by collection.         |
+| --help | n/a               | Displays help for using the command.             |
+
+## show alias
+
+Shows details of an alias.
+
+<h3 id="show-alias">Syntax</h3>
+
+```shell
+show alias -a (text)
+```
+
+<h3 id="show-alias">Options</h3>
+
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -a     | --alias-name | [Required] The alias name.           |
+| --help | n/a          | Displays help for using the command. |
+
+## delete alias
+
+Deletes an alias.
+
+<h3 id="delete-alias">Syntax</h3>
+
+```shell
+delete alias -a (text)
+```
+
+<h3 id="delete-alias">Options</h3>
+
+| Option | Full name    | Description                          |
+| :----- | :----------- | :----------------------------------- |
+| -a     | --alias-name | The alias.                           |
+| --help | n/a          | Displays help for using the command. |
+
+## create privilege_group
+
+Creates a new privilege group.
+
+<h3 id="create-privilege-group">Syntax</h3>
+
+```shell
+create privilege_group -n (text)
+```
+
+<h3 id="create-privilege-group">Options</h3>
+
+| Option | Full name | Description                            |
+| :----- | :-------- | :------------------------------------- |
+| -n     | --name    | [Required] The privilege group name.   |
+| --help | n/a       | Displays help for using the command.   |
+
+## list privilege_groups
+
+Lists all privilege groups.
+
+<h3 id="list-privilege-groups">Syntax</h3>
+
+```shell
+list privilege_groups
+```
+
+## grant privilege_group
+
+Adds privileges to a privilege group.
+
+<h3 id="grant-privilege-group">Syntax</h3>
+
+```shell
+grant privilege_group -n (text) -p (text)
+```
+
+<h3 id="grant-privilege-group">Options</h3>
+
+| Option | Full name    | Description                                         |
+| :----- | :----------- | :-------------------------------------------------- |
+| -n     | --name       | [Required] The privilege group name.                |
+| -p     | --privileges | [Required] Comma-separated list of privileges.      |
+| --help | n/a          | Displays help for using the command.                |
+
+<h3 id="grant-privilege-group">Example</h3>
+
+```shell
+milvus_cli > grant privilege_group -n my_group -p CreateCollection,DropCollection
+```
+
+## revoke privilege_group
+
+Removes privileges from a privilege group.
+
+<h3 id="revoke-privilege-group">Syntax</h3>
+
+```shell
+revoke privilege_group -n (text) -p (text)
+```
+
+<h3 id="revoke-privilege-group">Options</h3>
+
+| Option | Full name    | Description                                         |
+| :----- | :----------- | :-------------------------------------------------- |
+| -n     | --name       | [Required] The privilege group name.                |
+| -p     | --privileges | [Required] Comma-separated list of privileges.      |
+| --help | n/a          | Displays help for using the command.                |
+
+## delete privilege_group
+
+Deletes a privilege group.
+
+<h3 id="delete-privilege-group">Syntax</h3>
+
+```shell
+delete privilege_group -n (text) [--yes]
+```
+
+<h3 id="delete-privilege-group">Options</h3>
+
+| Option | Full name | Description                            |
+| :----- | :-------- | :------------------------------------- |
+| -n     | --name    | [Required] The privilege group name.   |
+| --yes  | -y        | (Optional) Skip confirmation prompt.   |
+| --help | n/a       | Displays help for using the command.   |
+
+## create resource_group
+
+Creates a new resource group.
+
+<h3 id="create-resource-group">Syntax</h3>
+
+```shell
+create resource_group -n (text)
+```
+
+<h3 id="create-resource-group">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -n     | --name    | [Required] The resource group name.  |
+| --help | n/a       | Displays help for using the command. |
+
+<h3 id="create-resource-group">Interactive Example</h3>
+
+```shell
+milvus_cli > create resource_group -n my_rg
+
+Configure node limits? [y/N]: y
+requests.node_num [0]: 1
+limits.node_num [0]: 3
+```
+
+## list resource_groups
+
+Lists all resource groups.
+
+<h3 id="list-resource-groups">Syntax</h3>
+
+```shell
+list resource_groups
+```
+
+## show resource_group
+
+Shows resource group details.
+
+<h3 id="show-resource-group">Syntax</h3>
+
+```shell
+show resource_group -n (text)
+```
+
+<h3 id="show-resource-group">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -n     | --name    | [Required] The resource group name.  |
+| --help | n/a       | Displays help for using the command. |
+
+## update resource_group
+
+Updates resource group configuration.
+
+<h3 id="update-resource-group">Syntax</h3>
+
+```shell
+update resource_group -n (text)
+```
+
+<h3 id="update-resource-group">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -n     | --name    | [Required] The resource group name.  |
+| --help | n/a       | Displays help for using the command. |
+
+<h3 id="update-resource-group">Interactive Example</h3>
+
+```shell
+milvus_cli > update resource_group -n my_rg
+
+requests.node_num [current]: 2
+limits.node_num [current]: 5
+```
+
+## delete resource_group
+
+Deletes a resource group.
+
+<h3 id="delete-resource-group">Syntax</h3>
+
+```shell
+delete resource_group -n (text)
+```
+
+<h3 id="delete-resource-group">Options</h3>
+
+| Option | Full name | Description                          |
+| :----- | :-------- | :----------------------------------- |
+| -n     | --name    | [Required] The resource group name.  |
+| --help | n/a       | Displays help for using the command. |
+
+## transfer replica
+
+Transfers replicas between resource groups.
+
+<h3 id="transfer-replica">Syntax</h3>
+
+```shell
+transfer replica
+```
+
+<h3 id="transfer-replica">Interactive Example</h3>
+
+```shell
+milvus_cli > transfer replica
+
+Source resource group: __default_resource_group
+Target resource group: my_rg
+Collection name: car
+Number of replicas to transfer: 1
+```
+
+## list connections
+
+Lists all Milvus connections.
+
+<h3 id="list-connections">Syntax</h3>
 
 ```shell
 list connections
 ```
 
-<h3 id="show-connection">Options</h3>
+## list connection_history
 
-| Option | Full name | Description                          |
-| :----- | :-------- | :----------------------------------- |
-| --help | n/a       | Displays help for using the command. |
+Lists saved connection history.
 
-## show index_progress
-
-Shows the progress of entity indexing.
-
-<h3 id="show-index-progress">Syntax</h3>
+<h3 id="list-connection-history">Syntax</h3>
 
 ```shell
-show index_progress -c (text) [-i (text)]
+list connection_history
 ```
 
-<h3 id="show-index-progress">Options</h3>
+## delete connection_history
 
-| Option | Full name         | Description                                             |
-| :----- | :---------------- | :------------------------------------------------------ |
-| -c     | --collection-name | The name of the collection that the entities belong to. |
-| -i     | --index           | (Optional) The name of the index.                       |
-| --help | n/a               | Displays help for using the command.                    |
+Deletes a saved connection from history.
 
-## show loading_progress
+<h3 id="delete-connection-history">Syntax</h3>
 
-Displays the progress of loading a collection.
-
-<h3 id="show-loading-progress">Syntax</h3>
- 
 ```shell
-show loading_progress -c (text) [-p (text)]
+delete connection_history -uri (text)
 ```
-<h3 id="show-loading-progress">Options</h3>
- 
-|Option|Full name|Description
-|:---|:---|:---|
-|-c|--collection-name|The name of the collection that the entities belong to.|
-|-p|--partition|(Optional/Multiple) The name of the loading partition.|
-|--help|n/a|Displays help for using the command.|
+
+<h3 id="delete-connection-history">Options</h3>
+
+| Option | Full name | Description                                  |
+| :----- | :-------- | :------------------------------------------- |
+| -uri   | --uri     | [Required] URI of the connection to delete.  |
+| --help | n/a       | Displays help for using the command.         |
+
+## show output
+
+Shows the current output format setting.
+
+<h3 id="show-output">Syntax</h3>
+
+```shell
+show output
+```
+
+## set output
+
+Sets the global output format for CLI results.
+
+<h3 id="set-output">Syntax</h3>
+
+```shell
+set output (table|json|csv)
+```
+
+<h3 id="set-output">Example</h3>
+
+```shell
+milvus_cli > set output json
+```
+
+## history
+
+Shows or clears command history.
+
+<h3 id="history">Syntax</h3>
+
+```shell
+history [clear]
+```
+
+<h3 id="history">Examples</h3>
+
+```shell
+milvus_cli > history
+
+milvus_cli > history clear
+```
 
 ## version
 
 Shows the version of Milvus_CLI.
 
 <h3 id="version">Syntax</h3>
- 
+
 ```shell
 version
 ```
-<h3 id="version">Options</h3>
- 
-|Option|Full name|Description
-|:---|:---|:---|
-|--help|n/a|Displays help for using the command.|
 
 <div class="alert note"> You can also check the version of Milvus_CLI in a shell as shown in the following example. In this case, <code>milvus_cli --version</code> acts as a command.</div>
 
@@ -1122,5 +1901,58 @@ version
 
 ```shell
 $ milvus_cli --version
-Milvus_CLI v0.4.0
+Milvus_CLI v1.2.1
 ```
+
+## exit
+
+Closes the command line window.
+
+<h3 id="exit">Syntax</h3>
+
+```shell
+exit
+```
+
+## help
+
+Displays help for using a command.
+
+<h3 id="help">Syntax</h3>
+
+```shell
+help <command>
+```
+
+<h3 id="help">Commands</h3>
+
+| Command  | Description                                                                 |
+| :------- | :-------------------------------------------------------------------------- |
+| alter    | Alter database, collection properties, or collection field.                 |
+| clear    | Clears the screen.                                                          |
+| compact  | Compact a collection.                                                       |
+| connect  | Connects to Milvus.                                                         |
+| create   | Create collection, database, partition, user, role, alias, index, and more. |
+| delete   | Delete collection, database, partition, alias, user, role, index, and more. |
+| exit     | Closes the command line window.                                             |
+| flush    | Flush collection data to storage.                                           |
+| get      | Get entities by IDs.                                                        |
+| grant    | Grant role, privilege, or privilege_group.                                   |
+| help     | Displays help for using a command.                                          |
+| history  | Show or clear command history.                                              |
+| insert   | Import data into a collection.                                              |
+| list     | List collections, databases, partitions, users, roles, and more.            |
+| load     | Load a collection or partition.                                             |
+| query    | Query entities with filter expressions.                                     |
+| release  | Release a collection or partition.                                          |
+| rename   | Rename collection.                                                          |
+| revoke   | Revoke role, privilege, or privilege_group.                                  |
+| search   | Perform vector similarity search.                                           |
+| set      | Set output format.                                                          |
+| show     | Show collection, database, partition, index details, and more.              |
+| transfer | Transfer replicas between resource groups.                                  |
+| truncate | Remove all data from a collection.                                          |
+| update   | Update password or resource group.                                          |
+| upsert   | Upsert data into a collection.                                              |
+| use      | Use database.                                                               |
+| version  | Shows the version of Milvus_CLI.                                            |

--- a/site/en/userGuide/tools/cli_overview.md
+++ b/site/en/userGuide/tools/cli_overview.md
@@ -29,10 +29,11 @@ In the following table, you can find the recommended versions of PyMilvus and Mi
 |   2.3.x   |  2.3.x   |   0.4.2    |
 |   2.4.x   |  2.4.x   |   1.0.1    |
 |   2.5.x   |  2.5.x   |   1.0.2    |
+|   2.6.x   |  2.6.x   |   1.2.1    |
 
 <div class="alert note">Milvus 2.0.0-RC7 and later are not backward compatible with 2.0.0-RC6 and earlier due to changes made to storage formats.</div>
 
 ## Current version
 
-The current version of Milvus_CLI is 1.0.2.
+The current version of Milvus_CLI is 1.2.1.
 To find your installed version and see if you need to update, run `milvus_cli --version`.

--- a/site/en/userGuide/tools/install_cli.md
+++ b/site/en/userGuide/tools/install_cli.md
@@ -14,7 +14,7 @@ You can install Milvus_CLI from [PyPI](https://pypi.org/project/milvus-cli/).
 
 ### Prerequisites
 
-- Install [Python 3.8.5](https://www.python.org/downloads/release/python-385/) or later
+- Install [Python 3.9](https://www.python.org/downloads/release/python-390/) or later
 - Install [pip](https://pip.pypa.io/en/stable/installation/)
 
 ### Install via pip


### PR DESCRIPTION
## Summary
- Update CLI command reference with 50+ new commands added in Milvus CLI v1.2.1
- Update version compatibility table and current version info
- Update Python requirement from 3.8 to 3.9

## Changed Files
- `cli_commands.md`: Add documentation for new commands including truncate, flush, compact, upsert, hybrid_search, query/search iterators, privilege_group, resource_group, show user/role, bulk_insert, alter collection properties, connection history, output format, and more
- `cli_overview.md`: Add Milvus 2.6.x row to version table, update current version to 1.2.1
- `install_cli.md`: Update Python version requirement from 3.8.5 to 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)