### PR TITLE
docs: update 3.0 query aggregation docs

### DIFF
--- a/site/en/release_notes.md
+++ b/site/en/release_notes.md
@@ -16,9 +16,7 @@ Release date: May 9, 2026
 | -------------- | ------------------ | ------------------- |
 | 3.0-beta       | 3.0.0              | 3.0.0               |
 
-Milvus v3.0-beta starts Milvus's shift from a vector database to a semantic-native lake engine. The Milvus kernel can now operate directly on data in open lake formats, and core Milvus capabilities have been extended across retrieval, schema, lifecycle, language, and operations.
-
-External Collection and Snapshot are the headline additions on the lake side. The same kernel also powers Zilliz Lakebase, a semantic-native data platform built on Milvus 3.0.
+Milvus 3.0-beta extends the Milvus vector database with new integration into the open lake ecosystem: External Collection lets Milvus query external lake tables zero-copy, and Spark can read Milvus collections directly through Snapshot. The release also brings richer retrieval, more expressive schema, deeper text search customization, finer data and model lifecycle controls, and more operator-side controls. Milvus 3.0 is the core kernel of Zilliz Lakebase, powering its unified serving, discovery, and batch.
 
 ### Key Features
 
@@ -38,12 +36,6 @@ Snapshot creates a point-in-time, read-only view of a Collection by referencing 
 
 For more information, refer to [Snapshots](snapshots.md), [Manage Snapshots](manage-snapshots.md), and [Snapshot Use Cases](snapshot-use-cases.md).
 
-#### External Backfill
-
-Upgrading an embedding model, such as moving from v1 embeddings to v2 embeddings on an existing Collection, used to mean rebuilding from scratch. That forced either service downtime or dual-write logic on the application side.
-
-Milvus 3.0 supports the upgrade as a hot workflow. You can add a new vector field with `AddCollectionField`, use Snapshot to freeze a consistent starting point, run the embedding job offline against the Snapshot, and write the values back through normal ingestion paths. After the new field is indexed online, the application can switch over with no downtime.
-
 #### Query / Search Order By
 
 Search and Query now accept multi-field ordering, with the sort pushed down into the Milvus kernel and `ASC` / `DESC` settable per field. This closes a common production gap: Top-K by distance alone often does not match the business need when the most similar item is not the cheapest, the most recent, or the most popular.
