### PR TITLE
doc: note that multi-field arithmetic filter expressions are not supported

### DIFF
--- a/site/en/userGuide/search-query-get/boolean/basic-operators.md
+++ b/site/en/userGuide/search-query-get/boolean/basic-operators.md
@@ -168,6 +168,12 @@ To find entities where `price` raised to the power of 2 is greater than 1000:
 filter = 'price ** 2 > 1000'
 ```
 
+<div class="alert note">
+
+Arithmetic operators only support expressions involving a **single field and a constant**. Expressions that combine two fields arithmetically — such as `price * quantity > 100` — are not currently supported and will return an error. If you need to filter on a derived value computed from multiple fields, consider storing the pre-computed value as a separate scalar field at insert time.
+
+</div>
+
 ## Logical Operators
 
 Logical operators are used to combine multiple conditions into a more complex filter expression. These include `AND`, `OR`, and `NOT`.


### PR DESCRIPTION
## Summary

- The arithmetic operators section lists `+`, `-`, `*`, `/`, `%`, `**` with examples, but never mentions that expressions combining **two fields** (e.g. `price * quantity > 100`) are not supported.
- Users attempting this pattern hit a confusing server-side error: `not supported to do arithmetic operations between multiple fields: invalid parameter` (tracked in milvus-io/milvus#39629).
- Add an `alert note` immediately after the arithmetic examples clarifying the single-field-plus-constant constraint and suggesting the pre-computed field workaround.

## Test plan

- [x] Rendered diff looks correct (`<div class="alert note">` pattern matches existing usage throughout the docs)
- [x] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)