### PR TITLE
docs: add mqType pages (Pulsar/Kafka/RocksMQ + overview) + extend chapter nav

### DIFF
--- a/site/en/adminGuide/data-infra-integration-overview.md
+++ b/site/en/adminGuide/data-infra-integration-overview.md
@@ -1,0 +1,15 @@
+---
+id: data-infra-integration-overview.md
+title: Data Infrastructure & Integration
+summary: Overview of the third-party infrastructure Milvus integrates with — metadata, object storage, and message queues.
+---
+
+# Data Infrastructure & Integration
+
+Milvus builds on open data infrastructure for its core dependencies. This chapter covers the components you can plug in and configure:
+
+- **[Metadata](etcd.md)** — Milvus stores metadata (collection schemas, node status, consumption checkpoints) in etcd.
+- **[Object Storage](object-storage.md)** — Milvus stores index files and binary logs in MinIO, AWS S3, or other S3-compatible / cloud object storage.
+- **[Message Queue](mqtype-overview.md)** — Milvus uses a write-ahead log (WAL): Woodpecker (default), Pulsar, Kafka, or RocksMQ.
+
+By default, a new Milvus 3.x deployment runs with **Woodpecker** as the message queue, **etcd** for metadata, and **MinIO** for object storage — no extra messaging infrastructure required.

--- a/site/en/adminGuide/mq_kafka.md
+++ b/site/en/adminGuide/mq_kafka.md
@@ -1,0 +1,122 @@
+---
+id: mq_kafka.md
+title: Kafka
+---
+
+# Use Kafka as the Milvus Message Queue
+
+Apache Kafka is one of the message-queue (WAL) backends Milvus supports. In Milvus 3.x, [Woodpecker](woodpecker.md) is the default message queue; Kafka remains fully supported for users who prefer it. Kafka is primarily used with Milvus Distributed (cluster); standalone deployments typically use embedded Woodpecker or [RocksMQ](mq_rocksmq.md).
+
+## Version compatibility
+
+- Milvus supports **Kafka 2.x and 3.x** only.
+- Kafka is configured for Milvus Distributed (cluster) via Helm or Milvus Operator.
+
+## Deploy a Milvus cluster with Kafka using Helm
+
+### Install and configure
+
+To use an external Kafka service, disable the bundled Pulsar and enable `externalKafka` in a `values.yaml` override, then install Milvus with it:
+
+```yaml
+pulsarv3:
+  enabled: false
+externalKafka:
+  enabled: true
+  brokerList: <your_kafka_address>:<your_kafka_port>
+  securityProtocol: SASL_SSL
+  sasl:
+    mechanisms: PLAIN
+    username: ""
+    password: ""
+```
+
+```bash
+helm install my-release zilliztech/milvus -f values.yaml
+```
+
+For SASL/SSL authentication details, see [Connect to Kafka with SASL/SSL](connect_kafka_ssl.md).
+
+### Uninstall
+
+```bash
+helm uninstall my-release
+```
+
+## Deploy a Milvus cluster with Kafka using Milvus Operator
+
+With Milvus Operator, set `spec.dependencies.msgStreamType: "kafka"` and configure Kafka under `spec.dependencies.kafka` (cluster only). `kafka` supports `external` and `inCluster`.
+
+### External Kafka
+
+```yaml
+apiVersion: milvus.io/v1alpha1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  config:
+    kafka:
+      # securityProtocol supports: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
+      securityProtocol: PLAINTEXT
+      # saslMechanisms supports: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+      saslMechanisms: PLAIN
+      saslUsername: ""
+      saslPassword: ""
+  dependencies:
+    msgStreamType: "kafka"
+    kafka:
+      external: true
+      brokerList:
+        - "kafkaBrokerAddr1:9092"
+        - "kafkaBrokerAddr2:9092"
+```
+
+<div class="alert note">
+
+SASL configurations are supported in Milvus Operator v0.8.5 or later.
+
+</div>
+
+### Internal (in-cluster) Kafka
+
+```yaml
+apiVersion: milvus.io/v1alpha1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  dependencies:
+    msgStreamType: "kafka"
+    kafka:
+      inCluster:
+        values: {}  # see https://artifacthub.io/packages/helm/bitnami/kafka
+  components: {}
+  config: {}
+```
+
+Apply the configuration (assuming the file is `milvuscluster.yaml`):
+
+```bash
+kubectl apply -f milvuscluster.yaml
+```
+
+### Uninstall
+
+```bash
+kubectl delete milvus my-release
+```
+
+## Notes
+
+- **Upgrading from 2.5.x to 2.6.x:** {{fragments/mq_upgrade_limitation.md}} If you run Kafka and want to keep it, do not change the message queue during the upgrade.
+- Only **Kafka 2.x and 3.x** are supported.
+- For SASL/SSL connectivity, see [Connect to Kafka with SASL/SSL](connect_kafka_ssl.md).
+
+## What's next
+
+- [Woodpecker (default message queue)](woodpecker.md)

