### PR TITLE
Deprecate ColPali tutorial and link to new example

### DIFF
--- a/site/en/tutorials/use_ColPali_with_milvus.md
+++ b/site/en/tutorials/use_ColPali_with_milvus.md
@@ -15,6 +15,12 @@ title: Use ColPali for Multi-Modal Retrieval with Milvus
 
 Modern retrieval models typically use a single embedding to represent text or images. ColBERT, however, is a neural model that utilizes a list of embeddings for each data instance and employs a "MaxSim" operation to calculate the similarity between two texts. Beyond textual data, figures, tables, and diagrams also contain rich information, which is often disregarded in text-based information retrieval.
 
+<div class="alert warning">
+
+This page has been deprecated. For the latest example of the use of CoPali with Milvus, refer to [Sesarch with Embedding Lists](search-with-embedding-lists.md).
+
+</div>
+
 ![](../../../assets/colpali_formula.png)
 
 MaxSim function compares a query with a document (what you're searching in) by looking at their token embeddings. For each word in the query, it picks the most similar word from the document (using cosine similarity or squared L2 distance) and sums these maximum similarities across all words in the query


### PR DESCRIPTION
Added deprecation notice for the tutorial page and linked to the updated example.