### PR TITLE
docs: correct the standalone Docker container name to milvus-standalone

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-docker.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-docker.md
@@ -46,7 +46,7 @@ If you encounter any issues pulling the image, contact us at <a href="mailto:com
 
 After running the installation script:
 
-- A docker container named milvus has been started at port **19530**.
+- A docker container named milvus-standalone has been started at port **19530**.
 - An embed etcd is installed along with Milvus in the same container and serves at port **2379**. Its configuration file is mapped to **embedEtcd.yaml** in the current folder.
 - To change the default Milvus configuration, add your settings to the **user.yaml** file in the current folder and then restart the service.
 - The Milvus data volume is mapped to **volumes/milvus** in the current folder.


### PR DESCRIPTION
On the **Run Milvus in Docker** page, `standalone_embed.sh` starts a container named **milvus-standalone** (consistent with the later stop/delete steps and the Windows page), but the post-install note said it was named `milvus`. This fixes that single reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)