### PR TITLE
docs: fix MinIO host ports and use Docker Compose V2 ps on the Compose page

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
@@ -50,19 +50,18 @@ After starting up Milvus,
 
 - Containers named **milvus-standalone**, **milvus-minio**, and **milvus-etcd** are up.
   - The **milvus-etcd** container does not expose any ports to the host and maps its data to **volumes/etcd** in the current folder.
-  - The **milvus-minio** container serves ports **9090** and **9091** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.
+  - The **milvus-minio** container serves ports **9000** and **9001** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.
   - The **milvus-standalone** container serves ports **19530** locally with the default settings and maps its data to **volumes/milvus** in the current folder.
 
 You can check if the containers are up and running using the following command:
 
 ```shell
-$ sudo docker-compose ps
+$ docker compose ps
 
-      Name                     Command                  State                            Ports
---------------------------------------------------------------------------------------------------------------------
-milvus-etcd         etcd -advertise-client-url ...   Up             2379/tcp, 2380/tcp
-milvus-minio        /usr/bin/docker-entrypoint ...   Up (healthy)   9000/tcp
-milvus-standalone   /tini -- milvus run standalone   Up             0.0.0.0:19530->19530/tcp, 0.0.0.0:9091->9091/tcp
+NAME                IMAGE   COMMAND                  SERVICE      CREATED         STATUS                   PORTS
+milvus-etcd         …       "etcd -advertise-cli…"   etcd         2 minutes ago   Up 2 minutes (healthy)   2379-2380/tcp
+milvus-minio        …       "/usr/bin/docker-ent…"   minio        2 minutes ago   Up 2 minutes (healthy)   9000-9001/tcp
+milvus-standalone   …       "/tini -- milvus run…"   standalone   2 minutes ago   Up 2 minutes (healthy)   0.0.0.0:9091->9091/tcp, 0.0.0.0:19530->19530/tcp
 ```
 
 You can also access Milvus WebUI at `http://127.0.0.1:9091/webui/` to learn more about the your Milvus instance. For details, refer to [Milvus WebUI](milvus-webui.md).


### PR DESCRIPTION
Two small fixes on the **Run Milvus with Docker Compose (Linux)** page:

1. **MinIO host ports** — the `milvus-minio` container serves host ports **9000** and **9001**, not `9090`/`9091`.
2. **`ps` example** — the page uses `docker compose up -d` (V2), but the status check still showed the legacy `sudo docker-compose ps` (V1) table. Updated to `docker compose ps` with V2 output columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)