### PR TITLE
docs: improve AI Agents section layout and quickstart page

### DIFF
--- a/site/en/aiTools/agents_overview.md
+++ b/site/en/aiTools/agents_overview.md
@@ -4,11 +4,11 @@ title: "AGENTS.md for Milvus"
 summary: Rules and patterns for AI coding agents that generate, review, or debug Milvus vector database code using PyMilvus.
 ---
 
-{{fragments/ai_prompt_howto.md}}
-
 # AGENTS.md — Milvus
 
 Milvus is an open-source vector database for similarity search, hybrid search, and RAG. You interact with it through the PyMilvus SDK's `MilvusClient` interface. Copy the full prompt below into your AI tool to apply these rules automatically. For detailed task-specific prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/aiTools/index_selection.md
+++ b/site/en/aiTools/index_selection.md
@@ -4,9 +4,11 @@ title: "Prompt: Milvus Index Selection"
 summary: Rules for AI coding assistants to choose and configure Milvus indexes.
 ---
 
-{{fragments/ai_prompt_howto.md}}
+# Index Selection
 
 Decision guides and configuration rules for choosing and tuning Milvus indexes, including AUTOINDEX, HNSW, DiskANN, IVF, and sparse indexes. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/aiTools/milvus_for_agents.md
+++ b/site/en/aiTools/milvus_for_agents.md
@@ -33,13 +33,6 @@ Milvus provides agent-friendly interfaces that allow AI coding agents and autono
   </a>
 </div>
 
-<div class="start_card_container">
-  <a href="integrations_overview.md" style="text-decoration: none; color: inherit;">
-    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Agent Frameworks</p>
-    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">Integrations with LangChain, LlamaIndex, OpenAI Agents, and other agent orchestration frameworks.</p>
-  </a>
-</div>
-
 </div>
 
 ## AI prompts
@@ -132,8 +125,3 @@ Choosing the right Milvus deployment depends on your development stage.
 For agent workloads, **Zilliz Cloud** is recommended for production use. Agents typically do not manage infrastructure, so a serverless deployment eliminates operational overhead and provides automatic scaling.
 
 </div>
-
-## Next steps
-
-- [Quick Start](quickstart.md) — Run your first Milvus search in minutes.
-- [Agent Framework Integrations](integrations_overview.md) — Connect Milvus with LangChain, LlamaIndex, OpenAI Agents, and more.

--- a/site/en/aiTools/python_sdk.md
+++ b/site/en/aiTools/python_sdk.md
@@ -4,9 +4,11 @@ title: "Prompt: Milvus Python SDK"
 summary: Rules for AI coding assistants to write correct Milvus Python code using MilvusClient.
 ---
 
-{{fragments/ai_prompt_howto.md}}
+# Python SDK
 
 Rules for writing correct Milvus Python code using the MilvusClient interface, including ORM migration, connection patterns, and common operations. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/aiTools/rag_pipeline.md
+++ b/site/en/aiTools/rag_pipeline.md
@@ -4,9 +4,11 @@ title: "Prompt: Milvus RAG Pipeline"
 summary: Rules for AI coding assistants to build RAG pipelines with Milvus.
 ---
 
-{{fragments/ai_prompt_howto.md}}
+# RAG Pipeline
 
 End-to-end rules for building RAG pipelines with Milvus, including ingestion, chunking, embedding, hybrid retrieval with BM25, and document updates with upsert. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/aiTools/schema_design.md
+++ b/site/en/aiTools/schema_design.md
@@ -4,9 +4,11 @@ title: "Prompt: Milvus Schema Design"
 summary: Rules for AI coding assistants to design correct Milvus collection schemas.
 ---
 
-{{fragments/ai_prompt_howto.md}}
+# Schema Design
 
 Rules and decision guides for designing correct Milvus collection schemas, including field types, primary keys, BM25 configuration, and schema immutability constraints. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/aiTools/search_patterns.md
+++ b/site/en/aiTools/search_patterns.md
@@ -4,9 +4,11 @@ title: "Prompt: Milvus Search Patterns"
 summary: Rules for AI coding assistants to implement search, hybrid search, and full-text search in Milvus.
 ---
 
-{{fragments/ai_prompt_howto.md}}
+# Search Patterns
 
 Rules for implementing similarity search, hybrid search, filtered search, and full-text search in Milvus, including AnnSearchRequest constraints and ranker usage. Copy the full prompt below into your AI tool to apply these rules automatically. For an overview of all prompts, see [AI Prompts](milvus_for_agents.md).
+
+{{fragments/ai_prompt_howto.md}}
 
 ## Full prompt
 

--- a/site/en/getstarted/quickstart.md
+++ b/site/en/getstarted/quickstart.md
@@ -301,13 +301,6 @@ Milvus provides REST and gRPC API, with client libraries in languages such as [P
 
 ## Milvus for AI Agents
 
-<div class="card-wrapper">
+If you are using AI coding assistants like Claude Code or Cursor, you can install [Milvus Skill](https://github.com/zilliztech/milvus-skill) to help your AI tools write correct Milvus code.
 
-<div class="start_card_container">
-  <a href="milvus_for_agents.md" style="text-decoration: none; color: inherit;">
-    <p class="link-btn" style="font-size: 1rem; white-space: nowrap;">Milvus for AI Agents</p>
-    <p style="font-size: 0.875rem; font-weight: 400; color: #555;">Using AI coding assistants or building agent applications? Explore agent skills, MCP servers, and curated prompts that help your AI tools write correct Milvus code.</p>
-  </a>
-</div>
-
-</div>
+For more agent tools including MCP servers and curated prompts, see [Milvus for AI Agents](milvus_for_agents.md).


### PR DESCRIPTION
- Move fragment includes below H1 headings for consistent page structure
- Add H1 titles to AI prompt pages (index_selection, python_sdk, etc.)
- Simplify quickstart AI Agents section from card wrapper to plain markdown
- Remove redundant next-steps and agent-frameworks card from landing page