### PR TITLE
docs: default the Docker Compose standalone install to Woodpecker

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
@@ -33,10 +33,11 @@ Creating milvus-standalone ... done
 
 <div class="alert note">
 
-**What's new in v{{var.milvus_release_version}}:**
-- **Enhanced Architecture**: Features the new Streaming Node and optimized components
-- **Updated Dependencies**: Includes the latest MinIO and etcd versions
-- **Improved Configuration**: Optimized settings for better performance
+**Default deployment (v{{var.milvus_release_version}}):** `docker compose up -d` starts three containers — `milvus-etcd` (metadata), `milvus-minio` (object storage), and `milvus-standalone`. The message queue is **Woodpecker (embedded, with MinIO / object storage as its WAL backend)**, so no separate message-queue container is required.
+
+**Message-queue default by version:**
+- **2.5.x** — default message queue is **RocksMQ**.
+- **2.6.x and later** — default message queue is **Woodpecker (embedded)**.
 
 Always download the latest Docker Compose configuration to ensure compatibility with v{{var.milvus_release_version}} features.
 
@@ -50,19 +51,18 @@ After starting up Milvus,
 
 - Containers named **milvus-standalone**, **milvus-minio**, and **milvus-etcd** are up.
   - The **milvus-etcd** container does not expose any ports to the host and maps its data to **volumes/etcd** in the current folder.
-  - The **milvus-minio** container serves ports **9090** and **9091** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.
+  - The **milvus-minio** container serves ports **9000** and **9001** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.
   - The **milvus-standalone** container serves ports **19530** locally with the default settings and maps its data to **volumes/milvus** in the current folder.
 
 You can check if the containers are up and running using the following command:
 
 ```shell
-$ sudo docker-compose ps
+$ docker compose ps
 
-      Name                     Command                  State                            Ports
---------------------------------------------------------------------------------------------------------------------
-milvus-etcd         etcd -advertise-client-url ...   Up             2379/tcp, 2380/tcp
-milvus-minio        /usr/bin/docker-entrypoint ...   Up (healthy)   9000/tcp
-milvus-standalone   /tini -- milvus run standalone   Up             0.0.0.0:19530->19530/tcp, 0.0.0.0:9091->9091/tcp
+NAME                IMAGE   COMMAND                  SERVICE      CREATED         STATUS                   PORTS
+milvus-etcd         …       "etcd -advertise-cli…"   etcd         2 minutes ago   Up 2 minutes (healthy)   2379-2380/tcp
+milvus-minio        …       "/usr/bin/docker-ent…"   minio        2 minutes ago   Up 2 minutes (healthy)   9000-9001/tcp
+milvus-standalone   …       "/tini -- milvus run…"   standalone   2 minutes ago   Up 2 minutes (healthy)   0.0.0.0:9091->9091/tcp, 0.0.0.0:19530->19530/tcp
 ```
 
 You can also access Milvus WebUI at `http://127.0.0.1:9091/webui/` to learn more about the your Milvus instance. For details, refer to [Milvus WebUI](milvus-webui.md).
@@ -105,6 +105,28 @@ $ sudo docker compose down
 # Delete service data
 $ sudo rm -rf volumes
 ```
+
+## Upgrading from Milvus 2.5.x to 2.6.x
+
+{{fragments/mq_upgrade_limitation.md}}
+
+Because 2.6.x changes the default message queue to Woodpecker, an instance running **RocksMQ** on 2.5.x must **explicitly pin RocksMQ before upgrading** — otherwise the upgrade would attempt to change the message queue, which is not supported. After downloading the 2.6.x Docker Compose file, set the message-queue type back to `rocksmq` in your `user.yaml` override, then upgrade:
+
+```yaml
+# user.yaml — keep RocksMQ across the 2.5.x → 2.6.x upgrade
+mq:
+  type: rocksmq
+```
+
+To switch the message queue *after* upgrading, see the Switch MQ Type guide.
+
+## Optional dependencies
+
+This deployment runs **Woodpecker** (embedded, MinIO WAL backend) for messaging, **etcd** for metadata, and **MinIO** for object storage. To use a different message queue or connect external object storage / metadata, see:
+
+- Message queue: [Woodpecker](woodpecker.md) (default) · [Pulsar](mq_pulsar.md) · [Kafka](mq_kafka.md) · [RocksMQ](mq_rocksmq.md)
+- Object storage: [MinIO](deploy_s3.md) (default) · [AWS S3](deploy_s3.md) · [Azure Blob](abs.md) · [GCP Cloud Storage](gcs.md) · [Aliyun OSS](deploy_s3.md) · [Tencent COS](deploy_s3.md) · [Huawei OBS](deploy_s3.md) · [S3-compatible](deploy_s3.md)
+- Metadata: [etcd](deploy_etcd.md)
 
 ## What's next
 


### PR DESCRIPTION
**PR 4 of the phased Milvus 3.x docs restructure** (targets `preview`; follows #3539).

Updates the **Docker Compose (Linux)** standalone install:

- Default-deployment note + per-version MQ defaults (2.5.x RocksMQ → 2.6.x Woodpecker).
- **2.5.x → 2.6.x upgrade caveat** (pin RocksMQ before upgrading) + an *Optional dependencies* section.
- Folds in the compose fixes: minio host ports **9000/9001** (were 9090/9091), status check modernized to `docker compose ps` (V2), and the WAL-backend wording corrected to **MinIO**.

**Deferred:** the "Switch MQ Type" link points at a page created in the later switch-recut PR, so it is plain text here and re-linked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)