### PR TITLE
docs: add Milvus for AI Agents landing page and restructure AI Tools …

### DIFF
--- a/site/en/aiTools/agents_overview.md
+++ b/site/en/aiTools/agents_overview.md
@@ -8,7 +8,7 @@ summary: Rules and patterns for AI coding agents that generate, review, or debug
 
 # AGENTS.md — Milvus
 
-Milvus is an open-source vector database for similarity search, hybrid search, and RAG. You interact with it through the PyMilvus SDK's `MilvusClient` interface. Copy the full prompt below into your AI tool to apply these rules automatically. For detailed task-specific prompts, see [AI Prompts](ai_prompts_landing.md).
+Milvus is an open-source vector database for similarity search, hybrid search, and RAG. You interact with it through the PyMilvus SDK's `MilvusClient` interface. Copy the full prompt below into your AI tool to apply these rules automatically. For detailed task-specific prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/aiTools/index_selection.md
+++ b/site/en/aiTools/index_selection.md
@@ -6,7 +6,7 @@ summary: Rules for AI coding assistants to choose and configure Milvus indexes.
 
 {{fragments/ai_prompt_howto.md}}
 
-Decision guides and configuration rules for choosing and tuning Milvus indexes, including AUTOINDEX, HNSW, DiskANN, IVF, and sparse indexes. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](ai_prompts_landing.md).
+Decision guides and configuration rules for choosing and tuning Milvus indexes, including AUTOINDEX, HNSW, DiskANN, IVF, and sparse indexes. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/aiTools/milvus_for_agents.md
+++ b/site/en/aiTools/milvus_for_agents.md
@@ -1,20 +1,62 @@
 ---
-id: ai_prompts_landing.md
-title: "AI Prompts for Milvus"
-summary: Curated prompts to help AI coding assistants write correct, up-to-date Milvus code.
+id: milvus_for_agents.md
+title: Milvus for AI Agents
+summary: Learn how AI agents can use Milvus as a vector database for RAG, semantic search, and long-term memory.
 ---
 
-# AI Prompts
+# Milvus for AI Agents
+
+Milvus provides agent-friendly interfaces that allow AI coding agents and autonomous agent systems to interact with vector databases programmatically. Whether you are building RAG pipelines, semantic search, or agent memory systems, Milvus offers multiple ways for agents to connect and operate.
+
+## Agent tools
+
+<div class="card-wrapper">
+
+<div class="start_card_container">
+  <a href="https://github.com/zilliztech/milvus-skill" style="text-decoration: none; color: inherit;">
+    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Milvus Skill</p>
+    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">An agent skill for Claude Code that teaches LLMs to use PyMilvus for vector database operations.</p>
+  </a>
+</div>
+
+<div class="start_card_container">
+  <a href="https://github.com/zilliztech/mcp-server-milvus" style="text-decoration: none; color: inherit;">
+    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">MCP Server</p>
+    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">Model Context Protocol server that lets any MCP-compatible agent interact with Milvus directly.</p>
+  </a>
+</div>
+
+<div class="start_card_container">
+  <a href="https://github.com/zilliztech/claude-context" style="text-decoration: none; color: inherit;">
+    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Claude Context MCP</p>
+    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">MCP server designed for Claude Code, providing context-aware Milvus documentation access.</p>
+  </a>
+</div>
+
+</div>
+
+<div class="card-wrapper">
+
+<div class="start_card_container">
+  <a href="integrations_overview.md" style="text-decoration: none; color: inherit;">
+    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Agent Frameworks</p>
+    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">Integrations with LangChain, LlamaIndex, OpenAI Agents, and other agent orchestration frameworks.</p>
+  </a>
+</div>
+
+</div>
+
+## AI prompts
 
 Curated prompts that help AI coding assistants write correct Milvus code. Each prompt encodes the rules and patterns that prevent the most common mistakes.
 
