### PR TITLE
docs: clarify collection existence checks

### DIFF
--- a/site/en/userGuide/collections/view-collections.md
+++ b/site/en/userGuide/collections/view-collections.md
@@ -108,6 +108,14 @@ If you have already created a collection named `quick_setup`, the result of the 
 ["quick_setup"]
 ```
 
+<div class="alert note">
+
+Use `list_collections()` when you need to retrieve all collection names in the current database.
+To check whether a specific collection exists, use the dedicated existence check instead.
+For example, in Python, call `client.has_collection(collection_name="quick_setup")` rather than scanning the list returned by `list_collections()`.
+
+</div>
+
 ## Describe Collection
 
 You can also obtain the details of a specific collection. The following example assumes that you have already created a collection named quick_setup.


### PR DESCRIPTION
## What

Clarifies that `list_collections()` is intended to retrieve all collection names, and that `has_collection()` should be used when checking whether a specific collection exists.

## Why

This addresses #3481 and helps users avoid scanning the full collection list for a single existence check.

## Test

- Ran `git diff --check`.

Fixes #3481