### PR TITLE
docs: default the single-pod Docker standalone install to Woodpecker (local FS)

### DIFF
--- a/site/en/getstarted/run-milvus-docker/install_standalone-binary.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-binary.md
@@ -17,7 +17,7 @@ This page illustrates how to install Milvus standalone with a pre-built RPM/DEB 
 
 ## Download the RPM/DEB Package
 
-You can download the RPM/DEB package according to your system architecture from the [Milvus Releases page](https://github.com/milvus-io/milvus/releases/tag/v{{var.milvus_release_version}}).
+You can download the RPM/DEB package according to your system architecture from the [Milvus Releases page](https://github.com/milvus-io/milvus/releases/tag/v{{var.milvus_deb_release}}).
 
 - For x86_64/amd64, download the **{{var.milvus_deb_amd64}}** or **{{var.milvus_rpm_amd64}}** package.
 - For ARM64, download the **{{var.milvus_deb_arm64}}** or **{{var.milvus_rpm_arm64}}** package.
@@ -73,6 +73,12 @@ If Milvus is running successfully, you should see the following output:
 ```
 
 You can find the Milvus binary at `/usr/bin/milvus`, the systemd service file at `/lib/systemd/system/milvus.service`, and the dependencies at `/usr/lib/milvus/`.
+
+<div class="alert note">
+
+By default, Milvus Standalone runs **Woodpecker** (local filesystem) as its message queue with embedded etcd, so no external messaging or metadata service is required. See [Woodpecker](woodpecker.md).
+
+</div>
 
 ## (Optional) Update Milvus configurations
 

--- a/site/en/getstarted/run-milvus-docker/install_standalone-docker.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-docker.md
@@ -33,7 +33,7 @@ $ bash standalone_embed.sh start
 
 **What's new in v{{var.milvus_release_version}}:**
 - **Streaming Node**: Enhanced data processing capabilities
-- **Woodpecker MQ**: Improved message queue with reduced maintenance overhead, see [Use Woodpecker](use-woodpecker.md) for detail
+- **Woodpecker MQ (default)**: This Docker deployment runs Woodpecker as the message queue with the **local filesystem** as its WAL backend, so no external message-queue service is required. See [Woodpecker](woodpecker.md).
 - **Optimized Architecture**: Consolidated components for better performance
 
 Always download the latest script to ensure you get the most recent configurations and architecture improvements.
@@ -46,7 +46,7 @@ If you encounter any issues pulling the image, contact us at <a href="mailto:com
 
 After running the installation script:
 
-- A docker container named milvus has been started at port **19530**.
+- A docker container named milvus-standalone has been started at port **19530**.
 - An embed etcd is installed along with Milvus in the same container and serves at port **2379**. Its configuration file is mapped to **embedEtcd.yaml** in the current folder.
 - To change the default Milvus configuration, add your settings to the **user.yaml** file in the current folder and then restart the service.
 - The Milvus data volume is mapped to **volumes/milvus** in the current folder.
@@ -105,6 +105,14 @@ $ bash standalone_embed.sh stop
 # Delete Milvus data
 $ bash standalone_embed.sh delete
 ```
+
+## Optional dependencies
+
+By default this deployment runs **Woodpecker** (local-filesystem WAL) as the message queue and an **embedded etcd** for metadata — nothing else to install. To use a different message queue or connect external object storage / metadata, see:
+
+- Message queue: [Woodpecker](woodpecker.md) (default) · [Pulsar](mq_pulsar.md) · [Kafka](mq_kafka.md) · [RocksMQ](mq_rocksmq.md)
+- Object storage: [MinIO](deploy_s3.md) (default) · [AWS S3](deploy_s3.md) · [Azure Blob](abs.md) · [GCP Cloud Storage](gcs.md) · [Aliyun OSS](deploy_s3.md) · [Tencent COS](deploy_s3.md) · [Huawei OBS](deploy_s3.md) · [S3-compatible](deploy_s3.md)
+- Metadata: [etcd](deploy_etcd.md)
 
 ## What's next
 

--- a/site/en/getstarted/run-milvus-docker/install_standalone-windows.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-windows.md
@@ -3,10 +3,12 @@ id: install_standalone-windows.md
 label: Docker
 related_key: Docker
 summary: Learn how to install Milvus standalone with Docker Desktop for Windows.
-title: Run Milvus in Docker (Linux)
+title: Run Milvus in Docker (Windows)
 ---
 
 # Run Milvus in Docker (Windows)
+
+> By default, this deployment runs **Woodpecker** (local filesystem) as its message queue, so no external message-queue service is required. See [Woodpecker](woodpecker.md).
 
 This page demonstrates how to run Milvus on Windows using Docker Desktop for Windows.​
 
@@ -109,7 +111,7 @@ If you prefer to start Milvus using Linux commands and shell scripts on Windows,
     Stop successfully.​
     ​
     # Delete Milvus data​
-    $ bash standalone_embed.sh stop​
+    $ bash standalone_embed.sh delete​
     Delete Milvus container successfully.​
     Delete successfully.​
 
@@ -141,7 +143,7 @@ Once you have installed Docker Desktop on Microsoft Windows, you can access the 
 
     - The **milvus-etcd** container does not expose any ports to the host and maps its data to **volumes/etcd** in the current folder.​
 
-    - The **milvus-minio** container serves ports **9090** and **9091** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.​
+    - The **milvus-minio** container serves ports **9000** and **9001** locally with the default authentication credentials and maps its data to **volumes/minio** in the current folder.​
 
     - The **milvus-standalone** container serves ports **19530** locally with the default settings and maps its data to **volumes/milvus** in the current folder.​
 

--- a/site/en/getstarted/run-milvus-docker/prerequisite-docker.md
+++ b/site/en/getstarted/run-milvus-docker/prerequisite-docker.md
@@ -32,7 +32,8 @@ The following dependencies will be obtained and configured automatically when Mi
 | -------- | ----------------------------- | ---- |
 | etcd     | 3.5.0                         |  See [additional disk requirements](#Additional-disk-requirements). |
 | MinIO    |  RELEASE.2024-12-18T13-15-44Z | |
-| Pulsar   | 2.8.2                         | |
+| Woodpecker | Bundled with Milvus | Default message queue (embedded); no separate service to install. |
+| Pulsar   | 2.8.2                         | Optional — only if you switch the message queue to Pulsar; not installed by default. |
 
 ### Additional disk requirements
 


### PR DESCRIPTION
**PR 5 of the phased Milvus 3.x docs restructure** (targets `preview`; follows #3542).

Standalone **Docker** family — Woodpecker **embedded (local filesystem)** as the default:

- `install_standalone-docker.md` — WP local-FS default note + *Optional dependencies*; container name fixed to `milvus-standalone`.
- `install_standalone-windows.md` / `install_standalone-binary.md` — Woodpecker-default notes; folds in the Windows minio ports (9000/9001) + `stop`→`delete` fix, and points the RPM/DEB releases link at the package release tag.
- `prerequisite-docker.md` — Pulsar marked optional; Woodpecker (embedded) row added.

All content edits to existing pages (already in nav); link-closed on `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)