### PR TITLE
docs: add REST request timeout examples

### DIFF
--- a/site/en/adminGuide/drop_users_roles.md
+++ b/site/en/adminGuide/drop_users_roles.md
@@ -104,6 +104,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "userName": "user_1"
 }'
@@ -150,6 +151,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 
@@ -213,6 +215,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a"
 }'
@@ -257,6 +260,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 

--- a/site/en/adminGuide/grant_privileges.md
+++ b/site/en/adminGuide/grant_privileges.md
@@ -528,6 +528,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/grant_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "Search",
@@ -539,6 +540,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/grant_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "privilege_group_1",
@@ -550,6 +552,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/grant_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "ClusterReadOnly",
@@ -607,6 +610,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a"
 }'
@@ -741,6 +745,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/revoke_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "Search",
@@ -752,6 +757,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/revoke_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "Search",
@@ -763,6 +769,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/revoke_privilege_v2" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "privilege": "ClusterReadOnly",

--- a/site/en/adminGuide/grant_roles.md
+++ b/site/en/adminGuide/grant_roles.md
@@ -104,6 +104,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/grant_role" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a",
     "userName": "user_1"
@@ -157,6 +158,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "userName": "user_1"
 }'
@@ -220,6 +222,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/revoke_role" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "userName": "user_1",
     "roleName": "role_a"

--- a/site/en/adminGuide/privilege_group.md
+++ b/site/en/adminGuide/privilege_group.md
@@ -477,6 +477,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/privilege_groups/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "privilegeGroupName":"privilege_group_1"
 }'
@@ -532,6 +533,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/privilege_groups/add_privileges_to_group" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "privilegeGroupName":"privilege_group_1",
     "privileges":["Query", "Search"]
@@ -586,6 +588,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/privilege_groups/remove_privileges_from_group" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "privilegeGroupName":"privilege_group_1",
     "privileges":["Search"]
@@ -638,6 +641,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/privilege_groups/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 
@@ -691,6 +695,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/privilege_groups/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "privilegeGroupName":"privilege_group_1"
 }'

--- a/site/en/adminGuide/tls.md
+++ b/site/en/adminGuide/tls.md
@@ -473,11 +473,17 @@ For RESTful APIs, you can check tls by using the `curl` command.
 ### One-way TLS connection
 
 ```bash
-curl --cacert path_to/ca.pem https://localhost:8080/v2/vectordb/collections/list
+curl --cacert path_to/ca.pem \
+  -H "Request-Timeout: 10" \
+  https://localhost:8080/v2/vectordb/collections/list
 ```
 
 ### Two-way TLS connection
 
 ```bash
-curl --cert path_to/client.pem --key path_to/client.key --cacert path_to/ca.pem https://localhost:8080/v2/vectordb/collections/list
+curl --cert path_to/client.pem \
+  --key path_to/client.key \
+  --cacert path_to/ca.pem \
+  -H "Request-Timeout: 10" \
+  https://localhost:8080/v2/vectordb/collections/list
 ```

--- a/site/en/adminGuide/users_and_roles.md
+++ b/site/en/adminGuide/users_and_roles.md
@@ -110,6 +110,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "userName": "user_1",
     "password": "P@ssw0rd"
@@ -178,6 +179,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/update_password" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "newPassword": "P@ssw0rd!",
     "userName": "user_1",
@@ -224,6 +226,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/users/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 
@@ -287,6 +290,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "roleName": "role_a"
 }'
@@ -333,6 +337,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/roles/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 

--- a/site/en/getstarted/connect-to-milvus-server.md
+++ b/site/en/getstarted/connect-to-milvus-server.md
@@ -68,6 +68,7 @@ export HOST="localhost:19530"
 
 curl -X POST "http://${HOST}/v2/vectordb/collections/list" \
     -H "Content-Type: application/json" \
+    -H "Request-Timeout: 10" \
     -d '{}'
 ```
 
@@ -139,6 +140,7 @@ export TOKEN="root:Milvus"
 curl -X POST "http://${HOST}/v2/vectordb/collections/list" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
+    -H "Request-Timeout: 10" \
     -d '{}'
 ```
 
