### PR TITLE
fix: improve AI Agents page layout and cross-page visibility

### DIFF
--- a/site/en/aiTools/milvus_for_agents.md
+++ b/site/en/aiTools/milvus_for_agents.md
@@ -33,10 +33,6 @@ Milvus provides agent-friendly interfaces that allow AI coding agents and autono
   </a>
 </div>
 
-</div>
-
-<div class="card-wrapper">
-
 <div class="start_card_container">
   <a href="integrations_overview.md" style="text-decoration: none; color: inherit;">
     <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Agent Frameworks</p>
@@ -136,26 +132,6 @@ Choosing the right Milvus deployment depends on your development stage.
 For agent workloads, **Zilliz Cloud** is recommended for production use. Agents typically do not manage infrastructure, so a serverless deployment eliminates operational overhead and provides automatic scaling.
 
 </div>
-
-## Quick connection examples
-
-Connect to Milvus from your agent code:
-
-```python
-from pymilvus import MilvusClient
-
-# Milvus Lite (local, zero-config)
-client = MilvusClient(uri="./milvus_agent.db")
-
-# Milvus Standalone
-client = MilvusClient(uri="http://localhost:19530")
-
-# Zilliz Cloud
-client = MilvusClient(
-    uri="YOUR_ZILLIZ_CLOUD_URI",
-    token="YOUR_ZILLIZ_CLOUD_TOKEN"
-)
-```
 
 ## Next steps
 

--- a/site/en/getstarted/quickstart.md
+++ b/site/en/getstarted/quickstart.md
@@ -299,4 +299,15 @@ client = MilvusClient(uri="http://localhost:19530", token="root:Milvus")
 
 Milvus provides REST and gRPC API, with client libraries in languages such as [Python](install-pymilvus.md), [Java](install-java.md), [Go](install-go.md), C# and [Node.js](install-node.md).
 
-If you are using AI coding assistants or building AI agent applications, check out [Milvus for AI Agents](milvus_for_agents.md) to explore agent skills, MCP servers, and curated prompts that help your AI tools write correct Milvus code.
+## Milvus for AI Agents
+
+<div class="card-wrapper">
+
+<div class="start_card_container">
+  <a href="milvus_for_agents.md" style="text-decoration: none; color: inherit;">
+    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Milvus for AI Agents</p>
+    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">Using AI coding assistants or building agent applications? Explore agent skills, MCP servers, and curated prompts that help your AI tools write correct Milvus code.</p>
+  </a>
+</div>
+
+</div>

--- a/site/en/home/home.md
+++ b/site/en/home/home.md
@@ -56,14 +56,6 @@ id: home.md
   </p>
 </div>
 
-<div class="start_card_container">
-  <a href="milvus_for_agents.md">
-    <img src="https://milvus-docs.s3.us-west-2.amazonaws.com/assets/home_quick_start.svg" alt="icon" />
-    <p class="link-btn">Milvus for AI Agents</p>
-  </a>
-  <p>Teach your AI agents to use Milvus with skills, prompts, and MCP servers.</p>
-</div>
-
 </div>
 
 ## Recommended articles
@@ -77,7 +69,7 @@ id: home.md
 - [Insert, Upsert, and Delete](insert-update-delete.md)
 - [Index Vector Fields](index-vector-fields.md)
 - [Single-Vector Search](single-vector-search.md)
-- [Get & Scalar Query](get-and-scalar-query.md)
+- [Milvus for AI Agents](milvus_for_agents.md)
 </div>
 
 <div class="recomment-item">


### PR DESCRIPTION
- Merge Agent Frameworks card into same row as other 3 tool cards
- Remove redundant Quick connection examples section
- Replace plain text with card component in quickstart for visibility
- Move AI Agents from Get Started cards to Recommended articles (no unique SVG)