--- a/site/en/adminGuide/mq_pulsar.md
+++ b/site/en/adminGuide/mq_pulsar.md
@@ -1,0 +1,152 @@
+---
+id: mq_pulsar.md
+title: Pulsar
+---
+
+# Use Pulsar as the Milvus Message Queue
+
+Apache Pulsar is one of the message-queue (WAL) backends Milvus supports. In Milvus 3.x, [Woodpecker](woodpecker.md) is the default message queue; Pulsar remains fully supported for users who prefer it. Pulsar is primarily used with Milvus Distributed (cluster); standalone deployments typically use embedded Woodpecker or [RocksMQ](mq_rocksmq.md).
+
+## Version compatibility
+
+| Milvus version | Supported Pulsar version | Default |
+| --- | --- | --- |
+| 2.5.x and later | Pulsar v3 (recommended) or Pulsar v2 | Pulsar v3 (via Helm / Milvus Operator) |
+| 2.4.x and earlier | Pulsar v2 | Pulsar v2 |
+
+Since Milvus 2.5, the Milvus Helm chart and Milvus Operator deploy **Pulsar v3** by default; Pulsar v2 remains compatible. See [Upgrade Pulsar from v2 to v3](upgrade-pulsar-v3.md) and [Continue Using Pulsar v2](use-pulsar-v2.md).
+
+## Deploy a Milvus cluster with Pulsar using Helm
+
+### Install
+
+To deploy a Milvus cluster that uses the bundled Pulsar (instead of Woodpecker), install the Helm chart with the Streaming Node enabled:
+
+```bash
+helm install my-release zilliztech/milvus \
+  --set image.all.tag=v{{var.milvus_release_version}} \
+  --set pulsarv3.enabled=true \
+  --set woodpecker.enabled=false \
+  --set streaming.enabled=true \
+  --set indexNode.enabled=false
+```
+
+On Kubernetes v1.25 and later, if you hit PodDisruptionBudget API issues from the bundled Pulsar sub-chart, disable the Pulsar PDB policies:
+
+```bash
+helm install my-release zilliztech/milvus \
+  --set pulsar.bookkeeper.pdb.usePolicy=false \
+  --set pulsar.broker.pdb.usePolicy=false \
+  --set pulsar.proxy.pdb.usePolicy=false \
+  --set pulsar.zookeeper.pdb.usePolicy=false
+```
+
+### Configure
+
+To connect Milvus to an **external** Pulsar service, disable the bundled Pulsar and enable `externalPulsar` in a `values.yaml` override:
+
+```yaml
+pulsarv3:
+  enabled: false
+externalPulsar:
+  enabled: true
+  host: <your_pulsar_host>
+  port: 6650
+  maxMessageSize: "5242880"  # 5 MB, maximum size of each message
+  tenant: public
+  namespace: default
+```
+
+```bash
+helm install my-release zilliztech/milvus -f values.yaml
+```
+
+### Uninstall
+
+```bash
+helm uninstall my-release
+```
+
+If you used the bundled Pulsar and want to remove its persisted data, delete the Pulsar PVCs (named `my-release-pulsarv3-*`):
+
+```bash
+kubectl get pvc | grep my-release-pulsarv3
+kubectl delete pvc <pulsar-pvc-name> ...
+```
+
+## Deploy a Milvus cluster with Pulsar using Milvus Operator
+
+With Milvus Operator, configure Pulsar under `spec.dependencies.pulsar` (supported for Milvus cluster only). `pulsar` supports `external` and `inCluster`.
+
+### External Pulsar
+
+```yaml
+apiVersion: milvus.io/v1alpha1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  dependencies:
+    pulsar:
+      external: true
+      endpoints:
+      - 192.168.1.1:6650
+  components: {}
+  config: {}
+```
+
+### Internal (in-cluster) Pulsar
+
+```yaml
+apiVersion: milvus.io/v1alpha1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  dependencies:
+    pulsar:
+      inCluster:
+        values:
+          components:
+            autorecovery: false
+          zookeeper:
+            replicaCount: 1
+          bookkeeper:
+            replicaCount: 1
+          broker:
+            replicaCount: 1
+            configData:
+              autoSkipNonRecoverableData: "true"
+              managedLedgerDefaultEnsembleSize: "1"
+              managedLedgerDefaultWriteQuorum: "1"
+              managedLedgerDefaultAckQuorum: "1"
+          proxy:
+            replicaCount: 1
+  components: {}
+  config: {}
+```
+
+Apply the configuration (assuming the file is `milvuscluster.yaml`):
+
+```bash
+kubectl apply -f milvuscluster.yaml
+```
+
+### Uninstall
+
+```bash
+kubectl delete milvus my-release
+```
+
+## Notes
+
+- **Upgrading from 2.5.x to 2.6.x:** {{fragments/mq_upgrade_limitation.md}} If you run Pulsar and want to keep it, do not change the message queue during the upgrade.
+- **Pulsar v2 → v3:** see [Upgrade Pulsar from v2 to v3](upgrade-pulsar-v3.md); to stay on v2, see [Continue Using Pulsar v2](use-pulsar-v2.md).
+
+## What's next
+
+- [Woodpecker (default message queue)](woodpecker.md)