@@ -210,7 +212,7 @@ export TOKEN="root:Milvus"
 curl -X POST "http://${HOST}/v2/vectordb/collections/list" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
-    -H "Request-Timeout: 5" \
+    -H "Request-Timeout: 10" \
     --max-time 7 \
     -d '{}'
 ```
@@ -299,6 +301,7 @@ export TOKEN="root:Milvus"
 curl -X POST "http://${HOST}/v2/vectordb/collections/list" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
+    -H "Request-Timeout: 10" \
     -d '{
       "dbName": "analytics"
     }'

--- a/site/en/reference/tune_consistency.md
+++ b/site/en/reference/tune_consistency.md
@@ -128,6 +128,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -190,6 +191,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [
@@ -254,6 +256,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "color like \"red_%\"",

--- a/site/en/userGuide/collections/create-an-external-collection.md
+++ b/site/en/userGuide/collections/create-an-external-collection.md
@@ -552,6 +552,7 @@ curl --request POST \
 --url "${PROJECT_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"dbName\": \"my_database\",
     \"collectionName\": \"test_collection\",
@@ -671,6 +672,7 @@ curl --request POST \
 --url "${PROJECT_ENDPOINT}/v2/vectordb/indexes/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"dbName\": \"my_database\",
     \"collectionName\": \"test_collection\",
@@ -763,6 +765,7 @@ curl --request POST \
 --url "${PROJECT_ENDPOINT}/v2/vectordb/jobs/external_collection/refresh" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"dbName\": \"my_database\",
     \"collectionName\": \"test_collection\",

--- a/site/en/userGuide/collections/create-collection.md
+++ b/site/en/userGuide/collections/create-collection.md
@@ -396,6 +396,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_1\",
     \"schema\": $schema,
@@ -505,6 +506,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_2\",
     \"schema\": $schema
@@ -514,6 +516,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/get_load_state" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_2\"
 }"
@@ -592,6 +595,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_3\",
     \"schema\": $schema,
@@ -666,6 +670,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_5\",
     \"schema\": $schema,
@@ -747,6 +752,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_5\",
     \"schema\": $schema,
@@ -823,6 +829,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"customized_setup_6\",
     \"schema\": $schema,

--- a/site/en/userGuide/collections/drop-collection.md
+++ b/site/en/userGuide/collections/drop-collection.md
@@ -116,6 +116,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'

--- a/site/en/userGuide/collections/load-and-release.md
+++ b/site/en/userGuide/collections/load-and-release.md
@@ -164,6 +164,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/load" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -177,6 +178,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/get_load_state" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -399,6 +401,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/release" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -412,6 +415,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/get_load_state" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'

--- a/site/en/userGuide/collections/manage-aliases.md
+++ b/site/en/userGuide/collections/manage-aliases.md
@@ -169,6 +169,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "bob",
     "collectionName": "my_collection_1"
@@ -183,6 +184,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "alice",
     "collectionName": "my_collection_1"
@@ -274,6 +276,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 
 # {
@@ -375,6 +378,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "bob"
 }'
@@ -540,6 +544,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/alter" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "alice",
     "collectionName": "my_collection_2"
@@ -554,6 +559,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "alice"
 }'
@@ -571,6 +577,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "bob"
 }'
@@ -672,6 +679,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "bob"
 }'
@@ -685,6 +693,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/aliases/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "aliasName": "alice"
 }'

--- a/site/en/userGuide/collections/manage-partitions.md
+++ b/site/en/userGuide/collections/manage-partitions.md
@@ -139,6 +139,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -252,6 +253,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionName": "partitionA"
@@ -266,6 +268,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -352,6 +355,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/has" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionName": "partitionA"
@@ -471,6 +475,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/load" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"]
@@ -485,6 +490,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/get_load_state" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"]
@@ -595,6 +601,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/release" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"]
@@ -609,6 +616,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/get_load_state" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"]
@@ -756,6 +764,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/release" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"]
@@ -770,6 +779,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionName": "partitionA"
@@ -784,6 +794,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/partitions/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'

--- a/site/en/userGuide/collections/modify-collection.md
+++ b/site/en/userGuide/collections/modify-collection.md
@@ -110,6 +110,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/rename" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "newCollectionName": "my_new_collection"
@@ -217,6 +218,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/alter_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "properties": {
@@ -316,6 +318,7 @@ if err != nil {
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/alter_properties" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -d '{
     "collectionName": "my_collection",
     "properties": {
@@ -375,6 +378,7 @@ if err != nil {
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/alter_properties" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "my_collection",
@@ -435,6 +439,7 @@ if err != nil {
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/alter_properties" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "my_collection",
@@ -497,6 +502,7 @@ if err != nil {
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/alter_properties" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "my_collection",
@@ -555,6 +561,7 @@ if err != nil {
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/alter_properties" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "my_collection",
@@ -612,6 +619,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/drop_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "propertyKeys": [

--- a/site/en/userGuide/collections/set-collection-ttl.md
+++ b/site/en/userGuide/collections/set-collection-ttl.md
@@ -239,6 +239,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -341,6 +342,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/alter_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"properties\": {
@@ -419,6 +421,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/drop_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"propertyKeys\": [

--- a/site/en/userGuide/collections/view-collections.md
+++ b/site/en/userGuide/collections/view-collections.md
@@ -98,6 +98,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/list" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{}'
 ```
 