-## How to use
+**How to use:**
 
 1. **Copy** a prompt from the "Full prompt" section on any prompt page.
 2. **Save** it to the file your AI tool expects (see [environments table](#use-in-different-environments) below).
 3. Your AI assistant will automatically apply the rules when it generates or reviews Milvus code.
 
-## Prompt pages
+### Prompt pages
 
 <div class="card-wrapper">
 
@@ -66,7 +108,7 @@ Curated prompts that help AI coding assistants write correct Milvus code. Each p
 
 </div>
 
-## Use in different environments
+### Use in different environments
 
 | Environment    | Where to put prompt                            | Instructions                                                                                                            |
 | -------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
@@ -77,3 +119,45 @@ Curated prompts that help AI coding assistants write correct Milvus code. Each p
 | Gemini CLI     | `GEMINI.md`                                    | [Gemini CLI codelab](https://codelabs.developers.google.com/gemini-cli-hands-on)                                        |
 | VS Code        | `.instructions.md`                             | [Configure .instructions.md](https://code.visualstudio.com/docs/copilot/copilot-customization)                          |
 | Windsurf       | `guidelines.md`                                | [Configure guidelines.md](https://docs.windsurf.com/windsurf/customize)                                                 |
+
+## Recommended deployment for agents
+
+Choosing the right Milvus deployment depends on your development stage.
+
+| Stage | Deployment | Why |
+|---|---|---|
+| Prototyping | [Milvus Lite](milvus_lite.md) | Zero-config, in-process. Runs anywhere Python runs — ideal for rapid agent prototyping. |
+| Development | [Milvus Standalone](install_standalone-docker.md) | Single-node Docker deployment. Good for local development and testing with realistic data volumes. |
+| Production | [Zilliz Cloud](https://cloud.zilliz.com/signup) | Fully managed, serverless Milvus. No infrastructure to manage — agents just connect and operate. |
+| Self-hosted production | [Milvus Distributed](install_cluster-helm.md) | Multi-node Kubernetes deployment for teams that need full control over their infrastructure. |
+
+<div class="alert note">
+
+For agent workloads, **Zilliz Cloud** is recommended for production use. Agents typically do not manage infrastructure, so a serverless deployment eliminates operational overhead and provides automatic scaling.
+
+</div>
+
+## Quick connection examples
+
+Connect to Milvus from your agent code:
+
+```python
+from pymilvus import MilvusClient
+
+# Milvus Lite (local, zero-config)
+client = MilvusClient(uri="./milvus_agent.db")
+
+# Milvus Standalone
+client = MilvusClient(uri="http://localhost:19530")
+
+# Zilliz Cloud
+client = MilvusClient(
+    uri="YOUR_ZILLIZ_CLOUD_URI",
+    token="YOUR_ZILLIZ_CLOUD_TOKEN"
+)
+```
+
+## Next steps
+
+- [Quick Start](quickstart.md) — Run your first Milvus search in minutes.
+- [Agent Framework Integrations](integrations_overview.md) — Connect Milvus with LangChain, LlamaIndex, OpenAI Agents, and more.

--- a/site/en/aiTools/python_sdk.md
+++ b/site/en/aiTools/python_sdk.md
@@ -6,7 +6,7 @@ summary: Rules for AI coding assistants to write correct Milvus Python code usin
 
 {{fragments/ai_prompt_howto.md}}
 
-Rules for writing correct Milvus Python code using the MilvusClient interface, including ORM migration, connection patterns, and common operations. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](ai_prompts_landing.md).
+Rules for writing correct Milvus Python code using the MilvusClient interface, including ORM migration, connection patterns, and common operations. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/aiTools/rag_pipeline.md
+++ b/site/en/aiTools/rag_pipeline.md
@@ -6,7 +6,7 @@ summary: Rules for AI coding assistants to build RAG pipelines with Milvus.
 
 {{fragments/ai_prompt_howto.md}}
 
-End-to-end rules for building RAG pipelines with Milvus, including ingestion, chunking, embedding, hybrid retrieval with BM25, and document updates with upsert. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](ai_prompts_landing.md).
+End-to-end rules for building RAG pipelines with Milvus, including ingestion, chunking, embedding, hybrid retrieval with BM25, and document updates with upsert. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/aiTools/schema_design.md
+++ b/site/en/aiTools/schema_design.md
@@ -6,7 +6,7 @@ summary: Rules for AI coding assistants to design correct Milvus collection sche
 
 {{fragments/ai_prompt_howto.md}}
 
-Rules and decision guides for designing correct Milvus collection schemas, including field types, primary keys, BM25 configuration, and schema immutability constraints. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](ai_prompts_landing.md).
+Rules and decision guides for designing correct Milvus collection schemas, including field types, primary keys, BM25 configuration, and schema immutability constraints. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/aiTools/search_patterns.md
+++ b/site/en/aiTools/search_patterns.md
@@ -6,7 +6,7 @@ summary: Rules for AI coding assistants to implement search, hybrid search, and 
 
 {{fragments/ai_prompt_howto.md}}
 
-Rules for implementing similarity search, hybrid search, filtered search, and full-text search in Milvus, including AnnSearchRequest constraints and ranker usage. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](ai_prompts_landing.md).
+Rules for implementing similarity search, hybrid search, filtered search, and full-text search in Milvus, including AnnSearchRequest constraints and ranker usage. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
 
 ## Full prompt
 

--- a/site/en/fragments/ai_prompt_howto.md
+++ b/site/en/fragments/ai_prompt_howto.md
@@ -1,7 +1,7 @@
 ## How to use this prompt
 
 1. **Copy** the full prompt from the [Full prompt](#full-prompt) section below.
-2. **Save** it to the location your AI tool expects — see the [environment table](ai_prompts_landing.md) for placement details.
+2. **Save** it to the location your AI tool expects — see the [environment table](milvus_for_agents.md) for placement details.
 3. Your AI assistant will automatically apply these rules when generating or reviewing Milvus code.
 
 For **Cursor** users: copy the prompt from the [Full prompt](#full-prompt) section and save it under `.cursor/rules/` in your project.

--- a/site/en/getstarted/quickstart.md
+++ b/site/en/getstarted/quickstart.md
@@ -298,3 +298,5 @@ client = MilvusClient(uri="http://localhost:19530", token="root:Milvus")
 ```
 
 Milvus provides REST and gRPC API, with client libraries in languages such as [Python](install-pymilvus.md), [Java](install-java.md), [Go](install-go.md), C# and [Node.js](install-node.md).
+
+If you are using AI coding assistants or building AI agent applications, check out [Milvus for AI Agents](milvus_for_agents.md) to explore agent skills, MCP servers, and curated prompts that help your AI tools write correct Milvus code.

--- a/site/en/home/home.md
+++ b/site/en/home/home.md
@@ -56,6 +56,14 @@ id: home.md
   </p>
 </div>
 
+<div class="start_card_container">
+  <a href="milvus_for_agents.md">
+    <img src="https://milvus-docs.s3.us-west-2.amazonaws.com/assets/home_quick_start.svg" alt="icon" />
+    <p class="link-btn">Milvus for AI Agents</p>
+  </a>
+  <p>Teach your AI agents to use Milvus with skills, prompts, and MCP servers.</p>
+</div>
+
 </div>
 
 ## Recommended articles

--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -647,66 +647,73 @@
     "order": 5,
     "children": [
       {
+        "label": "Milvus for AI Agents",
+        "id": "milvus_for_agents.md",
+        "order": 0,
+        "children": []
+      },
+      {
         "label": "AI Prompts",
         "id": "ai_prompts",
         "isMenu": true,
-        "order": 0,
+        "order": 1,
         "children": [
-          {
-            "label": "Overview",
-            "id": "ai_prompts_landing.md",
-            "order": 0,
-            "children": []
-          },
           {
             "label": "AGENTS.md for Milvus",
             "id": "agents_overview.md",
-            "order": 1,
+            "order": 0,
             "children": []
           },
           {
             "label": "Python SDK",
             "id": "python_sdk.md",
-            "order": 2,
+            "order": 1,
             "children": []
           },
           {
             "label": "Schema Design",
             "id": "schema_design.md",
-            "order": 3,
+            "order": 2,
             "children": []
           },
           {
             "label": "Search Patterns",
             "id": "search_patterns.md",
-            "order": 4,
+            "order": 3,
             "children": []
           },
           {
             "label": "Index Selection",
             "id": "index_selection.md",
-            "order": 5,
+            "order": 4,
             "children": []
           },
           {
             "label": "RAG Pipeline",
             "id": "rag_pipeline.md",
-            "order": 6,
+            "order": 5,
             "children": []
           }
         ]
       },
       {
+        "label": "Milvus Skill",
+        "id": "milvus_skill",
+        "order": 2,
+        "externalLink": "https://github.com/zilliztech/milvus-skill",
+        "children": []
+      },
+      {
         "label": "Milvus MCP Server",
         "id": "mcp_server_milvus",
-        "order": 1,
+        "order": 3,
         "externalLink": "https://github.com/zilliztech/mcp-server-milvus",
         "children": []
       },
       {
         "label": "MCP Server for Claude Code",
         "id": "mcp_claude_context",
-        "order": 2,
+        "order": 4,
         "externalLink": "https://github.com/zilliztech/claude-context",
         "children": []
       }


### PR DESCRIPTION
…section

- Add milvus_for_agents.md as the landing page for AI Tools, covering agent tools, AI prompts, deployment recommendations, and quick start
- Merge ai_prompts_landing.md content into the new landing page to consolidate navigation
- Add "Milvus for AI Agents" card to the docs homepage
- Add Milvus Skill as external link in sidebar menu
- Add AI Tools reference to Quickstart page
- Update all internal links from ai_prompts_landing.md to milvus_for_agents.md