@@ -51,6 +43,12 @@ Search and Query now accept multi-field ordering, with the sort pushed down into
 Applications no longer have to over-fetch results and re-sort on the client to express composite ranking.
 
 For more information, refer to [Sort Search Results by Scalar Fields](single-vector-search.md#Sort-Search-Results-by-Scalar-Fields--Milvus-30x) and [Sort Query Results](get-and-scalar-query.md#Sort-Query-Results--Milvus-30x).
+
+#### Query Aggregation
+
+Producing tenant-distribution stats, field-completeness counts, or version-rollout progress from a Milvus Collection used to require pulling matching entities back to the client and aggregating them there. Milvus 3.0 pushes SQL-style scalar aggregation into the kernel. A query call accepts `group_by_fields` and aggregation expressions in `output_fields`, including `count(*)`, `count(<field>)`, `sum(<field>)`, `avg(<field>)`, `min(<field>)`, and `max(<field>)`. Aggregation is evaluated server-side after filtering.
+
+For more information, refer to [Aggregate Query Results](get-and-scalar-query.md#Aggregate-Query-Results--Milvus-30x).
 
 #### Null Vector
 
@@ -99,3 +97,11 @@ Production workloads accumulate segment fragmentation over time, which causes qu
 Milvus 3.0 adds the ability to trigger segment compaction explicitly during off-peak windows, in both synchronous and asynchronous modes.
 
 For more information, refer to [Force Merge Compaction](force-merge.md).
+
+#### Storage V3
+
+Milvus 3.0 introduces Storage V3, a manifest-based columnar storage engine where data and metadata live on S3-compatible object storage. Each dataset version is captured as an immutable manifest snapshot, an Avro-encoded file that records which column groups, delta logs, and statistics comprise the dataset.
+
+Manifests are compact Avro files, and delta logs record entity-level deletes without rewriting data files. This keeps metadata overhead small as datasets grow. The manifest also decouples metadata tracking from the query path, allowing a Collection to manage more segments without degrading query performance.
+
+Because states are stored on object storage, the dataset is self-descriptive: any reader with access to the storage path can discover and interpret it without a central catalog. This property underpins External Collection, Snapshot, and future lake integrations.

--- a/site/en/userGuide/search-query-get/get-and-scalar-query.md
+++ b/site/en/userGuide/search-query-get/get-and-scalar-query.md
@@ -1,12 +1,12 @@
 ---
 id: get-and-scalar-query.md
 title: "Query"
-summary: "Use Query, Get, and QueryIterator to retrieve entities and filter metadata in Milvus."
+summary: "Use Query, Get, and QueryIterator to retrieve entities, filter metadata, sort query results, and aggregate scalar values in Milvus."
 ---
 
 # Query
 
-In addition to ANN searches, Milvus also supports metadata filtering through queries. This page introduces how to use Query, Get, and QueryIterators to perform metadata filtering.
+In addition to ANN searches, Milvus also supports metadata filtering through queries. This page introduces how to use Query, Get, and QueryIterators to retrieve entities, filter metadata, sort query results, and aggregate scalar values.
 
 <div class="alert note">
 
@@ -57,7 +57,7 @@ A Collection can store various types of scalar fields. You can have Milvus filte
    </tr>
 </table>
 
-For more on metadata filtering, refer to .
+For more on metadata filtering, refer to [Boolean Expression Rules](basic-operators.md).
 
 ## Use Get
 
@@ -439,6 +439,198 @@ page2 = client.query(
     # highlight-next-line
     order_by=["price:asc"],
 )
+```
+
+```java
+// java
+```
+
+```go
+// go
+```
+
+```javascript
+// nodejs
+```
+
+```bash
+# restful
+```
+
+### Aggregate Query Results | Milvus 3.0.x
+
+You can group query results by one or more scalar fields and compute aggregations per group. The supported aggregation operators are `count`, `min`, `max`, `sum`, and `avg`.
+
+When using `group_by_fields`, note that:
+
+- Supported field types for `group_by_fields`: `INT8`, `INT16`, `INT32`, `INT64`, `VARCHAR`, and `TIMESTAMPTZ`. Grouping by `FLOAT`, `DOUBLE`, vector, `JSON`, or `ARRAY` fields returns an error.
+
+- `sum` and `avg` are numeric only. You can apply them to numeric fields, including `FLOAT` and `DOUBLE`, but applying them to a `VARCHAR` field returns an error.
+
+To enable aggregation, pass `group_by_fields` to `query()` and add aggregation expressions (`count(*)`, `count(<field>)`, `min(<field>)`, `max(<field>)`, `sum(<field>)`, `avg(<field>)`) to `output_fields`.
+
+The following example groups entities by the `color` field and returns the number of entities in each color group:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#go">Go</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+res = client.query(
+    collection_name="my_collection",
+    filter="",
+    # highlight-start
+    group_by_fields=["color"],
+    output_fields=["color", "count(*)"],
+    # highlight-end
+)
+
+# [{'color': 'red',    'count(*)': 10},
+#  {'color': 'orange', 'count(*)': 10},
+#  {'color': 'yellow', 'count(*)': 10},
+#  {'color': 'green',  'count(*)': 10},
+#  {'color': 'blue',   'count(*)': 10}]
+```
+
+```java
+// java
+```
+
+```go
+// go
+```
+
+```javascript
+// nodejs
+```
+
+```bash
+# restful
+```
+
+You can request several aggregation expressions in a single call. The following example groups by `color` and returns the entity count, average price, and maximum rating for each group:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#go">Go</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+res = client.query(
+    collection_name="my_collection",
+    filter="",
+    # highlight-start
+    group_by_fields=["color"],
+    output_fields=["color", "count(*)", "avg(price)", "max(rating)"],
+    # highlight-end
+)
+
+# [{'color': 'red',    'count(*)': 10, 'avg(price)': 65.22, 'max(rating)': 5},
+#  {'color': 'orange', 'count(*)': 10, 'avg(price)': 48.67, 'max(rating)': 5},
+#  {'color': 'yellow', 'count(*)': 10, 'avg(price)': 64.15, 'max(rating)': 3},
+#  {'color': 'green',  'count(*)': 10, 'avg(price)': 58.28, 'max(rating)': 5},
+#  {'color': 'blue',   'count(*)': 10, 'avg(price)': 50.20, 'max(rating)': 5}]
+```
+
+```java
+// java
+```
+
+```go
+// go
+```
+
+```javascript
+// nodejs
+```
+
+```bash
+# restful
+```
+
+Pass more than one field to `group_by_fields` to compute composite groups. The following example groups by `(color, rating)` and computes the price range in each group:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#go">Go</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+res = client.query(
+    collection_name="my_collection",
+    filter="",
+    # highlight-start
+    group_by_fields=["color", "rating"],
+    output_fields=["color", "rating", "min(price)", "max(price)"],
+    # highlight-end
+)
+
+# [{'color': 'red',    'rating': 5, 'min(price)': 34.51, 'max(price)': 70.90},
+#  {'color': 'orange', 'rating': 2, 'min(price)': 12.39, 'max(price)': 81.99},
+#  {'color': 'yellow', 'rating': 2, 'min(price)': 22.62, 'max(price)': 88.24},
+#  {'color': 'green',  'rating': 1, 'min(price)': 18.35, 'max(price)': 59.53},
+#  {'color': 'blue',   'rating': 4, 'min(price)': 21.23, 'max(price)': 82.45},
+#  ...]
+```
+
+```java
+// java
+```
+
+```go
+// go
+```
+
+```javascript
+// nodejs
+```
+
+```bash
+# restful
+```
+
+You can also combine `group_by_fields` with `limit` to cap how many groups come back. This is useful when a field has high cardinality and you only need a sample of groups:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#go">Go</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+res = client.query(
+    collection_name="my_collection",
+    filter="",
+    group_by_fields=["color"],
+    output_fields=["color", "avg(price)", "count(*)"],
+    # highlight-next-line
+    limit=5,
+)
+
+# [{'color': 'red',    'avg(price)': 65.22, 'count(*)': 10},
+#  {'color': 'orange', 'avg(price)': 48.67, 'count(*)': 10},
+#  {'color': 'yellow', 'avg(price)': 64.15, 'count(*)': 10},
+#  {'color': 'green',  'avg(price)': 58.28, 'count(*)': 10},
+#  {'color': 'blue',   'avg(price)': 50.20, 'count(*)': 10}]
 ```
 
 ```java


### PR DESCRIPTION
## What changed
- Add Query Aggregation to the Milvus 3.0 beta release notes.
- Remove External Backfill from the 3.0 beta release notes.
- Add the Aggregate Query Results section to the Query guide.
- Clarify that FLOAT and DOUBLE cannot be used as group_by_fields, but can be used as numeric aggregation targets.
- Add Storage V3 to the 3.0 beta release notes.

## Verification
- node check-link.js
- git diff --check