@@ -161,6 +162,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup"
 }'

--- a/site/en/userGuide/data-import/import-data.md
+++ b/site/en/userGuide/data-import/import-data.md
@@ -90,6 +90,7 @@ export MILVUS_URI="localhost:19530"
 
 curl --request POST "http://${MILVUS_URI}/v2/vectordb/jobs/import/create" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data-raw '{
     "files": [
         [
@@ -211,6 +212,7 @@ export MILVUS_URI="localhost:19530"
 
 curl --request POST "http://${MILVUS_URI}/v2/vectordb/jobs/import/describe" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data-raw '{
     "jobId": "449839014328146739"
 }'
@@ -296,6 +298,7 @@ export MILVUS_URI="localhost:19530"
 
 curl --request POST "http://${MILVUS_URI}/v2/vectordb/jobs/import/list" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data-raw '{
     "collectionName": "quick_setup"
 }'

--- a/site/en/userGuide/embeddings-reranking/embedding-function/bm25-function.md
+++ b/site/en/userGuide/embeddings-reranking/embedding-function/bm25-function.md
@@ -511,6 +511,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -570,6 +571,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"text": "information retrieval is a field of study."},
@@ -659,6 +661,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data-raw '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/insert-and-delete/delete-entities.md
+++ b/site/en/userGuide/insert-and-delete/delete-entities.md
@@ -118,6 +118,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/delete" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "filter": "color in [\"red_7025\", \"purple_4976\"]"
@@ -194,6 +195,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/delete" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "filter": "id in [18, 19]"
@@ -274,6 +276,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/delete" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "partitionName": "partitionA",

--- a/site/en/userGuide/insert-and-delete/insert-update-delete.md
+++ b/site/en/userGuide/insert-and-delete/insert-update-delete.md
@@ -203,6 +203,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"id": 0, "vector": [0.3580376395471989, -0.6023495712049978, 0.18414012509913835, -0.26286205330961354, 0.9029438446296592], "color": "pink_8682"},
@@ -383,6 +384,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"id": 10, "vector": [0.3580376395471989, -0.6023495712049978, 0.18414012509913835, -0.26286205330961354, 0.9029438446296592], "color": "pink_8682"},