--- a/site/en/adminGuide/mq_rocksmq.md
+++ b/site/en/adminGuide/mq_rocksmq.md
@@ -1,0 +1,78 @@
+---
+id: mq_rocksmq.md
+title: RocksMQ
+---
+
+# Use RocksMQ as the Milvus Message Queue
+
+RocksMQ is an embedded message queue (WAL) bundled with Milvus, available for **Milvus Standalone only**. It was the default standalone message queue in earlier Milvus versions; in Milvus 3.x, Milvus Standalone uses embedded [Woodpecker](woodpecker.md) by default.
+
+## Version compatibility
+
+- **Standalone only** — RocksMQ is **not** supported in Milvus Distributed (cluster). See the [message queue support matrix](mqtype-overview.md#Supported-message-queues).
+- RocksMQ ships with Milvus, so there is no separate version to install.
+- It was the default standalone message queue in earlier Milvus versions, and is superseded by embedded Woodpecker in Milvus 3.x.
+
+## Deploy Milvus Standalone with RocksMQ using Docker
+
+### Install
+
+Follow [Run Milvus in Docker](install_standalone-docker.md). In Milvus 3.x the standalone default is Woodpecker, so switch the message-queue type to RocksMQ explicitly. The bootstrap script writes a fresh `user.yaml` on the **first** `start`, so set the type **after** that first start and then `restart` to apply (a `restart` preserves `user.yaml`):
+
+```bash
+mkdir milvus-rocksmq && cd milvus-rocksmq
+curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh -o standalone_embed.sh
+
+# 1. First start — boots the container and writes a default user.yaml
+bash standalone_embed.sh start
+
+# 2. Set the message queue to RocksMQ
+cat > user.yaml <<'EOF'
+mq:
+  type: rocksmq
+EOF
+
+# 3. Restart to apply the change
+bash standalone_embed.sh restart
+```
+
+<div class="alert note">
+Switching <code>mq.type</code> this way is meant for a <b>brand-new</b> instance (no collections yet). To change the message queue of an instance that already holds data, follow the switch procedure instead.
+</div>
+
+### Configure
+
+To tune RocksMQ, add a `rocksmq` section to `user.yaml` and restart the service:
+
+```yaml
+mq:
+  type: rocksmq
+rocksmq:
+  path: /var/lib/milvus/rdb_data   # where messages are stored
+  lrucacheratio: 0.06              # rocksdb cache memory ratio
+  rocksmqPageSize: 67108864        # 64 MB, size of each message page
+  retentionTimeInMinutes: 4320     # 3 days
+  retentionSizeInMB: 8192          # 8 GB
+  compactionInterval: 86400        # 1 day, trigger rocksdb compaction
+  compressionTypes: [0, 0, 7, 7, 7]
+```
+
+```bash
+bash standalone_embed.sh restart
+```
+
+### Uninstall
+
+```bash
+bash standalone_embed.sh stop
+bash standalone_embed.sh delete
+```
+
+## Notes
+
+- **Upgrading from 2.5.x to 2.6.x:** {{fragments/mq_upgrade_limitation.md}} Because 2.6.x changes the standalone default to Woodpecker, pin `mq.type: rocksmq` in your `user.yaml` **before** upgrading if you want to keep RocksMQ.
+- To change the message queue of a running instance, see Switch from RocksMQ to Woodpecker.
+
+## What's next
+
+- [Woodpecker (default message queue)](woodpecker.md)

--- a/site/en/adminGuide/mqtype-overview.md
+++ b/site/en/adminGuide/mqtype-overview.md
@@ -1,0 +1,32 @@
+---
+id: mqtype-overview.md
+title: Message Queue Overview
+summary: Overview of the message queue (mqType) options Milvus supports, and which one to use for standalone vs. distributed deployments.
+---
+
+# Message Queue Overview
+
+Milvus relies on a message queue (write-ahead log, WAL) to manage logs of recent changes, output stream logs, and provide log subscriptions. In Milvus 3.x, **Woodpecker** is the default message queue and requires no separate messaging infrastructure. Pulsar, Kafka, and RocksMQ remain supported for specific scenarios.
+
+## Supported message queues
+
+| Message queue | Milvus Standalone | Milvus Distributed (cluster) | Default in | Notes |
+| --- | :---: | :---: | --- | --- |
+| [Woodpecker](woodpecker.md) | ✔️ (embedded) | ✔️ (embedded or service) | **Milvus 3.x** (both modes) | Default and recommended. Cloud-native WAL on object storage; no external service required. |
+| [Pulsar](mq_pulsar.md) | ✔️ | ✔️ | ≤ 2.5.x (cluster default) | Supported, external or bundled. |
+| [Kafka](mq_kafka.md) | ✔️ | ✔️ | — | Supported. Only Kafka 2.x or 3.x. |
+| [RocksMQ](mq_rocksmq.md) | ✔️ | ✖️ | ≤ 2.5.x (standalone default) | Supported for **standalone only**. |
+
+<div class="alert note">
+
+- Each Milvus instance uses exactly one message queue.
+- {{fragments/mq_upgrade_limitation.md}}
+- To change the message queue of a running instance, see Switch MQ Type (supported from v2.6.14).
+
+</div>
+
+## Choosing a message queue
+
+- **New deployments (Milvus 3.x):** use **Woodpecker** (the default). Standalone runs it embedded; for distributed (cluster), the recommended default is a dedicated [service](woodpecker.md#Deployment-modes) deployed with Helm, and embedded is also supported.
+- **Existing Pulsar or Kafka users:** Pulsar and Kafka remain fully supported. Keep them, or switch to Woodpecker.
+- **RocksMQ:** standalone only, and superseded by embedded Woodpecker in Milvus 3.x.

--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -1490,6 +1490,12 @@
     "order": 9,
     "children": [
       {
+        "label": "Overview",
+        "id": "data-infra-integration-overview.md",
+        "order": 0,
+        "children": []
+      },
+      {
         "label": "Metadata",
         "id": "metadata",
         "isMenu": true,
@@ -1516,9 +1522,33 @@
         "order": 4,
         "children": [
           {
+            "label": "Overview",
+            "id": "mqtype-overview.md",
+            "order": 0,
+            "children": []
+          },
+          {
             "label": "Woodpecker",
             "id": "woodpecker.md",
             "order": 1,
+            "children": []
+          },
+          {
+            "label": "Pulsar",
+            "id": "mq_pulsar.md",
+            "order": 2,
+            "children": []
+          },
+          {
+            "label": "Kafka",
+            "id": "mq_kafka.md",
+            "order": 3,
+            "children": []
+          },
+          {
+            "label": "RocksMQ",
+            "id": "mq_rocksmq.md",
+            "order": 4,
             "children": []
           }
         ]


### PR DESCRIPTION
**PR 2 of the phased Milvus 3.x docs restructure** (targets `preview`; follows #3535).

Adds the Message Queue (mqType) section of the new *Data Infrastructure & Integration* chapter and wires it into the sidebar:

- `data-infra-integration-overview.md` — chapter overview / hub
- `mqtype-overview.md` — MQ overview + support matrix
- `mq_pulsar.md`, `mq_kafka.md`, `mq_rocksmq.md` — per-MQ pages
- `en.json` — extends the chapter node (Overview + mqType > Overview/Pulsar/Kafka/RocksMQ)

**Deferred (kept link-closed):** the "see Switch…" cross-links point at pages created in the later switch-recut PR, so they are omitted here and added there. Pulsar's sub-pages (`upgrade-pulsar-v3`, `use-pulsar-v2`) are re-parented under Pulsar in the cleanup PR to avoid duplicate nav ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)