### PR TITLE
docs: fix MinIO host ports and stop/delete command on the Windows install page

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-windows.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-windows.md
@@ -109,7 +109,7 @@ If you prefer to start Milvus using Linux commands and shell scripts on Windows,
     Stop successfully.​
     ​
     # Delete Milvus data​
-    $ bash standalone_embed.sh stop​
+    $ bash standalone_embed.sh delete​
     Delete Milvus container successfully.​
     Delete successfully.​
 
@@ -141,7 +141,7 @@ Once you have installed Docker Desktop on Microsoft Windows, you can access the 
 
     - The **milvus-etcd** container does not expose any ports to the host and maps its data to **volumes/etcd** in the current folder.​
 
-    - The **milvus-minio** container serves ports **9090** and **9091** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.​
+    - The **milvus-minio** container serves ports **9000** and **9001** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.​
 
     - The **milvus-standalone** container serves ports **19530** locally with the default settings and maps its data to **volumes/milvus** in the current folder.​
 


### PR DESCRIPTION
Two small fixes on the **Run Milvus in Docker (Windows)** page:

1. **MinIO host ports** — the `milvus-minio` container serves host ports **9000** and **9001**, not `9090`/`9091`.
2. **Delete step** — under *From WSL 2 → Delete Milvus data*, the command was `standalone_embed.sh stop` but should be `standalone_embed.sh delete` (its output already reads "Delete ... successfully").

🤖 Generated with [Claude Code](https://claude.com/claude-code)