--- a/site/en/userGuide/insert-and-delete/upsert-entities.md
+++ b/site/en/userGuide/insert-and-delete/upsert-entities.md
@@ -246,6 +246,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/upsert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"id": 0, "vector": [0.3580376395471989, -0.6023495712049978, 0.18414012509913835, -0.26286205330961354, 0.9029438446296592], "title": "Artificial Intelligence in Real Life", "issue": "vol.12"},
@@ -397,6 +398,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/upsert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"id": 10, "vector": [0.06998888224297328, 0.8582816610326578, -0.9657938677934292, 0.6527905683627726, -0.8668460657158576], "title": "Layour Design Reference", "issue": "vol.34"},
@@ -547,6 +549,7 @@ export UPSERT_DATA='[
 
 curl -X POST "http://localhost:19530/v2/vectordb/entities/upsert" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",

--- a/site/en/userGuide/manage_databases.md
+++ b/site/en/userGuide/manage_databases.md
@@ -90,6 +90,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "my_database_1"
 }'
@@ -148,6 +149,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "my_database_2",
     "properties": {
@@ -223,6 +225,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/describe" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "default"
 }'
@@ -328,6 +331,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/alter" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "my_database",
     "properties": {
@@ -386,6 +390,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/alter" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "my_database",
     "propertyKeys": [
@@ -491,6 +496,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/databases/drop" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "dbName": "my_database"
 }'

--- a/site/en/userGuide/schema/add-fields-to-an-existing-collection.md
+++ b/site/en/userGuide/schema/add-fields-to-an-existing-collection.md
@@ -144,6 +144,7 @@ await client.addCollectionField({
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/fields/add" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "product_catalog",
@@ -265,6 +266,7 @@ await client.addCollectionField({
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/fields/add" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "product_catalog",
@@ -381,6 +383,7 @@ await client.addCollectionField({
 # ❌ This is NOT supported
 curl -X POST "http://localhost:19530/v2/vectordb/collections/fields/add" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer <token>" \
   -d '{
     "collectionName": "existing_collection",
@@ -530,6 +533,7 @@ export COLLECTION_NAME="product_catalog"
 echo "Step 1: Insert initial data with dynamic fields..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/insert" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",
@@ -544,6 +548,7 @@ curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/insert" \
 echo -e "\n\nStep 2: Add static field with same name as dynamic field..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/collections/fields/add" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",
@@ -557,6 +562,7 @@ curl -X POST "http://${MILVUS_HOST}/v2/vectordb/collections/fields/add" \
 echo -e "\n\nStep 3: Insert new data after adding static field..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/insert" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",
@@ -668,6 +674,7 @@ export COLLECTION_NAME="product_catalog"
 echo "Query 1: Static field only (dynamic field masked)..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/query" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",
@@ -678,6 +685,7 @@ curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/query" \
 echo -e "\n\nQuery 2: Both static and original dynamic values..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/query" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",
@@ -688,6 +696,7 @@ curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/query" \
 echo -e "\n\nQuery 3: New entity with static field value..."
 curl -X POST "http://${MILVUS_HOST}/v2/vectordb/entities/query" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -d "{
     \"collectionName\": \"${COLLECTION_NAME}\",

--- a/site/en/userGuide/schema/analyzer/multi-language-analyzers.md
+++ b/site/en/userGuide/schema/analyzer/multi-language-analyzers.md
@@ -649,6 +649,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"multilingual_documents\",
   \"schema\": $schema,
@@ -797,6 +798,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data '{
   "collectionName": "multilingual_documents",
   "data": [
@@ -968,6 +970,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data '{
   "collectionName": "multilingual_documents",
   "data": ["artificial intelligence"],
@@ -1097,6 +1100,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data '{
   "collectionName": "multilingual_documents",
   "data": ["人工智能"],

--- a/site/en/userGuide/schema/array-of-structs.md
+++ b/site/en/userGuide/schema/array-of-structs.md
@@ -588,6 +588,7 @@ await milvusClient.createCollection({
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/collections/create" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -d "{
     \"collectionName\": \"my_collection\",
     \"description\": \"A collection for storing book information with struct array chunks\",
@@ -707,6 +708,7 @@ await milvusClient.insert({
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/entities/insert" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -d '{
     "collectionName": "my_collection",
     "data": [
@@ -913,6 +915,7 @@ embeddingList1='[[0.2,0.9,0.4,-0.3,0.2]]'
 embeddingList2='[[-0.2,-0.2,0.5,0.6,0.9],[-0.4,0.3,0.5,0.8,0.2]]'
 curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -d "{
     \"collectionName\": \"my_collection\",
     \"data\": [$embeddingList1],
@@ -1041,6 +1044,7 @@ const results2 = await milvusClient.search({
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -d "{
     \"collectionName\": \"my_collection\",
     \"data\": [$embeddingList1, $embeddingList2],

--- a/site/en/userGuide/schema/array_data_type.md
+++ b/site/en/userGuide/schema/array_data_type.md
@@ -379,6 +379,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -499,6 +500,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {
@@ -603,6 +605,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "tags IS NOT NULL",
@@ -697,6 +700,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
   "collectionName": "my_collection",
   "filter": "ratings[0] > 4",
@@ -800,6 +804,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/schema/binary-vector.md
+++ b/site/en/userGuide/schema/binary-vector.md
@@ -315,6 +315,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -431,6 +432,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"data\": $data,
     \"collectionName\": \"my_collection\"
@@ -548,6 +550,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"data\": $data,

--- a/site/en/userGuide/schema/dense-vector.md
+++ b/site/en/userGuide/schema/dense-vector.md
@@ -352,6 +352,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -430,6 +431,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"dense_vector": [0.1, 0.2, 0.3, 0.4]},
@@ -542,6 +544,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/schema/enable-dynamic-field.md
+++ b/site/en/userGuide/schema/enable-dynamic-field.md
@@ -250,6 +250,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"my_collection\",
   \"schema\": $schema
@@ -370,6 +371,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data '{
   "data": [
     {
@@ -806,6 +808,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/indexes/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"my_collection\",
   \"indexParams\": $indexParams
@@ -980,6 +983,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"my_collection\",
   \"data\": [

--- a/site/en/userGuide/schema/nullable-and-default.md
+++ b/site/en/userGuide/schema/nullable-and-default.md
@@ -209,6 +209,7 @@ curl --request POST \
   --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
   --header "Authorization: Bearer ${TOKEN}" \
   --header "Content-Type: application/json" \
+  --header "Request-Timeout: 10" \
   -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": {
@@ -375,6 +376,7 @@ curl --request POST \
   --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
   --header "Authorization: Bearer ${TOKEN}" \
   --header "Content-Type: application/json" \
+  --header "Request-Timeout: 10" \
   -d '{
     "collectionName": "my_collection",
     "data": [
@@ -500,6 +502,7 @@ curl --request POST \
   --url "${CLUSTER_ENDPOINT}/v2/vectordb/indexes/create" \
   --header "Authorization: Bearer ${TOKEN}" \
   --header "Content-Type: application/json" \
+  --header "Request-Timeout: 10" \
   -d '{
     "collectionName": "my_collection",
     "indexParams": [
@@ -515,6 +518,7 @@ curl --request POST \
   --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/load" \
   --header "Authorization: Bearer ${TOKEN}" \
   --header "Content-Type: application/json" \
+  --header "Request-Timeout: 10" \
   -d '{"collectionName": "my_collection"}'
 ```
 
@@ -623,6 +627,7 @@ curl --request POST \
   --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
   --header "Authorization: Bearer ${TOKEN}" \
   --header "Content-Type: application/json" \
+  --header "Request-Timeout: 10" \
   -d '{
     "collectionName": "my_collection",
     "data": [[0.1, 0.2, 0.3, 0.4]],

--- a/site/en/userGuide/schema/number.md
+++ b/site/en/userGuide/schema/number.md
@@ -389,6 +389,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -492,6 +493,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"age": 25, "price": 99.99, "pk": 1, "embedding": [0.1, 0.2, 0.3]},
@@ -582,6 +584,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "age > 30",
@@ -679,6 +682,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
   "collectionName": "my_collection",
   "filter": "price is null",
@@ -770,6 +774,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
   "collectionName": "my_collection",
   "filter": "age == 18",
@@ -879,6 +884,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/schema/primary-field.md
+++ b/site/en/userGuide/schema/primary-field.md
@@ -229,6 +229,7 @@ export SCHEMA='{
 
 curl -X POST 'http://localhost:19530/v2/vectordb/collections/create' \
 -H 'Content-Type: application/json' \
+-H 'Request-Timeout: 10' \
 -d "{
     \"collectionName\": \"demo_autoid\",
     \"schema\": $SCHEMA
@@ -317,6 +318,7 @@ export INSERT_DATA='[
 
 curl -X POST 'http://localhost:19530/v2/vectordb/entities/insert' \
 -H 'Content-Type: application/json' \
+-H 'Request-Timeout: 10' \
 -d "{
     \"collectionName\": \"demo_autoid\",
     \"data\": $INSERT_DATA
@@ -487,6 +489,7 @@ export SCHEMA='{
 
 curl -X POST 'http://localhost:19530/v2/vectordb/collections/create' \
 -H 'Content-Type: application/json' \
+-H 'Request-Timeout: 10' \
 -d "{
     \"collectionName\": \"demo_manual_ids\",
     \"schema\": $SCHEMA
@@ -582,6 +585,7 @@ export INSERT_DATA='[
 # 插入数据
 curl -X POST 'http://localhost:19530/v2/vectordb/entities/insert' \
 -H 'Content-Type: application/json' \
+-H 'Request-Timeout: 10' \
 -d "{
     \"collectionName\": \"demo_manual_ids\",
     \"data\": $INSERT_DATA

--- a/site/en/userGuide/schema/sparse_vector.md
+++ b/site/en/userGuide/schema/sparse_vector.md
@@ -394,6 +394,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -523,6 +524,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {
@@ -696,6 +698,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": $queryData,

--- a/site/en/userGuide/schema/string.md
+++ b/site/en/userGuide/schema/string.md
@@ -387,6 +387,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -509,6 +510,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data '{
     "data": [
         {"varchar_field1": "Product A", "varchar_field2": "High quality product", "pk": 1, "embedding": [0.1, 0.2, 0.3]},
@@ -606,6 +608,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "varchar_field1 == \"Product A\"",
@@ -692,6 +695,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "varchar_field2 is null",
@@ -776,6 +780,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "varchar_field1 == \"Unknown\"",
@@ -884,6 +889,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/schema/use-json-fields.md
+++ b/site/en/userGuide/schema/use-json-fields.md
@@ -232,6 +232,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"product_catalog\",
   \"schema\": $schema
@@ -413,6 +414,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/product_catalog/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"data\": $entities
 }"
@@ -953,6 +955,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/indexes/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
   \"collectionName\": \"product_catalog\",
   \"indexParams\": $indexParams

--- a/site/en/userGuide/search-query-get/filtered-search.md
+++ b/site/en/userGuide/search-query-get/filtered-search.md
@@ -215,6 +215,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [
@@ -413,6 +414,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/search-query-get/full-text-search.md
+++ b/site/en/userGuide/search-query-get/full-text-search.md
@@ -512,6 +512,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -577,6 +578,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"text": "information retrieval is a field of study."},
@@ -674,6 +676,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data-raw '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/search-query-get/get-and-scalar-query.md
+++ b/site/en/userGuide/search-query-get/get-and-scalar-query.md
@@ -196,6 +196,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/get" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "id": [0, 1, 2],
@@ -297,6 +298,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": "color like \"red%\"",
@@ -893,6 +895,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/get" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"],
@@ -905,6 +908,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/get" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "partitionNames": ["partitionA"],

--- a/site/en/userGuide/search-query-get/grouping-search.md
+++ b/site/en/userGuide/search-query-get/grouping-search.md
@@ -199,6 +199,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [
@@ -345,6 +346,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/search-query-get/keyword-match.md
+++ b/site/en/userGuide/search-query-get/keyword-match.md
@@ -481,6 +481,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "annsField": "embeddings",
@@ -568,6 +569,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "filter": '"$filter"',

--- a/site/en/userGuide/search-query-get/mmap.md
+++ b/site/en/userGuide/search-query-get/mmap.md
@@ -267,6 +267,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema
@@ -276,6 +277,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/fields/alter_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "fieldName": "doc_chunk",
@@ -388,6 +390,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/indexes/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "indexParams": [
@@ -405,6 +408,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/indexes/alter_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "indexName": "doc_chunk",
@@ -471,6 +475,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 --data "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -557,6 +562,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/release" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'
@@ -565,6 +571,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/alter_properties" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "properties": {
@@ -576,6 +583,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/load" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection"
 }'

--- a/site/en/userGuide/search-query-get/multi-vector-search.md
+++ b/site/en/userGuide/search-query-get/multi-vector-search.md
@@ -493,6 +493,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -636,6 +637,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "data": [
         {"id": 0, "text": "Red cotton t-shirt with round neck" , "text_dense": [0.3580376395471989, -0.6023495712049978, 0.18414012509913835, ...], "image_dense": [0.6366019600530924, -0.09323198122475052, ...]},
@@ -976,6 +978,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/hybrid_search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"search\": ${req},

--- a/site/en/userGuide/search-query-get/range-search.md
+++ b/site/en/userGuide/search-query-get/range-search.md
@@ -216,6 +216,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "my_collection",
     "data": [

--- a/site/en/userGuide/search-query-get/single-vector-search.md
+++ b/site/en/userGuide/search-query-get/single-vector-search.md
@@ -215,6 +215,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "data": [
@@ -452,6 +453,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "data": [
@@ -542,6 +544,7 @@ for hits in res:
 # restful
 curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
   -H "Content-Type: application/json" \
+  -H "Request-Timeout: 10" \
   -H "Authorization: Bearer root:Milvus" \
   -d '{
     "collectionName": "quick_setup",
@@ -685,6 +688,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "partitionNames": ["partitionA"],
@@ -850,6 +854,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "data": [
@@ -1108,6 +1113,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d '{
     "collectionName": "quick_setup",
     "data": [
@@ -1165,6 +1171,7 @@ export QUERY_VECTOR='[0.1, 0.2, 0.3, 0.4]'
 
 curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
 -H "Content-Type: application/json" \
+-H "Request-Timeout: 10" \
 -d '{
   "collectionName": "quick_setup",
   "annsField": "vector",

--- a/site/en/userGuide/search-query-get/use-partition-key.md
+++ b/site/en/userGuide/search-query-get/use-partition-key.md
@@ -273,6 +273,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,
@@ -424,6 +425,7 @@ curl --request POST \
 --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" \
 --header "Authorization: Bearer ${TOKEN}" \
 --header "Content-Type: application/json" \
+--header "Request-Timeout: 10" \
 -d "{
     \"collectionName\": \"my_collection\",
     \"schema\": $schema,


### PR DESCRIPTION
## What changed

Added `Request-Timeout: 10` to Milvus RESTful cURL examples on the `v3.0.x` docs branch.

This covers RESTful examples under `site/en` that call `/v2/vectordb/...`, including user guides, admin guides, reference docs, and TLS examples.

## Why

`Request-Timeout` is the RESTful per-request timeout parameter. Adding it to examples makes timeout behavior visible and consistent across RESTful documentation.

## Verification

- Ran a Manta in-cluster smoke test against the temporary Milvus instance:
  - endpoint: `array-op-doc-verify-milvus.manta-user-leryn-li-f5e8de.svc.cluster.local:19530`
  - request: `POST /v2/vectordb/collections/list`
  - headers included `Request-Timeout: 10`
  - response: `{"code":0,"data":[]}`
  - Manta job: `2dea17e8-7143-43d8-ae09-484ed8463703`

- Local checks on `v3.0.x` branch:
  - `request_timeout_5_files=0`
  - `missing_rest_curl_timeout_10=0`
  - `git diff --check`
  - `node check-link.js`