### PR TITLE
docs: point the RPM/DEB releases-page link at the package release tag

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-binary.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-binary.md
@@ -17,7 +17,7 @@ This page illustrates how to install Milvus standalone with a pre-built RPM/DEB 
 
 ## Download the RPM/DEB Package
 
-You can download the RPM/DEB package according to your system architecture from the [Milvus Releases page](https://github.com/milvus-io/milvus/releases/tag/v{{var.milvus_release_version}}).
+You can download the RPM/DEB package according to your system architecture from the [Milvus Releases page](https://github.com/milvus-io/milvus/releases/tag/v{{var.milvus_deb_release}}).
 
 - For x86_64/amd64, download the **{{var.milvus_deb_amd64}}** or **{{var.milvus_rpm_amd64}}** package.
 - For ARM64, download the **{{var.milvus_deb_arm64}}** or **{{var.milvus_rpm_arm64}}** package.


### PR DESCRIPTION
On the **Install Milvus Standalone with RPM/DEB Package** page, the download command fetches packages from the `v{{var.milvus_deb_release}}` release, but the *Milvus Releases page* link pointed at `v{{var.milvus_release_version}}` — a different release that does not host the RPM/DEB artifacts. This aligns the link with the release that actually contains the packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)