### PR TITLE
ci: release v3.0.x docs to web-content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: dev
 on:
   push:
     branches:
-      - v2.6.x
+      - v3.0.x
   release:
     types: [released]
   workflow_dispatch:
@@ -20,7 +20,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
         with:
-          ref: v2.6.x
+          ref: v3.0.x
 
       - name: Extract branch name
         shell: bash


### PR DESCRIPTION
## Summary
- Update the docs release workflow to run from the v3.0.x branch.
- Checkout v3.0.x before generating and pushing docs to web-content:master.

## Deployment note
Merging this PR may trigger the v3.0.x push workflow once. That workflow pushes the current v3.0.x docs content to web-content:master.

## Scope
- CI-only change.
- No documentation content changes.
