### PR TITLE
fix: improve AI prompts card layout and clickability

### DIFF
--- a/site/en/aiTools/ai_prompts_landing.md
+++ b/site/en/aiTools/ai_prompts_landing.md
@@ -14,50 +14,54 @@ Curated prompts that help AI coding assistants write correct Milvus code. Each p
 2. **Save** it to the file your AI tool expects (see [environments table](#use-in-different-environments) below).
 3. Your AI assistant will automatically apply the rules when it generates or reviews Milvus code.
 
-## Prompts
+## Prompt pages
 
 <div class="card-wrapper">
 
 <div class="start_card_container">
   <a href="agents_overview.md">
     <p class="link-btn">🤖 AGENTS.md for Milvus</p>
+    <p>Top-level rules for any AI coding agent. Start here if you only want one file.</p>
   </a>
-  <p>Top-level rules for any AI coding agent. Start here if you only want one file.</p>
 </div>
 
 <div class="start_card_container">
   <a href="python_sdk.md">
     <p class="link-btn">🐍 Milvus Python SDK</p>
+    <p>Correct connection patterns, MilvusClient usage, and ORM API prohibition.</p>
   </a>
-  <p>Correct connection patterns, MilvusClient usage, and ORM API prohibition.</p>
 </div>
 
 <div class="start_card_container">
   <a href="schema_design.md">
     <p class="link-btn">📐 Schema Design</p>
+    <p>Field types, primary keys, schema immutability, and BM25 configuration.</p>
   </a>
-  <p>Field types, primary keys, schema immutability, and BM25 configuration.</p>
 </div>
+
+</div>
+
+<div class="card-wrapper">
 
 <div class="start_card_container">
   <a href="search_patterns.md">
     <p class="link-btn">🔍 Search Patterns</p>
+    <p>ANN, hybrid, and full-text search with critical constraint rules.</p>
   </a>
-  <p>ANN, hybrid, and full-text search with critical constraint rules.</p>
 </div>
 
 <div class="start_card_container">
   <a href="index_selection.md">
     <p class="link-btn">🗂️ Index Selection</p>
+    <p>Decision tree for AUTOINDEX, HNSW, DiskANN, and IVF_FLAT.</p>
   </a>
-  <p>Decision tree for AUTOINDEX, HNSW, DiskANN, and IVF_FLAT.</p>
 </div>
 
 <div class="start_card_container">
   <a href="rag_pipeline.md">
     <p class="link-btn">🔗 RAG Pipeline</p>
+    <p>End-to-end retrieval-augmented generation flow with Milvus.</p>
   </a>
-  <p>End-to-end retrieval-augmented generation flow with Milvus.</p>
 </div>
 
 </div>


### PR DESCRIPTION
Split 6 cards into two rows of 3 to prevent horizontal overflow, and wrap card descriptions inside anchor tags for full-card click.