### PR TITLE
docs: add StructArray documentation

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -462,10 +462,41 @@
             "children": []
           },
           {
-            "label": "Array of Structs",
-            "id": "array-of-structs.md",
+            "label": "StructArray",
+            "id": "structarray",
             "order": 10,
-            "children": []
+            "children": [
+              {
+                "label": "StructArray Overview",
+                "id": "array-of-structs.md",
+                "order": 0,
+                "children": []
+              },
+              {
+                "label": "Create a StructArray Field",
+                "id": "create-structarray-field.md",
+                "order": 1,
+                "children": []
+              },
+              {
+                "label": "Insert Data into StructArray Fields",
+                "id": "insert-data-into-structarray-fields.md",
+                "order": 2,
+                "children": []
+              },
+              {
+                "label": "Index StructArray Fields",
+                "id": "index-structarray-fields.md",
+                "order": 3,
+                "children": []
+              },
+              {
+                "label": "StructArray Limits",
+                "id": "structarray-limits.md",
+                "order": 4,
+                "children": []
+              }
+            ]
           },
           {
             "label": "Geometry Field",
@@ -1083,10 +1114,53 @@
             "children": []
           },
           {
-            "label": "Search with Embedding Lists",
-            "id": "search-with-embedding-lists.md",
+            "label": "Search with StructArray",
+            "id": "search-with-structarray",
             "order": 12,
-            "children": []
+            "children": [
+              {
+                "label": "Basic Vector Search with StructArray",
+                "id": "basic-vector-search-with-structarray.md",
+                "order": 0,
+                "children": []
+              },
+              {
+                "label": "Filtered Search with StructArray",
+                "id": "filtered-search-with-structarray.md",
+                "order": 1,
+                "children": []
+              },
+              {
+                "label": "Range Search with StructArray",
+                "id": "range-search-with-structarray.md",
+                "order": 2,
+                "children": []
+              },
+              {
+                "label": "Grouping Search with StructArray",
+                "id": "grouping-search-with-structarray.md",
+                "order": 3,
+                "children": []
+              },
+              {
+                "label": "Hybrid Search with StructArray",
+                "id": "hybrid-search-with-structarray.md",
+                "order": 4,
+                "children": []
+              },
+              {
+                "label": "Search with EmbeddingLists: ColBERT and ColPali",
+                "id": "search-with-embedding-lists.md",
+                "order": 5,
+                "children": []
+              },
+              {
+                "label": "Choose an EmbeddingList Search Strategy",
+                "id": "choose-an-embeddinglist-search-strategy.md",
+                "order": 6,
+                "children": []
+              }
+            ]
           },
           {
             "label": "Elasticsearch Queries to Milvus",

--- a/site/en/userGuide/schema/array-of-structs.md
+++ b/site/en/userGuide/schema/array-of-structs.md
@@ -1,1190 +1,132 @@
 ---
 id: array-of-structs.md
-title: "StructArray"
-summary: "Use StructArray fields to store ordered Struct elements with a shared schema of vector and scalar fields."
+title: "StructArray Overview"
+summary: "Use StructArray when one entity needs to store an ordered list of structured elements, such as one document with many chunks, one page with many visual patches, or one video with many clips. StructArray keeps these elements inside the parent entity while still allowing vector search and scalar filtering on fields inside each element."
 ---
+# StructArray Overview
 
-# StructArray
+Use StructArray when one entity needs to store an ordered list of structured elements, such as one document with many chunks, one page with many visual patches, or one video with many clips. StructArray keeps these elements inside the parent entity while still allowing vector search and scalar filtering on fields inside each element.
 
-An Array of Structs field, or a StructArray field, in an entity stores an ordered set of Struct elements. Each Struct in the Array shares the same pre-defined schema, comprising multiple vectors and scalar fields.
+## What is StructArray?
 
-Here's an example of an entity from a collection that contains a StructArray field.
+A **StructArray**, also known as an array of structs, stores an ordered set of Struct elements in each entity. Every Struct element in the array follows the same schema. A Struct element can contain scalar subfields, vector subfields, or both.
+
+For example, a collection can store one article as an entity and store its chunks in a StructArray field named `chunks`. Each chunk can include text, section metadata, quality scores, and one or more vector embeddings.
 
 ```json
 {
-    'id': 0,
-    'title': 'Walden',
-    'title_vector': [0.1, 0.2, 0.3, 0.4, 0.5],
-    'author': 'Henry David Thoreau',
-    'year_of_publication': 1845,
-    // highlight-start
-    'chunks': [
-        {
-            'text': 'When I wrote the following pages, or rather the bulk of them...',
-            'text_vector': [0.3, 0.2, 0.3, 0.2, 0.5],
-            'chapter': 'Economy',
-        },
-        {
-            'text': 'I would fain say something, not so much concerning the Chinese and...',
-            'text_vector': [0.7, 0.4, 0.2, 0.7, 0.8],
-            'chapter': 'Economy'
-        }
-    ]
-    // hightlight-end
-}
-```
-
-In the example above, the `chunks` field is a StructArray field, and each Struct element contains its own fields, namely `text`, `text_vector`, and `chapter`.
-
-## When to use
-
-Modern AI applications, from autonomous driving to multimodal retrieval, increasingly rely on nested, heterogeneous data. Traditional flat data models struggle to represent complex relationships like "**one document with many annotated chunks**" or "**one driving scene with multiple observed maneuvers**". This is where the StructArray data type in Milvus shines.
-
-To quickly determine if the StructArray field suits your application scenarios, consider whether:
-
-- Your data is in a hierarchical structure, such as one document with many annotated chunks.
-
-- The search result should be the document, rather than the chunks, as in the above example.
-
-- The search results contain massive duplicate entities, and you struggle to retrieve the final results using techniques such as grouping, deduplication, and reranking.
-
-If your answers to the questions above are yes, you should use the StructArray.
-
-## Limits
-
-- **Data types**
-
-    When you create a collection, you can use the Struct type as the data type for the elements in an Array field. Starting from Milvus 3.0.0, you can also add a StructArray field to an existing collection with `add_collection_struct_field()`. For details, refer to [Alter Collection Schema](add-fields-to-an-existing-collection.md#add-structarray-fields--milvus-300). Milvus does not support using the Struct type as the data type for a collection field.
-
-    The Structs in an Array field share the same schema, which should be defined when you create the Array field.
-
-    A Struct schema contains both vectors and scalar fields, as listed below:
-
-    <Grid columnSize="2" widthRatios="50,50">
-
-        <div>
-
-            Applicable vector fields:
-
-            - `FLOAT_VECTOR`
-
-            - `FLOAT16_VECTOR`
-
-            - `BFLOAT16_VECTOR`
-
-            - `INT8_VECTOR`
-
-            - `BINARY_VECTOR`
-
-        </div>
-
-        <div>
-
-            Applicable scalar fields:
-
-            - `VARCHAR`
-
-            - `INT8/16/32/64`
-
-            - `FLOAT`
-
-            - `DOUBLE`
-
-            - `BOOL`
-
-        </div>
-
-    </Grid>
-
-    Keep the number of vector fields both at the collection level and in the Structs combined to be no greater than or equal to 10.
-
-- **Nullable & default values**
-
-    A StructArray field is not nullable and does not accept any default value.
-
-- **Function**
-
-    You cannot use a function to derive a vector field from a scalar field within a Struct.
-
-- **Index type & metric type**
-
-    All vector fields in a collection must be indexed. To index a vector field within a StructArray field, Milvus uses an embedding list to organize the vector embeddings in each Struct element and indexes the entire embedding list as a whole.
-
-    You can use `AUTOINDEX` or `HNSW` as the index type and any metric type listed below to build indexes for the embedding lists in a StructArray field.
-
-    <table>
-       <tr>
-         <th><p>Index type</p></th>
-         <th><p>Metric type</p></th>
-         <th><p>Remarks</p></th>
-       </tr>
-       <tr>
-         <td rowspan="3"><ul><li><p><code>AUTOINDEX</code></p></li><li><p><code>HNSW</code></p></li><li><p><code>IVF_FLAT</code></p></li><li><p><code>DISKANN</code></p></li></ul></td>
-         <td rowspan="3"><ul><li><p><code>MAX_SIM_COSINE</code></p></li><li><p><code>MAX_SIM_IP</code></p></li><li><p><code>MAX_SIM_L2</code></p></li></ul></td>
-         <td rowspan="3"><p>For embedding lists of the following types:</p><ul><li><p><code>FLOAT_VECTOR</code></p></li><li><p><code>FLOAT16_VECTOR</code></p></li><li><p><code>BFLOAT16_VECTOR</code></p></li><li><p><code>INT8_VECTOR</code></p></li><li><p><code>BINARY_VECTOR</code></p></li></ul></td>
-       </tr>
-    </table>
-
-    For details on how Milvus calculates the similarity between the query and an embedding list, refer to [Maximum Similarity](metric.md#Maximum-similarity).
-
-    The scalar fields in the StructArray field support the following index types:
-
-    - `INVERTED`
-
-        This usually applies to string-like or categorical filters, like `structA[color]` or `structA[str_val]`. For details, refer to [INVERTED](inverted.md).
-
-    - `STL_SORT`
-
-        This usually applies to range or order-style acceleration on numeric values, like `strctA[num_val]`. For details, refer to [STL_SORT](stl-sort.md).
-
-- **Upsert data**
-
-    Structs do not support upsert in merge mode. However, you can still perform upserts in override mode to update data in Structs. For details about the differences between upsert in merge mode and override mode, refer to [Upsert Entities](upsert-entities.md#Overview).
-
-- **Scalar filtering**
-
-    You can use **element filters** and **operators in the match family** to conduct scalar filtering against a scalar sub-field in a StructArray field. For details, refer to [Scalar filtering in a StructArray field](array-of-structs.md#Scalar-filtering-in-a-StructArray-field).
-
-## Add a StructArray
-
-To add a StructArray field in Milvus, you need to define an array field when creating a collection, and set the data type for its elements to Struct. The process is as follows:
-
-1. Set the data type of a field to `DataType.ARRAY` when adding the field as an Array field to the collection schema.
-
-1. Set the field's `element_type` attribute to `DataType.STRUCT` to make the field a Struct Array.
-
-1. Create a Struct schema and include the required fields. Then, reference the Struct schema in the field's `struct_schema` attribute.
-
-1. Set the field's `max_capacity` attribute to an appropriate value to specify the maximum number of Structs each entity can contain in this field.
-
-1. (**Optional**) You can set `mmap.enabled` for any field within the Struct element to balance the hot and cold data in the Struct.
-
-Here's how you can define a collection schema that includes a StructArray field:
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-from pymilvus import MilvusClient, DataType
-
-client = MilvusClient(
-    uri="http://localhost:19530",
-    token="root:Milvus"
-)
-
-schema = client.create_schema()
-
-# add the primary field to the collection
-schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True, auto_id=True)
-
-# add some scalar fields to the collection
-schema.add_field(field_name="title", datatype=DataType.VARCHAR, max_length=512)
-schema.add_field(field_name="author", datatype=DataType.VARCHAR, max_length=512)
-schema.add_field(field_name="year_of_publication", datatype=DataType.INT64)
-
-# add a vector field to the collection
-schema.add_field(field_name="title_vector", datatype=DataType.FLOAT_VECTOR, dim=5)
-
-# highlight-start
-# Create a struct schema
-struct_schema = client.create_struct_field_schema()
-
-# add a scalar field to the struct
-struct_schema.add_field("text", DataType.VARCHAR, max_length=65535)
-struct_schema.add_field("chapter", DataType.VARCHAR, max_length=512)
-
-# add a vector field to the struct with mmap enabled
-struct_schema.add_field("text_vector", DataType.FLOAT_VECTOR, mmap_enabled=True, dim=5)
-
-# reference the struct schema in an Array field with its 
-# element type set to `DataType.STRUCT`
-schema.add_field("chunks", datatype=DataType.ARRAY, element_type=DataType.STRUCT, 
-                    struct_schema=struct_schema, max_capacity=1000)
-# highlight-end
-```
-
-```java
-import io.milvus.v2.common.DataType;
-import io.milvus.v2.service.collection.request.AddFieldReq;
-import io.milvus.v2.service.collection.request.CreateCollectionReq;
-
-CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
-        .build();
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("id")
-        .dataType(DataType.Int64)
-        .isPrimaryKey(true)
-        .autoID(true)
-        .build());
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("title")
-        .dataType(DataType.VarChar)
-        .maxLength(512)
-        .build());
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("author")
-        .dataType(DataType.VarChar)
-        .maxLength(512)
-        .build());
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("year_of_publication")
-        .dataType(DataType.Int64)
-        .build());
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("title_vector")
-        .dataType(DataType.FloatVector)
-        .dimension(5)
-        .build());
-
-Map<String, String> params = new HashMap<>();
-params.put("mmap_enabled", "true");
-collectionSchema.addField(AddFieldReq.builder()
-        .fieldName("chunks")
-        .dataType(DataType.Array)
-        .elementType(DataType.Struct)
-        .maxCapacity(1000)
-        .addStructField(AddFieldReq.builder()
-                .fieldName("text")
-                .dataType(DataType.VarChar)
-                .maxLength(65535)
-                .build())
-        .addStructField(AddFieldReq.builder()
-                .fieldName("chapter")
-                .dataType(DataType.VarChar)
-                .maxLength(512)
-                .build())
-        .addStructField(AddFieldReq.builder()
-                .fieldName("text_vector")
-                .dataType(DataType.FloatVector)
-                .dimension(VECTOR_DIM)
-                .typeParams(params)
-                .build())
-        .build());
-```
-
-```go
-// go
-```
-
-```javascript
-import { MilvusClient, DataType } from "@zilliz/milvus2-sdk-node";
-
-const milvusClient = new MilvusClient("http://localhost:19530");
-
-const schema = [
-  {
-    name: "id",
-    data_type: DataType.INT64,
-    is_primary_key: true,
-    auto_id: true,
-  },
-  {
-    name: "title",
-    data_type: DataType.VARCHAR,
-    max_length: 512,
-  },
-  {
-    name: "author",
-    data_type: DataType.VARCHAR,
-    max_length: 512,
-  },
-  {
-    name: "year_of_publication",
-    data_type: DataType.INT64,
-  },
-  {
-    name: "title_vector",
-    data_type: DataType.FLOAT_VECTOR,
-    dim: 5,
-  },
-  // highlight-start
-  {
-    name: "chunks",
-    data_type: DataType.ARRAY,
-    element_type: DataType.STRUCT,
-    fields: [
-      {
-        name: "text",
-        data_type: DataType.VARCHAR,
-        max_length: 65535,
-      },
-      {
-        name: "chapter",
-        data_type: DataType.VARCHAR,
-        max_length: 512,
-      },
-      {
-        name: "text_vector",
-        data_type: DataType.FLOAT_VECTOR,
-        dim: 5,
-        mmap_enabled: true,
-      },
-    ],
-    max_capacity: 1000,
-  },
-  // highlight-end
-];
-```
-
-```bash
-# restful
-SCHEMA='{
-  "autoID": true,
-  "fields": [
+  "doc_id": 1,
+  "title": "Vector search tuning guide",
+  "category": "search",
+  "title_vector": [0.10, 0.20, 0.30, 0.40],
+  "chunks": [
     {
-      "fieldName": "id",
-      "dataType": "Int64",
-      "isPrimary": true
+      "text": "Use HNSW efSearch to trade recall for latency.",
+      "section": "index",
+      "page": 1,
+      "quality_score": 0.92,
+      "has_code": true,
+      "emb_list_vector": [0.11, 0.21, 0.31, 0.41],
+      "emb": [0.12, 0.20, 0.33, 0.39]
     },
     {
-      "fieldName": "title",
-      "dataType": "VarChar",
-      "elementTypeParams": { "max_length": "512" }
-    },
-    {
-      "fieldName": "author",
-      "dataType": "VarChar",
-      "elementTypeParams": { "max_length": "512" }
-    },
-    {
-      "fieldName": "year_of_publication",
-      "dataType": "Int64"
-    },
-    {
-      "fieldName": "title_vector",
-      "dataType": "FloatVector",
-      "elementTypeParams": { "dim": "5" }
-    }
-  ],
-  "structArrayFields": [
-    {
-      "name": "chunks",
-      "description": "Array of document chunks with text and vectors",
-      "elementTypeParams":{
-         "max_capacity": 1000
-      },
-      "fields": [
-        {
-          "fieldName": "text",
-          "dataType": "VarChar",
-          "elementTypeParams": { "max_length": "65535" }
-        },
-        {
-          "fieldName": "chapter",
-          "dataType": "VarChar",
-          "elementTypeParams": { "max_length": "512" }
-        },
-        {
-          "fieldName": "text_vector",
-          "dataType": "FloatVector",
-          "elementTypeParams": {
-            "dim": "5",
-            "mmap_enabled": "true"
-          }
-        }
-      ]
+      "text": "Range search returns vectors within a distance boundary.",
+      "section": "search",
+      "page": 2,
+      "quality_score": 0.86,
+      "has_code": false,
+      "emb_list_vector": [0.18, 0.23, 0.29, 0.36],
+      "emb": [0.19, 0.24, 0.30, 0.37]
     }
   ]
-}'
-```
-
-The highlighted lines in the code example above illustrate how to include a StructArray in a collection schema.
-
-## Set index params
-
-Indexing is mandatory for all vector fields, including both the vector fields in the collection and those defined in the element Struct.
-
-The applicable index parameters vary by index type. For details on applicable index parameters, refer to [Index Explained](index-explained.md) and the documentation for your selected index type.
-
-### Index an embedding list
-
-To index an embedding list, you need to set its index type to `AUTOINDEX`  or any of the applicable index types listed above, and use an listed metric type for Milvus to measure the similarities between embedding lists.
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-# Create index parameters
-index_params = client.prepare_index_params()
-
-# Create an index for the vector field in the collection
-index_params.add_index(
-    field_name="title_vector",
-    index_type="AUTOINDEX",
-    metric_type="L2",
-)
-
-# highlight-start
-# Create an index for the vector field in the element Struct
-index_params.add_index(
-    field_name="chunks[text_vector]",
-    index_type="AUTOINDEX",
-    metric_type="MAX_SIM_COSINE",
-)
-# highlight-end
-```
-
-```java
-import io.milvus.v2.common.IndexParam;
-
-List<IndexParam> indexParams = new ArrayList<>();
-indexParams.add(IndexParam.builder()
-        .fieldName("title_vector")
-        .indexType(IndexParam.IndexType.AUTOINDEX)
-        .metricType(IndexParam.MetricType.L2)
-        .build());
-indexParams.add(IndexParam.builder()
-        .fieldName("chunks[text_vector]")
-        .indexType(IndexParam.IndexType.AUTOINDEX)
-        .metricType(IndexParam.MetricType.MAX_SIM_COSINE)
-        .build());
-```
-
-```go
-// go
-```
-
-```javascript
-await milvusClient.createCollection({
-  collection_name: "books",
-  fields: schema,
-});
-
-const indexParams = [
-  {
-    field_name: "title_vector",
-    index_type: "AUTOINDEX",
-    metric_type: "L2",
-  },
-  // highlight-start
-  {
-    field_name: "chunks[text_vector]",
-    index_type: "AUTOINDEX",
-    metric_type: "MAX_SIM_COSINE",
-  },
-  // highlight-end
-];
-```
-
-```bash
-# restful
-INDEX_PARAMS='[
-  {
-    "fieldName": "title_vector",
-    "indexName": "title_vector_index",
-    "indexType": "AUTOINDEX",
-    "metricType": "L2"
-  },
-  {
-    "fieldName": "chunks[text_vector]",
-    "indexName": "chunks_text_vector_index",
-    "indexType": "AUTOINDEX",
-    "metricType": "MAX_SIM_COSINE"
-  }
-]'
-```
-
-### Index a scalar struct sub-field
-
-When you create indexes on a scalar struct sub-field, Milvus actually builds the index at the **element level**, not at the row level, to accelerate scalar filtering.
-
-The following code snippet creates an index on a scalar struct sub-field named `chunks[text]`.
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-index_params.add_index(
-    field_name="chunks[text]",
-    index_type="INVERTED"
-)
-```
-
-```java
-indexParams.add(IndexParam.builder()
-        .fieldName("chunks[text]")
-        .indexType(IndexParam.IndexType.INVERTED)
-        .build());
-```
-
-```go
-// go
-```
-
-```javascript
-indexParams.push({
-    field_name: "chunks[text]",
-    index_type: "INVERTED"
-})
-```
-
-```bash
-INDEX_PARAMS += '{
-    "fieldName": "chunks[text]",
-    "indexName": "chunks_text_vector_index",
-    "indexType": "INVERTED"
-}'
-```
-
-## Create a collection
-
-Once the schema and index are ready, you can create a collection that includes a StructArray field.
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-client.create_collection(
-    collection_name="my_collection",
-    schema=schema,
-    index_params=index_params
-)
-```
-
-```java
-import io.milvus.v2.service.collection.request.CreateCollectionReq;
-
-CreateCollectionReq requestCreate = CreateCollectionReq.builder()
-        .collectionName("my_collection")
-        .collectionSchema(collectionSchema)
-        .indexParams(indexParams)
-        .build();
-client.createCollection(requestCreate);
-```
-
-```go
-// go
-```
-
-```javascript
-await milvusClient.createCollection({
-  collection_name: "my_collection",
-  fields: schema,
-  indexes: indexParams,
-});
-```
-
-```bash
-# restful
-curl -X POST "http://localhost:19530/v2/vectordb/collections/create" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"collectionName\": \"my_collection\",
-    \"description\": \"A collection for storing book information with struct array chunks\",
-    \"schema\": $SCHEMA,
-    \"indexParams\": $INDEX_PARAMS
-  }"
-```
-
-## Insert data
-
-After creating the collection, you can insert data that includes Arrays of Structs as follows.
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-# Sample data
-data = {
-    'title': 'Walden',
-    'title_vector': [0.1, 0.2, 0.3, 0.4, 0.5],
-    'author': 'Henry David Thoreau',
-    'year_of_publication': 1845,
-    'chunks': [
-        {
-            'text': 'When I wrote the following pages, or rather the bulk of them...',
-            'text_vector': [0.3, 0.2, 0.3, 0.2, 0.5],
-            'chapter': 'Economy',
-        },
-        {
-            'text': 'I would fain say something, not so much concerning the Chinese and...',
-            'text_vector': [0.7, 0.4, 0.2, 0.7, 0.8],
-            'chapter': 'Economy'
-        }
-    ]
 }
-
-# insert data
-client.insert(
-    collection_name="my_collection",
-    data=[data]
-)
 ```
-
-```java
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-
-import io.milvus.v2.service.vector.request.InsertReq;
-import io.milvus.v2.service.vector.response.InsertResp;
-
-Gson gson = new Gson();
-JsonObject row = new JsonObject();
-row.addProperty("title", "Walden");
-row.add("title_vector", gson.toJsonTree(Arrays.asList(0.1f, 0.2f, 0.3f, 0.4f, 0.5f)));
-row.addProperty("author", "Henry David Thoreau");
-row.addProperty("year_of_publication", 1845);
-
-JsonArray structArr = new JsonArray();
-JsonObject struct1 = new JsonObject();
-struct1.addProperty("text", "When I wrote the following pages, or rather the bulk of them...");
-struct1.add("text_vector", gson.toJsonTree(Arrays.asList(0.3f, 0.2f, 0.3f, 0.2f, 0.5f)));
-struct1.addProperty("chapter", "Economy");
-structArr.add(struct1);
-JsonObject struct2 = new JsonObject();
-struct2.addProperty("text", "I would fain say something, not so much concerning the Chinese and...");
-struct2.add("text_vector", gson.toJsonTree(Arrays.asList(0.7f, 0.4f, 0.2f, 0.7f, 0.8f)));
-struct2.addProperty("chapter", "Economy");
-structArr.add(struct2);
-
-row.add("chunks", structArr);
-
-InsertResp insertResp = client.insert(InsertReq.builder()
-        .collectionName("my_collection")
-        .data(Collections.singletonList(row))
-        .build());
-```
-
-```go
-// go
-```
-
-```javascript
-  {
-    id: 0,
-    title: "Walden",
-    title_vector: [0.1, 0.2, 0.3, 0.4, 0.5],
-    author: "Henry David Thoreau",
-    "year-of-publication": 1845,
-    chunks: [
-      {
-        text: "When I wrote the following pages, or rather the bulk of them...",
-        text_vector: [0.3, 0.2, 0.3, 0.2, 0.5],
-        chapter: "Economy",
-      },
-      {
-        text: "I would fain say something, not so much concerning the Chinese and...",
-        text_vector: [0.7, 0.4, 0.2, 0.7, 0.8],
-        chapter: "Economy",
-      },
-    ],
-  },
-];
-
-await milvusClient.insert({
-  collection_name: "books",
-  data: data,
-});
-```
-
-```bash
-# restful
-curl -X POST "http://localhost:19530/v2/vectordb/entities/insert" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "collectionName": "my_collection",
-    "data": [
-      {
-        "title": "Walden",
-        "title_vector": [0.1, 0.2, 0.3, 0.4, 0.5],
-        "author": "Henry David Thoreau",
-        "year_of_publication": 1845,
-        "chunks": [
-          {
-            "text": "When I wrote the following pages, or rather the bulk of them...",
-            "text_vector": [0.3, 0.2, 0.3, 0.2, 0.5],
-            "chapter": "Economy"
-          },
-          {
-            "text": "I would fain say something, not so much concerning the Chinese and...",
-            "text_vector": [0.7, 0.4, 0.2, 0.7, 0.8],
-            "chapter": "Economy"
-          }
-        ]
-      }
-    ]
-  }'
-```
-
-<details>
-
-<summary>Need more data?</summary>
-
-```python
-import json
-import random
-from typing import List, Dict, Any
-
-# Real classic books (title, author, year)
-BOOKS = [
-    ("Pride and Prejudice", "Jane Austen", 1813),
-    ("Moby Dick", "Herman Melville", 1851),
-    ("Frankenstein", "Mary Shelley", 1818),
-    ("The Picture of Dorian Gray", "Oscar Wilde", 1890),
-    ("Dracula", "Bram Stoker", 1897),
-    ("The Adventures of Sherlock Holmes", "Arthur Conan Doyle", 1892),
-    ("Alice's Adventures in Wonderland", "Lewis Carroll", 1865),
-    ("The Time Machine", "H.G. Wells", 1895),
-    ("The Scarlet Letter", "Nathaniel Hawthorne", 1850),
-    ("Leaves of Grass", "Walt Whitman", 1855),
-    ("The Brothers Karamazov", "Fyodor Dostoevsky", 1880),
-    ("Crime and Punishment", "Fyodor Dostoevsky", 1866),
-    ("Anna Karenina", "Leo Tolstoy", 1877),
-    ("War and Peace", "Leo Tolstoy", 1869),
-    ("Great Expectations", "Charles Dickens", 1861),
-    ("Oliver Twist", "Charles Dickens", 1837),
-    ("Wuthering Heights", "Emily Brontë", 1847),
-    ("Jane Eyre", "Charlotte Brontë", 1847),
-    ("The Call of the Wild", "Jack London", 1903),
-    ("The Jungle Book", "Rudyard Kipling", 1894),
-]
-
-# Common chapter names for classics
-CHAPTERS = [
-    "Introduction", "Prologue", "Chapter I", "Chapter II", "Chapter III",
-    "Chapter IV", "Chapter V", "Chapter VI", "Chapter VII", "Chapter VIII",
-    "Chapter IX", "Chapter X", "Epilogue", "Conclusion", "Afterword",
-    "Economy", "Where I Lived", "Reading", "Sounds", "Solitude",
-    "Visitors", "The Bean-Field", "The Village", "The Ponds", "Baker Farm"
-]
-
-# Placeholder text snippets (mimicking 19th-century prose)
-TEXT_SNIPPETS = [
-    "When I wrote the following pages, or rather the bulk of them...",
-    "I would fain say something, not so much concerning the Chinese and...",
-    "It is a truth universally acknowledged, that a single man in possession...",
-    "Call me Ishmael. Some years ago—never mind how long precisely...",
-    "It was the best of times, it was the worst of times...",
-    "All happy families are alike; each unhappy family is unhappy in its own way.",
-    "Whether I shall turn out to be the hero of my own life, or whether that station...",
-    "You will rejoice to hear that no disaster has accompanied the commencement...",
-    "The world is too much with us; late and soon, getting and spending...",
-    "He was an old man who fished alone in a skiff in the Gulf Stream..."
-]
-
-def random_vector() -> List[float]:
-    return [round(random.random(), 1) for _ in range(5)]
-
-def generate_chunk() -> Dict[str, Any]:
-    return {
-        "text": random.choice(TEXT_SNIPPETS),
-        "text_vector": random_vector(),
-        "chapter": random.choice(CHAPTERS)
-    }
-
-def generate_record(record_id: int) -> Dict[str, Any]:
-    title, author, year = random.choice(BOOKS)
-    num_chunks = random.randint(1, 5)  # 1 to 5 chunks per book
-    chunks = [generate_chunk() for _ in range(num_chunks)]
-    return {
-        "title": title,
-        "title_vector": random_vector(),
-        "author": author,
-        "year_of_publication": year,
-        "chunks": chunks
-    }
-
-# Generate 1000 records
-data = [generate_record(i) for i in range(1000)]
-
-# Insert the generated data
-client.insert(collection_name="my_collection", data=data)
-```
-
-</details>
-
-## Vector search in a StructArray field
-
-You can perform vector searches on the vector fields of a collection and in a StructArray.
-
-Specifically, you should concatenate the name of the StructArray field and those of the target vector fields within Struct elements as the value for the `anns_field` parameter in a search request, and use `EmbeddingList` to organize query vectors neatly.
 
 <div class="alert note">
 
-Milvus provides `EmbeddingList` to help you organize query vectors for searches against an embedding list in a StructArray more neatly. Each `EmbeddingList` contains at least a vector embedding and expects a number of topK entities in return.
-
-However, `EmbeddingList` can be used only in `search()` requests without range search or grouping search parameters, let alone `search_iterator()` requests.
+The two vector subfields in this example represent the same chunk from two search perspectives. `chunks[emb_list_vector]` is intended for EmbeddingList search with `MAX_SIM*` metrics, while `chunks[emb]` is intended for element-level search with regular vector metrics such as `COSINE`, `IP`, or `L2`.
 
 </div>
 
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
+## When to use StructArray
+
+Use StructArray when the natural unit you want to return is larger than the natural unit you want to search or filter.
+
+| Use case | Why StructArray helps | Typical StructArray field |
+| --- | --- | --- |
+| Document retrieval | Store one document as an entity while searching across its chunks. | `chunks` |
+| Late-interaction retrieval | Store a document or page as an embedding list and score it with `MAX_SIM*`. | `chunks[emb_list_vector]` or `patches[emb]` |
+| Element-level retrieval | Return the most relevant chunk, clip, patch, or observation, including its array offset. | `chunks[emb]` |
+| Structured filtering | Filter by scalar subfields inside Struct elements, such as section, score, page, or flags. | `chunks[section]`, `chunks[quality_score]` |
+| Reducing duplicate parent results | Keep child elements under the same parent entity instead of storing each child as a separate row. | `chunks`, `clips`, `patches` |
+
+## Decision Matrix
+
+Use the following matrix to choose the right StructArray path.
+
+| Goal | Recommended path | Result granularity | Start here |
+| --- | --- | --- | --- |
+| Model one parent object with many structured children. | Create a StructArray field. | Entity contains ordered Struct elements. | [Create a StructArray Field](create-structarray-field.md) |
+| Insert parent records with nested child data. | Insert entities whose StructArray field is a list of Struct objects. | Entity-level insert. | [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md) |
+| Run ColBERT, ColPali, or document-level late-interaction retrieval. | Use EmbeddingList search with a `MAX_SIM*` index. | Entity level. | [Search with Embedding Lists](search-with-embedding-lists.md) |
+| Search individual chunks, clips, or patches. | Use element-level search with a regular vector metric. | Struct element level, with offset when available. | Basic Vector Search with StructArray |
+| Restrict element-level vector search to elements that match scalar conditions. | Use `element_filter`. | Element-level filtering; result shape depends on the search type. | Filtered Search with StructArray |
+| Select entities by how many Struct elements satisfy a condition. | Use `MATCH_ANY`, `MATCH_ALL`, `MATCH_LEAST`, `MATCH_MOST`, or `MATCH_EXACT`. | Entity level. | [StructArray Operators](struct-array-operators.md) |
+| Use score or distance boundaries on StructArray vector subfields. | Use element-level range search. | Struct element level. | Range Search with StructArray |
+| Return at most one result per parent entity after element-level search. | Use grouping search by primary key. | Entity level after grouping. | Grouping Search with StructArray |
+| Combine StructArray element search with another vector field. | Use hybrid search with one AnnSearchRequest targeting a StructArray vector subfield. | Element-level sub-search, entity-level reranking. | Hybrid Search with StructArray |
+
+## Understand the two search models
+
+| ### EmbeddingList search EmbeddingList search treats the vectors inside a StructArray vector subfield as one embedding list for the parent entity. The query is also an embedding list. Milvus compares the query embedding list with the stored embedding list by using a `MAX_SIM*` metric and returns matching entities. - Query data: embedding list. - Metric family: `MAX_SIM*`. - Result granularity: entity level. - Best for: document-level or page-level late-interaction retrieval. | ### Element-level search Element-level search treats each Struct element as an independent vector-search candidate. Each hit represents a matched element inside the StructArray field, and ungrouped results can expose the element offset. - Query data: regular vector. - Metric family: regular vector metrics. - Result granularity: Struct element level. - Best for: chunk-level, clip-level, or patch-level retrieval. |
+| --- | --- |
+
+<div class="alert note">
+
+Warning
+
+If your collection needs both EmbeddingList search and element-level search, use two separate vector subfields. A vector field or vector subfield accepts only one index, and the two search modes require different metric families.
+
 </div>
 
-```python
-from pymilvus.client.embedding_list import EmbeddingList
+## Documentation map
 
-# each query embedding list triggers a single search
-embeddingList1 = EmbeddingList()
-embeddingList1.add([0.2, 0.9, 0.4, -0.3, 0.2])
+StructArray documentation is split into modeling pages and search pages. Use the modeling pages to define and prepare data. Use the search pages to choose the right retrieval and filtering behavior.
 
-embeddingList2 = EmbeddingList()
-embeddingList2.add([-0.2, -0.2, 0.5, 0.6, 0.9])
-embeddingList2.add([-0.4, 0.3, 0.5, 0.8, 0.2])
+| Area | Page | Use it for |
+| --- | --- | --- |
+| Modeling | [Create a StructArray Field](create-structarray-field.md) | Define Struct schema and add a StructArray field. |
+| Modeling | [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md) | Prepare and insert nested StructArray data. |
+| Modeling | [Index StructArray Fields](index-structarray-fields.md) | Create vector and scalar indexes on StructArray subfields. |
+| Reference | [StructArray Limits](structarray-limits.md) | Check schema, data type, index, search, filter, and version limits. |
+| Search | Basic Vector Search with StructArray | Compare EmbeddingList search and element-level vector search. |
+| Search | Range Search with StructArray | Use range constraints with StructArray vector subfields. |
+| Search | Grouping Search with StructArray | Group element-level search results by primary key. |
+| Search | Hybrid Search with StructArray | Combine StructArray element-level search with other vector searches. |
+| Search | Filtered Search with StructArray | Use StructArray filters in search, query, and hybrid search. |
+| Search | [Search with Embedding Lists](search-with-embedding-lists.md) | Build ColBERT and ColPali-style retrieval systems with StructArray. |
+| Filter | [StructArray Operators](struct-array-operators.md) | Reference syntax for `element_filter` and `MATCH_*` operators. |
 
-# a search with a single embedding list
-results = client.search(
-    collection_name="my_collection",
-    data=[ embeddingList1 ],
-    anns_field="chunks[text_vector]",
-    search_params={"metric_type": "MAX_SIM_COSINE"},
-    limit=3,
-    output_fields=["chunks[text]"]
-)
-```
+## Key limits to check first
 
-```java
-import io.milvus.v2.service.vector.request.data.EmbeddingList;
-import io.milvus.v2.service.vector.request.data.FloatVec;
+- Struct can be used as the element type of an Array field. It is not used as a top-level collection field.
 
-EmbeddingList embeddingList1 = new EmbeddingList();
-embeddingList1.add(new FloatVec(new float[]{0.2f, 0.9f, 0.4f, -0.3f, 0.2f}));
+- All Struct elements in the same StructArray field share one predefined schema.
 
-EmbeddingList embeddingList2 = new EmbeddingList();
-embeddingList2.add(new FloatVec(new float[]{-0.2f, -0.2f, 0.5f, 0.6f, 0.9f}));
-embeddingList2.add(new FloatVec(new float[]{-0.4f, 0.3f, 0.5f, 0.8f, 0.2f}));
+- Vector subfields require indexes. EmbeddingList search uses `MAX_SIM*` metrics, while element-level search uses regular vector metrics.
 
-Map<String, Object> params = new HashMap<>();
-params.put("metric_type", "MAX_SIM_COSINE");
-SearchResp searchResp = client.search(SearchReq.builder()
-        .collectionName("my_collection")
-        .annsField("chunks[text_vector]")
-        .data(Collections.singletonList(embeddingList1))
-        .searchParams(params)
-        .limit(3)
-        .outputFields(Collections.singletonList("chunks[text]"))
-        .build());
-```
+- `element_filter` and `MATCH_*` are for scalar subfields inside StructArray fields. Use `$[subfield]` only inside these operators.
 
-```go
-// go
-```
-
-```javascript
-const embeddingList1 = [[0.2, 0.9, 0.4, -0.3, 0.2]];
-const embeddingList2 = [
-  [-0.2, -0.2, 0.5, 0.6, 0.9],
-  [-0.4, 0.3, 0.5, 0.8, 0.2],
-];
-const results = await milvusClient.search({
-  collection_name: "books",
-  data: embeddingList1,
-  anns_field: "chunks[text_vector]",
-  search_params: { metric_type: "MAX_SIM_COSINE" },
-  limit: 3,
-  output_fields: ["chunks[text]"],
-});
-
-```
-
-```bash
-# restful
-embeddingList1='[[0.2,0.9,0.4,-0.3,0.2]]'
-embeddingList2='[[-0.2,-0.2,0.5,0.6,0.9],[-0.4,0.3,0.5,0.8,0.2]]'
-curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"collectionName\": \"my_collection\",
-    \"data\": [$embeddingList1],
-    \"annsField\": \"chunks[text_vector]\",
-    \"searchParams\": {\"metric_type\": \"MAX_SIM_COSINE\"},
-    \"limit\": 3,
-    \"outputFields\": [\"chunks[text]\"]
-  }"
-```
-
-The above search request uses `chunks[text_vector]` to refer to the `text_vector` field in Struct elements. You can use this syntax to set the `anns_field` and `output_fields` parameters. 
-
-The output would be a list of the three most similar entities.
-
-<details>
-
-<summary>Output</summary>
-
-```python
-# [
-#     [
-#         {
-#             'id': 461417939772144945,
-#             'distance': 0.9675756096839905,
-#             'entity': {
-#                 'chunks': [
-#                     {'text': 'The world is too much with us; late and soon, getting and spending...'},
-#                     {'text': 'All happy families are alike; each unhappy family is unhappy in its own way.'}
-#                 ]
-#             }
-#         },
-#         {
-#             'id': 461417939772144965,
-#             'distance': 0.9555778503417969,
-#             'entity': {
-#                 'chunks': [
-#                     {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#                     {'text': 'He was an old man who fished alone in a skiff in the Gulf Stream...'},
-#                     {'text': 'When I wrote the following pages, or rather the bulk of them...'},
-#                     {'text': 'It was the best of times, it was the worst of times...'},
-#                     {'text': 'The world is too much with us; late and soon, getting and spending...'}
-#                 ]
-#             }
-#         },
-#         {
-#             'id': 461417939772144962,
-#             'distance': 0.9469035863876343,
-#             'entity': {
-#                 'chunks': [
-#                     {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#                     {'text': 'The world is too much with us; late and soon, getting and spending...'},
-#                     {'text': 'He was an old man who fished alone in a skiff in the Gulf Stream...'},
-#                     {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#                     {'text': 'The world is too much with us; late and soon, getting and spending...'}
-#                 ]
-#             }
-#         }
-#     ]
-# ]
-```
-
-</details>
-
-You can also include multiple embedding lists in the `data` parameter to retrieve search results for each of these embedding lists.
-
-<div class="multipleCode">
-    <a href="#python">Python</a>
-    <a href="#java">Java</a>
-    <a href="#go">Go</a>
-    <a href="#javascript">NodeJS</a>
-    <a href="#bash">cURL</a>
-</div>
-
-```python
-# a search with multiple embedding lists
-results = client.search(
-    collection_name="my_collection",
-    data=[ embeddingList1, embeddingList2 ],
-    anns_field="chunks[text_vector]",
-    search_params={"metric_type": "MAX_SIM_COSINE"},
-    limit=3,
-    output_fields=["chunks[text]"]
-)
-
-print(results)
-```
-
-```java
-Map<String, Object> params = new HashMap<>();
-params.put("metric_type", "MAX_SIM_COSINE");
-SearchResp searchResp = client.search(SearchReq.builder()
-        .collectionName("my_collection")
-        .annsField("chunks[text_vector]")
-        .data(Arrays.asList(embeddingList1, embeddingList2))
-        .searchParams(params)
-        .limit(3)
-        .outputFields(Collections.singletonList("chunks[text]"))
-        .build());
-        
-List<List<SearchResp.SearchResult>> searchResults = searchResp.getSearchResults();
-for (int i = 0; i < searchResults.size(); i++) {
-    System.out.println("Results of No." + i + " embedding list");
-    List<SearchResp.SearchResult> results = searchResults.get(i);
-    for (SearchResp.SearchResult result : results) {
-        System.out.println(result);
-    }
-}
-```
-
-```go
-// go
-```
-
-```javascript
-const results2 = await milvusClient.search({
-  collection_name: "books",
-  data: [embeddingList1, embeddingList2],
-  anns_field: "chunks[text_vector]",
-  search_params: { metric_type: "MAX_SIM_COSINE" },
-  limit: 3,
-  output_fields: ["chunks[text]"],
-});
-```
-
-```bash
-# restful
-curl -X POST "http://localhost:19530/v2/vectordb/entities/search" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"collectionName\": \"my_collection\",
-    \"data\": [$embeddingList1, $embeddingList2],
-    \"annsField\": \"chunks[text_vector]\",
-    \"searchParams\": {\"metric_type\": \"MAX_SIM_COSINE\"},
-    \"limit\": 3,
-    \"outputFields\": [\"chunks[text]\"]
-  }"
-```
-
-The output would be a list of the three most similar entities for each embedding list.
-
-<details>
-
-<summary>Output</summary>
-
-```python
-# [
-#   [
-#     {
-#       'id': 461417939772144945,
-#       'distance': 0.9675756096839905,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'The world is too much with us; late and soon, getting and spending...'},
-#           {'text': 'All happy families are alike; each unhappy family is unhappy in its own way.'}
-#         ]
-#       }
-#     },
-#     {
-#       'id': 461417939772144965,
-#       'distance': 0.9555778503417969,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#           {'text': 'He was an old man who fished alone in a skiff in the Gulf Stream...'},
-#           {'text': 'When I wrote the following pages, or rather the bulk of them...'},
-#           {'text': 'It was the best of times, it was the worst of times...'},
-#           {'text': 'The world is too much with us; late and soon, getting and spending...'}
-#         ]
-#       }
-#     },
-#     {
-#       'id': 461417939772144962,
-#       'distance': 0.9469035863876343,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#           {'text': 'The world is too much with us; late and soon, getting and spending...'},
-#           {'text': 'He was an old man who fished alone in a skiff in the Gulf Stream...'},
-#           {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'},
-#           {'text': 'The world is too much with us; late and soon, getting and spending...'}
-#         ]
-#       }
-#     }
-#   ],
-#   [
-#     {
-#       'id': 461417939772144663,
-#       'distance': 1.9761409759521484,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'It was the best of times, it was the worst of times...'},
-#           {'text': 'It is a truth universally acknowledged, that a single man in possession...'},
-#           {'text': 'Whether I shall turn out to be the hero of my own life, or whether that station...'},
-#           {'text': 'He was an old man who fished alone in a skiff in the Gulf Stream...'}
-#         ]
-#       }
-#     },
-#     {
-#       'id': 461417939772144692,
-#       'distance': 1.974656581878662,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'It is a truth universally acknowledged, that a single man in possession...'},
-#           {'text': 'Call me Ishmael. Some years ago—never mind how long precisely...'}
-#         ]
-#       }
-#     },
-#     {
-#       'id': 461417939772144662,
-#       'distance': 1.9406685829162598,
-#       'entity': {
-#         'chunks': [
-#           {'text': 'It is a truth universally acknowledged, that a single man in possession...'}
-#         ]
-#       }
-#     }
-#   ]
-# ]
-```
-
-</details>
-
-In the above code example, `embeddingList1` is an embedding list of one vector, while `embeddingList2` contains two vectors. Each triggers a separate search request and expects a list of top-K similar entities.
-
-## Scalar filtering in a StructArray field
-
-You can use **element filters** and **operators in the match family** to conduct scalar filtering against a scalar sub-field in a StructArray. For more details and examples on the two operator types above, refer to [Array of Structs Operators](struct-array-operators.md).
-
-### Element filters
-
-This is an entity-level filter that checks whether at least one element in the StructArray field of an entity satisfies the predicate. For example, the following element filter returns entities that contain at least one chunk that starts with "Red" in the `text` sub-field.
-
-```python
-element_filter(chunks, $[text] LIKE "Red%")
-```
-
-You can use almost all comparison, range, and arithmetic operators in the predicate, which is evaluated per element, and the logical operators can be used to combine multiple conditions on the same element. For details, refer to [Basic Operators](basic-operators.md).
-
-If multiple scalar-filtering expressions are present in a filtered search or a query request, place the element filter expression after all entity-level filter expressions, as shown below.
-
-```python
-# correct
-id > 0 && element_filter(chunks, $[x] > 1)
-
-# incorrect, resulting errors
-element_filter(chunks, $[x] > 1) && id > 0
-```
-
-### Match family operators
-
-The match family operators work over a StructArray field too. Instead of simply checking whether an element exists, you can determine how many elements (or what proportion) must satisfy an element predicate.
-
-- `MATCH_ANY(chunks, $[text] LIKE "Red%")`
-
-    This returns entities that contain at least one chunk that starts with "Red" in the `text` sub-field; semantically, this is equivalent to `element_filter`.
-
-- `MATCH_ALL(chunks, $[text] LIKE "Red%")`
-
-    This returns entities whose text sub-fields in all chunks start with "Red".
-
-- `MATCH_LEAST(chunks, $[text] LIKE "Red%", k)`
-
-    This returns entities that contain at least `k` chunks that start with "Red" in the `text` sub-field.
-
-- `MATCH_MOST(chunks, $[text] LIKE "Red%", k)`
-
-    This returns entities that contain at most `k` chunks that start with "Red" in the `text` sub-field.
-
-- `MATCH_EXACT(chunks, $[text] LIKE "Red%", k)`
-
-    This returns entities that contain exactly `k` chunks that start with "Red" in the `text` sub-field.
+- Some search combinations are version-gated or mode-specific. Check [StructArray Limits](structarray-limits.md) before relying on range search, grouping search, hybrid search, nullable fields, or dynamically added fields.
 
 ## Next steps
 
-The development of a native StructArray data type represents a major advancement in Milvus's capability to handle complex data structures. To better understand its use cases and maximize this new feature, you are encouraged to read [Schema Design Using an Array of Structs](best-practices-for-array-of-structs.md).
+1. To design a schema, read [Create a StructArray Field](create-structarray-field.md).
+
+2. To prepare data, read [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md).
+
+3. To choose indexes, read [Index StructArray Fields](index-structarray-fields.md).
+
+4. To search StructArray vector subfields, start with Basic Vector Search with StructArray.
+
+5. To filter StructArray scalar subfields, read [StructArray Operators](struct-array-operators.md) and Filtered Search with StructArray.

--- a/site/en/userGuide/schema/create-structarray-field.md
+++ b/site/en/userGuide/schema/create-structarray-field.md
@@ -1,0 +1,321 @@
+---
+id: create-structarray-field.md
+title: "Create a StructArray Field"
+summary: "Create a StructArray field when one entity needs to contain an ordered list of structured elements. A StructArray field is an Array field whose element type is Struct. Each Struct element follows the same schema and can contain scalar subfields, vector subfields, or both."
+---
+# Create a StructArray Field
+
+Create a StructArray field when one entity needs to contain an ordered list of structured elements. A StructArray field is an Array field whose element type is Struct. Each Struct element follows the same schema and can contain scalar subfields, vector subfields, or both.
+
+This page shows how to define a Struct schema, add it as a StructArray field, choose subfields for later search and filtering, and understand the schema rules that apply before you insert or index data.
+
+## Before you begin
+
+This page uses a collection named `tech_articles`. Each entity represents one technical article, and the `chunks` field stores chunk-level data as Struct elements.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `doc_id` | `INT64` | Primary key for the article. |
+| `title` | `VARCHAR` | Article title. |
+| `category` | `VARCHAR` | Article-level category. |
+| `title_vector` | `FLOAT_VECTOR` | Article-level vector field, used later in hybrid search examples. |
+| `chunks` | `ARRAY` | StructArray field that stores chunk-level text, metadata, and embeddings. |
+
+The `chunks` StructArray field contains the following subfields.
+
+| Subfield | Type | Purpose |
+| --- | --- | --- |
+| `text` | `VARCHAR` | Chunk text. |
+| `section` | `VARCHAR` | Section name, such as `index`, `search`, or `filter`. |
+| `page` | `INT64` | Page number or logical position of the chunk. |
+| `quality_score` | `FLOAT` | Chunk-level score used in scalar filtering and range examples. |
+| `has_code` | `BOOL` | Whether the chunk contains code. |
+| `emb_list_vector` | `FLOAT_VECTOR` | Vector subfield for EmbeddingList search with `MAX_SIM*` metrics. |
+| `emb` | `FLOAT_VECTOR` | Vector subfield for element-level search with regular vector metrics. |
+
+<div class="alert note">
+
+A vector field or vector subfield accepts only one index. If you need both EmbeddingList search and element-level search, define two separate vector subfields. In this example, `chunks[emb_list_vector]` is for EmbeddingList search, and `chunks[emb]` is for element-level search.
+
+</div>
+
+## Supported subfield data types
+
+A StructArray field stores one array value for each Struct subfield. When you define a Struct schema, choose subfield types from the supported scalar and vector families.
+
+| Struct subfield physical type | Support | Notes |
+| --- | --- | --- |
+| `Array` | Supported | Define the subfield as `DataType.BOOL`. |
+| `Array` | Supported | Define the subfield as `DataType.INT8`, `DataType.INT16`, `DataType.INT32`, or `DataType.INT64`. |
+| `Array` | Supported | Define the subfield as `DataType.FLOAT` or `DataType.DOUBLE`. |
+| `Array` | Supported | Define the subfield as `DataType.VARCHAR` and set `max_length`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.FLOAT_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.FLOAT16_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.BFLOAT16_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.INT8_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.BINARY_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Not supported | Sparse vector subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Use `VARCHAR`, not `String`. |
+| `Array` | Not supported | JSON subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Geometry subfields and GIS functions are not supported in StructArray fields. |
+| `Array` | Not supported | Text subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Timestamptz subfields and time-specific expressions are not supported in StructArray fields. |
+| Nested `Array`, `ArrayOfVector`, `Struct`, or `ArrayOfStruct` | Not supported | A StructArray field cannot contain nested arrays, nested vector arrays, nested Struct fields, or nested Array-of-Struct fields. |
+
+For version-specific support, nullable behavior, and other limits, see [StructArray Limits](structarray-limits.md).
+
+## Create a collection with a StructArray field
+
+To create a StructArray field, first define the Struct schema used by each element. Then add an Array field and set its element type to Struct.
+
+1. Create the collection schema.
+
+2. Add collection-level fields, such as the primary key and article-level fields.
+
+3. Create a Struct schema for elements stored inside the StructArray field.
+
+4. Add scalar and vector subfields to the Struct schema.
+
+5. Add an Array field with `element_type=DataType.STRUCT`.
+
+6. Set `struct_schema` to the Struct schema.
+
+7. Set `max_capacity` to limit how many Struct elements each entity can store in the field.
+
+```python
+from pymilvus import MilvusClient, DataType
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+schema = client.create_schema(
+    auto_id=False,
+    enable_dynamic_field=False,
+)
+
+# Collection-level fields.
+schema.add_field(
+    field_name="doc_id",
+    datatype=DataType.INT64,
+    is_primary=True,
+)
+schema.add_field(
+    field_name="title",
+    datatype=DataType.VARCHAR,
+    max_length=512,
+)
+schema.add_field(
+    field_name="category",
+    datatype=DataType.VARCHAR,
+    max_length=128,
+)
+schema.add_field(
+    field_name="title_vector",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=4,
+)
+
+# Struct schema used by each element in the StructArray field.
+chunk_schema = client.create_struct_field_schema()
+chunk_schema.add_field(
+    field_name="text",
+    datatype=DataType.VARCHAR,
+    max_length=65535,
+)
+chunk_schema.add_field(
+    field_name="section",
+    datatype=DataType.VARCHAR,
+    max_length=128,
+)
+chunk_schema.add_field(
+    field_name="page",
+    datatype=DataType.INT64,
+)
+chunk_schema.add_field(
+    field_name="quality_score",
+    datatype=DataType.FLOAT,
+)
+chunk_schema.add_field(
+    field_name="has_code",
+    datatype=DataType.BOOL,
+)
+
+# Vector subfield for EmbeddingList search.
+chunk_schema.add_field(
+    field_name="emb_list_vector",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=4,
+)
+
+# Vector subfield for element-level search.
+chunk_schema.add_field(
+    field_name="emb",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=4,
+)
+
+# Add the StructArray field.
+schema.add_field(
+    field_name="chunks",
+    datatype=DataType.ARRAY,
+    element_type=DataType.STRUCT,
+    struct_schema=chunk_schema,
+    max_capacity=1000,
+)
+
+client.create_collection(
+    collection_name="tech_articles",
+    schema=schema,
+)
+```
+
+## Understand StructArray field paths
+
+After you create a StructArray field, refer to its subfields with the `structArray[subfield]` path syntax. Use this syntax when you create indexes, search vector subfields, output subfields, or build scalar filters.
+
+| Path | Meaning | Common usage |
+| --- | --- | --- |
+| `chunks[text]` | The `text` subfield inside each Struct element. | Output field or scalar filtering. |
+| `chunks[section]` | The section label for each chunk. | Scalar filtering. |
+| `chunks[quality_score]` | The chunk-level quality score. | Scalar filtering or scalar index. |
+| `chunks[emb_list_vector]` | The vector subfield used as an embedding list. | EmbeddingList search with `MAX_SIM*`. |
+| `chunks[emb]` | The vector subfield used by each Struct element independently. | Element-level vector search. |
+
+## Make a StructArray field nullable
+
+Milvus v3.0.x supports nullable StructArray fields. A nullable StructArray field allows an entity to store `null` for the entire StructArray field.
+
+```python
+schema.add_field(
+    field_name="chunks",
+    datatype=DataType.ARRAY,
+    element_type=DataType.STRUCT,
+    struct_schema=chunk_schema,
+    max_capacity=1000,
+    nullable=True,
+)
+```
+
+<div class="alert note">
+
+Warning
+Nullable StructArray fields are available only in Milvus v3.0.x. For a nullable StructArray field, an entity can provide a valid StructArray value or set the whole field to `null`. When inserting a valid StructArray value, all subfields should either be null or have valid values. Inserting an entity with some subfields set to null and others set to valid values results in an error. For details, see [StructArray Limits](structarray-limits.md).
+
+</div>
+
+## Add a StructArray field to an existing collection
+
+Milvus v3.0.x supports adding a StructArray field to an existing collection. The added StructArray field must be nullable, because entities that already exist in the collection do not have values for the new field.
+
+To add a StructArray field to an existing collection, define the Struct schema first. Then call `add_collection_struct_field()` and set `nullable=True`.
+
+```python
+chunk_schema = client.create_struct_field_schema()
+chunk_schema.add_field(
+    field_name="text",
+    datatype=DataType.VARCHAR,
+    max_length=65535,
+)
+chunk_schema.add_field(
+    field_name="section",
+    datatype=DataType.VARCHAR,
+    max_length=128,
+)
+chunk_schema.add_field(
+    field_name="page",
+    datatype=DataType.INT64,
+)
+chunk_schema.add_field(
+    field_name="quality_score",
+    datatype=DataType.FLOAT,
+)
+chunk_schema.add_field(
+    field_name="has_code",
+    datatype=DataType.BOOL,
+)
+chunk_schema.add_field(
+    field_name="emb_list_vector",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=4,
+)
+chunk_schema.add_field(
+    field_name="emb",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=4,
+)
+
+client.add_collection_struct_field(
+    collection_name="tech_articles",
+    field_name="chunks",
+    struct_schema=chunk_schema,
+    max_capacity=1000,
+    nullable=True,
+)
+```
+
+After the StructArray field is added, existing entities return `null` for the new field across all its subfields.
+
+After a StructArray field is created, you cannot add new subfields to that existing StructArray field. If you need additional element attributes later, call `drop_collection_field()` to drop the StructArray field, and then add a new StructArray field with the updated Struct schema.
+
+```python
+client.drop_collection_field(
+    collection_name="tech_articles",
+    field_name="chunks",
+)
+
+client.add_collection_struct_field(
+    collection_name="tech_articles",
+    field_name="chunks",
+    struct_schema=updated_chunk_schema,
+    max_capacity=1000,
+    nullable=True,
+)
+```
+
+## Schema rules
+
+| Rule | Explanation |
+| --- | --- |
+| Struct is used as an Array element type. | Create a StructArray field as an Array field with `element_type=STRUCT`. Do not create Struct as a top-level collection field. |
+| All elements share one schema. | Every Struct element in the same StructArray field follows the Struct schema defined for that field. |
+| `max_capacity` is required. | It limits how many Struct elements each entity can store in the StructArray field. |
+| Only supported subfield types are allowed. | Use scalar and vector subfield types supported by StructArray. Do not define JSON, Geometry, Text, Timestamptz, SparseFloatVector, or nested Struct / Array subfields. |
+| Vector subfields need indexes before search. | Create indexes on paths such as `chunks[emb_list_vector]` or `chunks[emb]` before running vector search. |
+| One vector subfield has one index. | If you need both EmbeddingList search and element-level search, create two separate vector subfields. |
+| Existing StructArray subfields are fixed. | After creating a StructArray field, do not expect to add more subfields to that same StructArray field. |
+| Functions are not supported inside Struct. | Do not define functions for fields or subfields inside a StructArray field. |
+| Scalar subfields should match filter needs. | Add fields such as `section`, `quality_score`, or `has_code` only when you need to filter, group, or output them later. |
+
+## Common mistakes
+
+- Creating `DataType.STRUCT` as a top-level collection field instead of using it as the element type of an Array field.
+
+- Forgetting to set `max_capacity` on the StructArray field.
+
+- Defining unsupported subfield types, such as JSON, Geometry, Text, Timestamptz, SparseFloatVector, nested Array, nested Struct, or Array-of-Struct.
+
+- Using `String` as a subfield type. Use `VARCHAR` and set `max_length`.
+
+- Using one vector subfield for both EmbeddingList search and element-level search.
+
+- Adding only vector subfields and forgetting scalar subfields needed for filtering, such as `section`, `quality_score`, or `has_code`.
+
+- Treating vector subfields as `$[...]` scalar predicate inputs. Use vector subfields for vector search, and scalar subfields for scalar predicates.
+
+- Assuming new subfields can be added to an existing StructArray field after the field is created.
+
+- Using `chunks.emb` or `chunks.emb_list_vector` instead of the required path syntax `chunks[emb]` or `chunks[emb_list_vector]`.
+
+- Treating nullable StructArray behavior as available in every target version.
+
+## Next steps
+
+1. To insert nested data into the StructArray field, read [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md).
+
+2. To create vector and scalar indexes, read [Index StructArray Fields](index-structarray-fields.md).
+
+3. To search StructArray vector subfields, read Basic Vector Search with StructArray.
+
+4. To review supported data types, nullable behavior, and version-specific limitations, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/schema/index-structarray-fields.md
+++ b/site/en/userGuide/schema/index-structarray-fields.md
@@ -1,0 +1,218 @@
+---
+id: index-structarray-fields.md
+title: "Index StructArray Fields"
+summary: "Create indexes on StructArray subfields before you run vector search or accelerate scalar filtering. For a StructArray field, the index target is a subfield path, such as chunks[emb_list_vector], chunks[emb], or chunks[section]."
+---
+# Index StructArray Fields
+
+Create indexes on StructArray subfields before you run vector search or accelerate scalar filtering. For a StructArray field, the index target is a subfield path, such as `chunks[emb_list_vector]`, `chunks[emb]`, or `chunks[section]`.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The `chunks` StructArray field contains scalar subfields for filtering and vector subfields for search.
+
+## Before you begin
+
+Make sure the collection schema already contains the `chunks` StructArray field and data has been inserted.
+
+| Subfield path | Type | Index purpose |
+| --- | --- | --- |
+| `chunks[emb_list_vector]` | `FLOAT_VECTOR` | EmbeddingList search with `MAX_SIM*` metrics. |
+| `chunks[emb]` | `FLOAT_VECTOR` | Element-level search with regular vector metrics. |
+| `chunks[section]` | `VARCHAR` | Categorical filtering. |
+| `chunks[quality_score]` | `FLOAT` | Numeric filtering and range-style predicates. |
+| `chunks[has_code]` | `BOOL` | Boolean filtering. |
+
+<div class="alert note">
+
+A vector field or vector subfield accepts only one index. If you need both EmbeddingList search and element-level search, create two separate vector subfields and index them separately. In this page, `chunks[emb_list_vector]` is indexed for EmbeddingList search, and `chunks[emb]` is indexed for element-level search.
+
+</div>
+
+## Choose indexes
+
+Use the search mode to choose the vector metric family.
+
+| Search or filter goal | Target path | What to choose |
+| --- | --- | --- |
+| EmbeddingList search | `chunks[emb_list_vector]` | A `MAX_SIM*` metric family. |
+| Element-level vector search | `chunks[emb]` | A regular vector metric family, such as `COSINE`, `IP`, or `L2`. |
+| Filter by string or category | `chunks[section]` | A scalar index supported by your target. |
+| Filter by numeric range | `chunks[quality_score]`, `chunks[page]` | A scalar index supported by your target. |
+| Filter by boolean value | `chunks[has_code]` | A scalar index supported by your target. |
+
+EmbeddingList search treats the vectors in a StructArray vector subfield as an embedding list and returns entity-level results. Element-level search searches each Struct element independently and can return the matched element offset.
+
+## Create vector indexes
+
+The following example creates two vector indexes. The first index uses a `MAX_SIM*` metric for EmbeddingList search. The second index uses a regular vector metric for element-level search.
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+index_params = client.prepare_index_params()
+
+# Index for EmbeddingList search.
+index_params.add_index(
+    field_name="chunks[emb_list_vector]",
+    index_name="chunks_emb_list_max_sim",
+    index_type="HNSW",
+    metric_type="MAX_SIM_COSINE",
+    params={
+        "M": 16,
+        "efConstruction": 200,
+    },
+)
+
+# Index for element-level search.
+index_params.add_index(
+    field_name="chunks[emb]",
+    index_name="chunks_emb_cosine",
+    index_type="HNSW",
+    metric_type="COSINE",
+    params={
+        "M": 16,
+        "efConstruction": 200,
+    },
+)
+
+client.create_index(
+    collection_name="tech_articles",
+    index_params=index_params,
+)
+```
+
+<div class="alert note">
+
+Warning
+Do not create a `MAX_SIM*` index and a regular vector-metric index on the same vector subfield. If both search modes are required, write vectors to two separate vector subfields and create one index on each subfield.
+
+</div>
+
+## Create scalar indexes
+
+Create scalar indexes on StructArray scalar subfields when you use them in filters. Use the same `structArray[subfield]` path syntax.
+
+```python
+index_params = client.prepare_index_params()
+
+index_params.add_index(
+    field_name="chunks[section]",
+    index_name="chunks_section_inverted",
+    index_type="INVERTED",
+)
+
+index_params.add_index(
+    field_name="chunks[has_code]",
+    index_name="chunks_has_code_inverted",
+    index_type="INVERTED",
+)
+
+index_params.add_index(
+    field_name="chunks[quality_score]",
+    index_name="chunks_quality_score_sort",
+    index_type="STL_SORT",
+)
+
+index_params.add_index(
+    field_name="chunks[page]",
+    index_name="chunks_page_sort",
+    index_type="STL_SORT",
+)
+
+client.create_index(
+    collection_name="tech_articles",
+    index_params=index_params,
+)
+```
+
+Scalar indexes are optional but useful when StructArray scalar subfields appear frequently in filters, such as `element_filter(chunks, $[quality_score] > 0.9)` or `MATCH_ANY(chunks, $[section] == "index")`.
+
+## Index metric compatibility
+
+Use the following tables to choose an index type and metric type for a StructArray vector subfield. Start from the target, then choose the metric family by search mode.
+
+Choose a Milvus index type and metric type from the following compatibility tables.
+
+### EmbeddingList search
+
+EmbeddingList search uses `MAX_SIM*` metrics. It treats the vectors in a StructArray vector subfield as an embedding list and returns entity-level results.
+
+| Vector subfield data type | Index type | Metric type |
+| --- | --- | --- |
+| `FLOAT_VECTOR`, `FLOAT16_VECTOR`, `BFLOAT16_VECTOR` | `IVF_FLAT`, `IVF_FLAT_CC`, `HNSW`, `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `DISKANN` | `MAX_SIM`, `MAX_SIM_COSINE`, `MAX_SIM_IP`, `MAX_SIM_L2` |
+| `INT8_VECTOR` | `HNSW`, `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ` | `MAX_SIM`, `MAX_SIM_COSINE`, `MAX_SIM_IP`, `MAX_SIM_L2` |
+| `BINARY_VECTOR` | `HNSW` | `MAX_SIM_HAMMING`, `MAX_SIM_JACCARD` |
+
+### Element-level search
+
+Element-level search uses regular vector metrics. It searches each Struct element independently and can return the matched element offset.
+
+| Vector subfield data type | Index type | Metric type |
+| --- | --- | --- |
+| `FLOAT_VECTOR`, `FLOAT16_VECTOR`, `BFLOAT16_VECTOR` | `FLAT`, `IVF_FLAT`, `IVF_FLAT_CC`, `IVF_SQ8`, `IVF_SQ_CC`, `IVF_PQ`, `SCANN`, `IVF_RABITQ`, `IVF_RABITQ_FASTSCAN`, `HNSW`, `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `DISKANN` | `L2`, `IP`, `COSINE` |
+| `INT8_VECTOR` | `HNSW`, `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ` | `L2`, `IP`, `COSINE` |
+| `BINARY_VECTOR` | `HNSW` | `HAMMING`, `JACCARD` |
+| `BINARY_VECTOR` | `BIN_FLAT` | `HAMMING`, `JACCARD`, `SUBSTRUCTURE`, `SUPERSTRUCTURE`, `MHJACCARD` |
+| `BINARY_VECTOR` | `BIN_IVF_FLAT` | `HAMMING`, `JACCARD` |
+
+For version-specific support and other limits, see [StructArray Limits](structarray-limits.md).
+
+## Verify indexes
+
+After creating indexes, describe the collection or list indexes to confirm that the expected subfield paths are indexed.
+
+```python
+indexes = client.list_indexes(
+    collection_name="tech_articles",
+)
+
+print(indexes)
+```
+
+You can also describe a specific index if your SDK version exposes index-description APIs.
+
+```python
+index = client.describe_index(
+    collection_name="tech_articles",
+    index_name="chunks_emb_cosine",
+)
+
+print(index)
+```
+
+## Index rules
+
+| Rule | Explanation |
+| --- | --- |
+| Use path syntax for subfield indexes. | Index `chunks[emb]`, not `emb` or `chunks.emb`. |
+| One vector subfield accepts one index. | Use separate vector subfields if you need different metric families. |
+| Use `MAX_SIM*` metrics for EmbeddingList search. | EmbeddingList query data requires an index built with a `MAX_SIM*` metric. |
+| Use regular vector metrics for element-level search. | Element-level search uses regular vector query data and metrics such as `COSINE`, `IP`, or `L2`. |
+| Index scalar subfields that appear in filters. | Use scalar index types supported by your target. |
+| Keep vector-field limits in mind. | The total number of vector fields and vector subfields is limited. See StructArray Limits before adding many vector subfields. |
+
+## Common mistakes
+
+- Creating an index on `chunks.emb` instead of `chunks[emb]`.
+
+- Creating only a `MAX_SIM*` index and then trying to run element-level search on the same subfield.
+
+- Creating only a regular vector index and then trying to run EmbeddingList search on the same subfield.
+
+- Reusing one vector subfield for both `MAX_SIM*` and regular vector metrics.
+
+- Forgetting scalar indexes for heavily used StructArray filters.
+
+- Indexing a StructArray subfield that does not exist in the Struct schema.
+
+## Next steps
+
+1. To run entity-level EmbeddingList search or element-level vector search, read Basic Vector Search with StructArray.
+
+2. To filter StructArray scalar subfields during search, read Filtered Search with StructArray.
+
+3. To review index and metric limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/schema/insert-data-into-structarray-fields.md
+++ b/site/en/userGuide/schema/insert-data-into-structarray-fields.md
@@ -1,0 +1,254 @@
+---
+id: insert-data-into-structarray-fields.md
+title: "Insert Data into StructArray Fields"
+summary: "Insert data into a StructArray field when each entity contains an ordered list of structured elements. In the insert payload, a StructArray field is represented as an array of objects. Each object represents one Struct element and uses the Struct subfield names defined in the collection schema."
+---
+# Insert Data into StructArray Fields
+
+Insert data into a StructArray field when each entity contains an ordered list of structured elements. In the insert payload, a StructArray field is represented as an array of objects. Each object represents one Struct element and uses the Struct subfield names defined in the collection schema.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). Each entity is a technical article, and the `chunks` field stores article chunks as Struct elements.
+
+## Before you begin
+
+Make sure the collection schema already contains the `chunks` StructArray field.
+
+| Field | Type | Insert value |
+| --- | --- | --- |
+| `doc_id` | `INT64` | Article ID. |
+| `title` | `VARCHAR` | Article title. |
+| `category` | `VARCHAR` | Article category. |
+| `title_vector` | `FLOAT_VECTOR` | Article-level embedding. |
+| `chunks` | `ARRAY` | A list of chunk objects. |
+
+Each object in `chunks` must follow the Struct schema.
+
+| Subfield | Type | Insert value |
+| --- | --- | --- |
+| `text` | `VARCHAR` | Chunk text. |
+| `section` | `VARCHAR` | Section name, such as `index`, `search`, or `filter`. |
+| `page` | `INT64` | Page number or logical position. |
+| `quality_score` | `FLOAT` | Chunk-level score. |
+| `has_code` | `BOOL` | Whether the chunk contains code. |
+| `emb_list_vector` | `FLOAT_VECTOR` | Vector written for EmbeddingList search. |
+| `emb` | `FLOAT_VECTOR` | Vector written for element-level search. |
+
+<div class="alert note">
+
+In an insert payload, `chunks` is a regular field whose value is an array of Struct objects. Inside each object, use subfield names such as `text` and `emb`. Use path syntax, such as `chunks[text]` or `chunks[emb]`, only after insertion when you create indexes, run searches, build filters, or specify output fields.
+
+</div>
+
+## Understand the insert payload shape
+
+The `chunks` value is an array of Struct elements. Each element is an object whose keys are subfield names.
+
+```json
+{
+  "doc_id": 1,
+  "title": "StructArray indexing patterns",
+  "category": "index",
+  "title_vector": [0.12, 0.08, 0.32, 0.48],
+  "chunks": [
+    {
+      "text": "Create one index for each vector subfield.",
+      "section": "index",
+      "page": 1,
+      "quality_score": 0.96,
+      "has_code": false,
+      "emb_list_vector": [0.10, 0.20, 0.30, 0.40],
+      "emb": [0.10, 0.20, 0.30, 0.40]
+    },
+    {
+      "text": "Use MAX_SIM metrics for EmbeddingList search.",
+      "section": "index",
+      "page": 2,
+      "quality_score": 0.91,
+      "has_code": true,
+      "emb_list_vector": [0.16, 0.24, 0.35, 0.45],
+      "emb": [0.16, 0.24, 0.35, 0.45]
+    }
+  ]
+}
+```
+
+`emb_list_vector` and `emb` are separate vector subfields because they support different search modes. EmbeddingList search treats all vectors in a StructArray field as one embedding list and returns entity-level results with `MAX_SIM*` metrics. Element-level search searches each Struct element independently and can return the matched element offset. This example stores the same vector values in both fields for simplicity. In a production application, you can store the same embeddings in both subfields when both search modes use the same chunk embedding, or store different embeddings when the two search modes use different representations.
+
+## Insert rows
+
+Use `client.insert()` to insert rows that contain StructArray values.
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+data = [
+    {
+        "doc_id": 1,
+        "title": "StructArray indexing patterns",
+        "category": "index",
+        "title_vector": [0.12, 0.08, 0.32, 0.48],
+        "chunks": [
+            {
+                "text": "Create one index for each vector subfield.",
+                "section": "index",
+                "page": 1,
+                "quality_score": 0.96,
+                "has_code": False,
+                "emb_list_vector": [0.10, 0.20, 0.30, 0.40],
+                "emb": [0.10, 0.20, 0.30, 0.40],
+            },
+            {
+                "text": "Use MAX_SIM metrics for EmbeddingList search.",
+                "section": "index",
+                "page": 2,
+                "quality_score": 0.91,
+                "has_code": True,
+                "emb_list_vector": [0.16, 0.24, 0.35, 0.45],
+                "emb": [0.16, 0.24, 0.35, 0.45],
+            },
+        ],
+    },
+    {
+        "doc_id": 2,
+        "title": "Filtered StructArray search",
+        "category": "filter",
+        "title_vector": [0.20, 0.18, 0.22, 0.40],
+        "chunks": [
+            {
+                "text": "Use element_filter to match scalar conditions within the same Struct element.",
+                "section": "filter",
+                "page": 1,
+                "quality_score": 0.93,
+                "has_code": True,
+                "emb_list_vector": [0.21, 0.18, 0.33, 0.44],
+                "emb": [0.21, 0.18, 0.33, 0.44],
+            },
+            {
+                "text": "MATCH_LEAST checks how many elements satisfy a predicate.",
+                "section": "filter",
+                "page": 2,
+                "quality_score": 0.88,
+                "has_code": False,
+                "emb_list_vector": [0.24, 0.22, 0.31, 0.39],
+                "emb": [0.24, 0.22, 0.31, 0.39],
+            },
+        ],
+    },
+    {
+        "doc_id": 3,
+        "title": "Element-level search with offsets",
+        "category": "search",
+        "title_vector": [0.33, 0.11, 0.29, 0.37],
+        "chunks": [
+            {
+                "text": "Element-level search can return the offset of the matched Struct element.",
+                "section": "search",
+                "page": 1,
+                "quality_score": 0.95,
+                "has_code": False,
+                "emb_list_vector": [0.32, 0.14, 0.28, 0.41],
+                "emb": [0.32, 0.14, 0.28, 0.41],
+            }
+        ],
+    },
+]
+
+result = client.insert(
+    collection_name="tech_articles",
+    data=data,
+)
+
+print(result)
+```
+
+## Insert into nullable StructArray fields
+
+If the `chunks` field is nullable, an entity can set the entire `chunks` field to null. In Python, use `None` to represent a null value.
+
+```python
+client.insert(
+    collection_name="tech_articles",
+    data=[
+        {
+            "doc_id": 10,
+            "title": "Article without chunks yet",
+            "category": "draft",
+            "title_vector": [0.05, 0.10, 0.15, 0.20],
+            "chunks": None,
+        }
+    ],
+)
+```
+
+When a nullable StructArray field contains a valid StructArray value, all subfields in that value should either be null or have valid values. Inserting an entity with some subfields set to null and others set to valid values results in an error.
+
+<div class="alert note">
+
+Warning
+Nullable StructArray fields are available only in Milvus v3.0.x. If you dynamically add a StructArray field to an existing collection, the added field must be nullable, and existing entities return `null` for the new field across all its subfields.
+
+</div>
+
+## Validate inserted data
+
+You can query the collection and return the StructArray field or selected subfields.
+
+```python
+rows = client.query(
+    collection_name="tech_articles",
+    filter="doc_id in [1, 2, 3]",
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+
+for row in rows:
+    print(row)
+```
+
+Use StructArray field paths, such as `chunks[text]`, only when you query, search, filter, or create indexes. Insert payloads should still use nested objects under `chunks`.
+
+## Insert rules
+
+| Rule | Explanation |
+| --- | --- |
+| Use an array of objects for a StructArray field. | The value of `chunks` is a list, and each item in the list is a Struct element. |
+| Use subfield names inside each Struct element. | Insert `{"text": "...", "emb": [...]}` inside `chunks`, not `{"chunks[text]": "..."}`. |
+| Match the Struct schema. | Each Struct element must use the subfields defined in the Struct schema. |
+| Match vector dimensions. | Vector values must match the `dim` configured for their vector subfields. |
+| Respect `max_capacity`. | The number of Struct elements in one entity must not exceed the `max_capacity` of the StructArray field. |
+| Use separate vector subfields for separate search modes. | If both EmbeddingList search and element-level search are required, write vector values to both vector subfields. |
+| Use `null` only when the field is nullable. | Non-nullable StructArray fields require valid StructArray values. |
+
+## Common mistakes
+
+- Using field paths such as `chunks[text]` in insert payloads.
+
+- Omitting required subfields from a Struct element.
+
+- Inserting vectors with the wrong dimension.
+
+- Inserting more Struct elements than `max_capacity` allows.
+
+- Setting only one subfield to `null` while other subfields in the same StructArray value are valid.
+
+- Writing vectors only to `emb_list_vector` and then trying to run element-level search on `chunks[emb]`.
+
+- Writing vectors only to `emb` and then trying to run EmbeddingList search on `chunks[emb_list_vector]`.
+
+## Next steps
+
+1. To create indexes for `chunks[emb_list_vector]`, `chunks[emb]`, and scalar subfields, read [Index StructArray Fields](index-structarray-fields.md).
+
+2. To search StructArray vector subfields, read Basic Vector Search with StructArray.
+
+3. To review nullable behavior and version-specific limitations, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/schema/structarray-limits.md
+++ b/site/en/userGuide/schema/structarray-limits.md
@@ -1,0 +1,142 @@
+---
+id: structarray-limits.md
+title: "StructArray Limits"
+summary: "StructArray support spans schema definition, insert payloads, indexing, search modes, and StructArray-specific filters. Use this page as the limits reference before you rely on StructArray behavior in production."
+---
+# StructArray Limits
+
+StructArray support spans schema definition, insert payloads, indexing, search modes, and StructArray-specific filters. Use this page as the limits reference before you rely on StructArray behavior in production.
+
+Most StructArray limits come from one of three places: the StructArray schema model, the search mode you choose for vector subfields, and the Milvus version that your collection runs on.
+
+## Limits at a glance
+
+| Area | Limit |
+| --- | --- |
+| Schema shape | A Struct can be used only as the element type of an Array field. Struct is not supported as a top-level collection field. |
+| Subfield schema | All Struct elements in the same StructArray field share one predefined Struct schema. |
+| Capacity | `max_capacity` is required and limits how many Struct elements one entity can store in the StructArray field. |
+| Subfield changes | After a StructArray field is created, you cannot add subfields to that existing StructArray field. |
+| Subfield path | Use `structArray[subfield]` paths, such as `chunks[emb]`, for indexes, search targets, output fields, and filters. Do not use `chunks.emb`. |
+| Insert shape | Insert a StructArray field as an array of objects. Do not use path syntax inside insert payloads. |
+| Vector indexes | A vector field or vector subfield accepts only one index. Use separate vector subfields for EmbeddingList search and element-level search. |
+| Functions | Field functions are not supported for fields or subfields inside a StructArray field. |
+| Nullable fields | Nullable StructArray fields are version-gated. When supported, null applies to the whole StructArray field, not to an individual Struct element independently. |
+| Dynamic add field | Adding a StructArray field to an existing collection is version-gated and requires the added field to be nullable. |
+
+## Schema limits
+
+| Limit | Details |
+| --- | --- |
+| Struct is not a top-level field type. | Create a StructArray field as `datatype=DataType.ARRAY` with `element_type=DataType.STRUCT` and a `struct_schema`. |
+| All elements share one schema. | Every Struct element in a StructArray field follows the same subfield list and subfield data types. |
+| `max_capacity` is required. | The number of Struct elements in one entity must not exceed the `max_capacity` configured for the StructArray field. |
+| Existing subfields are fixed. | You cannot append new subfields to an existing StructArray field. To change the subfield schema, drop the StructArray field and add it again with the updated schema. |
+| Nested StructArray is not supported. | A StructArray field cannot contain nested `Array`, `ArrayOfVector`, `Struct`, or `ArrayOfStruct` subfields. |
+| Functions are not supported inside StructArray. | Do not define field functions for StructArray fields or their subfields. |
+
+For schema creation examples, see [Create a StructArray Field](create-structarray-field.md).
+
+## Supported subfield data types
+
+StructArray subfields map to physical array-style storage. The following table lists supported and unsupported physical types.
+
+| Struct subfield physical type | Support | Notes |
+| --- | --- | --- |
+| `Array` | Supported | Define the subfield as `DataType.BOOL`. |
+| `Array` | Supported | Define the subfield as `DataType.INT8`, `DataType.INT16`, `DataType.INT32`, or `DataType.INT64`. |
+| `Array` | Supported | Define the subfield as `DataType.FLOAT` or `DataType.DOUBLE`. |
+| `Array` | Supported | Define the subfield as `DataType.VARCHAR` and set `max_length`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.FLOAT_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.FLOAT16_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.BFLOAT16_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.INT8_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Supported | Define the subfield as `DataType.BINARY_VECTOR` and set `dim`. |
+| `ArrayOfVector` | Not supported | Sparse vector subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Use `VARCHAR`, not `String`. |
+| `Array` | Not supported | JSON subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Geometry subfields and GIS functions are not supported in StructArray fields. |
+| `Array` | Not supported | Text subfields are not supported in StructArray fields. |
+| `Array` | Not supported | Timestamptz subfields and time-specific expressions are not supported in StructArray fields. |
+| Nested `Array`, `ArrayOfVector`, `Struct`, or `ArrayOfStruct` | Not supported | StructArray fields do not support nested array, vector-array, Struct, or Array-of-Struct subfields. |
+
+## Nullable and dynamic schema limits
+
+Nullable StructArray behavior and dynamic StructArray field addition are version-gated.
+
+| Capability | Limit |
+| --- | --- |
+| Nullable StructArray field | Supported only in versions that include nullable StructArray and nullable vector-array support. |
+| Null value in Python | Use `None` to insert a null StructArray value in Python. Do not use `Null` or `null`. |
+| Null scope | Null applies to the whole StructArray field. For example, `chunks=None` is valid only when `chunks` is nullable. |
+| Partially null StructArray value | When a StructArray field contains a valid array value, do not mix null subfield arrays with valid subfield arrays in the same value. |
+| Dynamic add StructArray field | Adding a StructArray field to an existing collection is supported only in versions that include dynamic StructArray field support. |
+| Nullable requirement for dynamic add | A StructArray field added to an existing collection must be nullable because existing entities have no value for the new field. |
+| Existing entities after dynamic add | Existing entities return `null` for the added StructArray field across its subfields. |
+
+In Milvus v3.0.x, nullable StructArray fields, nullable vector arrays, and dynamic StructArray field addition are available.
+
+For insert examples with nullable StructArray fields, see [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md).
+
+## Insert limits
+
+| Limit | Details |
+| --- | --- |
+| Payload shape | Insert the StructArray field as an array of Struct objects, such as `chunks: [{"text": "...", "emb": [...]}]`. |
+| Subfield names | Inside each Struct object, use subfield names such as `text` and `emb`, not paths such as `chunks[text]`. |
+| Schema alignment | Each Struct element must match the Struct schema. |
+| Capacity | The number of Struct elements in one entity must not exceed `max_capacity`. |
+| Vector dimensions | Vector values must match the `dim` configured for their vector subfields. |
+| Search-mode duplication | If you need both EmbeddingList search and element-level search, write vectors to two separate vector subfields. |
+
+## Index and metric limits
+
+A StructArray vector subfield can be indexed for either EmbeddingList search or element-level search. The same vector subfield cannot use both metric families because each vector field or vector subfield accepts only one index.
+
+| Search mode | Metric family | Result level |
+| --- | --- | --- |
+| EmbeddingList search | `MAX_SIM`, `MAX_SIM_COSINE`, `MAX_SIM_IP`, `MAX_SIM_L2`, or binary `MAX_SIM_*` metrics | Entity-level results. |
+| Element-level search | Regular vector metrics such as `L2`, `IP`, `COSINE`, `HAMMING`, or `JACCARD` | Element-level results that can include the matched element offset. |
+
+Use separate vector subfields when both modes are required. For example, use `chunks[emb_list_vector]` for EmbeddingList search and `chunks[emb]` for element-level search.
+
+StructArray vector subfields count as vector subfields when you plan your collection schema. Keep the total number of vector fields and vector subfields within the limits of your target version and service tier.
+
+For the supported index-type and metric-type matrix, see [Index StructArray Fields](index-structarray-fields.md).
+
+## Search limits
+
+| Search behavior | Support and limits |
+| --- | --- |
+| Basic EmbeddingList search | Supported on StructArray vector subfields indexed with `MAX_SIM*` metrics. Returns entity-level results. |
+| Basic element-level search | Supported on StructArray vector subfields indexed with regular vector metrics. Can return matched element offsets. |
+| Range search | Supported according to the search mode and index/metric support of the target version. For hybrid search range behavior on element-level StructArray requests, check your target version. |
+| Grouping search | Element-level grouping search can return offsets. Hybrid search group-by behavior for element-level StructArray requests is version-gated. |
+| Hybrid search | A hybrid search request can include StructArray vector subfield requests only where the target version supports that search combination. Each request still follows the metric family of the indexed vector subfield. |
+| Offset output | Offset is available for element-level search results. EmbeddingList search returns entity-level results and does not use element offsets as the primary result unit. |
+
+## Filter and operator limits
+
+StructArray scalar filtering is handled by StructArray operators, such as `element_filter` and the `MATCH_*` family. The detailed predicate support matrix belongs in [StructArray Operators](struct-array-operators.md).
+
+At a high level:
+
+- Use `$[subfield]` only inside StructArray operators.
+
+- Use scalar subfields for scalar predicates.
+
+- Do not use vector subfields as `$[...]` scalar predicate inputs.
+
+- JSON path syntax, JSON functions, array container functions, text match functions, Geometry / GIS functions, and Timestamptz expressions are not supported for StructArray element-level predicates.
+
+- Prefer explicit boolean comparisons such as `$[has_code] == true` instead of bare boolean expressions.
+
+## Related pages
+
+1. To create a StructArray field, read [Create a StructArray Field](create-structarray-field.md).
+
+2. To insert data, read [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md).
+
+3. To create vector and scalar indexes, read [Index StructArray Fields](index-structarray-fields.md).
+
+4. To review StructArray filter syntax, read [StructArray Operators](struct-array-operators.md).

--- a/site/en/userGuide/search-query-get/basic-vector-search-with-structarray.md
+++ b/site/en/userGuide/search-query-get/basic-vector-search-with-structarray.md
@@ -1,0 +1,155 @@
+---
+id: basic-vector-search-with-structarray.md
+title: "Basic Vector Search with StructArray"
+summary: "Use this page to run vector search on vector subfields inside a StructArray field. StructArray supports two basic vector search modes: EmbeddingList search, which scores an embedding list stored in each entity, and element-level search, which searches each Struct element independently."
+---
+# Basic Vector Search with StructArray
+
+Use this page to run vector search on vector subfields inside a StructArray field. StructArray supports two basic vector search modes: EmbeddingList search, which scores an embedding list stored in each entity, and element-level search, which searches each Struct element independently.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The collection has a StructArray field named `chunks`. Each chunk contains text, scalar metadata, a vector subfield named `emb_list_vector` with an index for EmbeddingList search, and a vector subfield named `emb` with an index for element-level search.
+
+## Before you begin
+
+Make sure the collection schema, data, and indexes are already prepared.
+
+| Requirement | Where to prepare it |
+| --- | --- |
+| Create a StructArray field, such as `chunks`. | [Create a StructArray Field](create-structarray-field.md) |
+| Insert entities whose `chunks` field contains Struct objects. | [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md) |
+| Create a `MAX_SIM*` index on `chunks[emb_list_vector]` for EmbeddingList search. | [Index StructArray Fields](index-structarray-fields.md) |
+| Create a regular vector-metric index on `chunks[emb]` for element-level search. | [Index StructArray Fields](index-structarray-fields.md) |
+
+<div class="alert note">
+
+Warning
+
+A vector field or vector subfield accepts only one index. If you need both EmbeddingList search and element-level search, create two separate vector subfields. In this page, `chunks[emb_list_vector]` is indexed for EmbeddingList search, and `chunks[emb]` is indexed for element-level search.
+
+</div>
+
+## Choose a search mode
+
+| Aspect | EmbeddingList search | Element-level search |
+| --- | --- | --- |
+| Target subfield | `chunks[emb_list_vector]` | `chunks[emb]` |
+| Query data | An embedding list that contains one or more vectors. | A regular vector. |
+| Metric family | `MAX_SIM*`, such as `MAX_SIM_COSINE`. | Regular vector metrics, such as `COSINE`, `IP`, or `L2`. |
+| What one hit represents | A matched entity whose StructArray vector subfield is similar to the query embedding list. | A matched Struct element inside the StructArray field. |
+| Result granularity | Entity level. | Struct element level. |
+| Offset | Not applicable. | Identifies the zero-based position of the matched Struct element when returned. |
+| Typical use | ColBERT, ColPali, and other late-interaction retrieval patterns. | Chunk-level, passage-level, clip-level, patch-level, or fact-level retrieval. |
+
+## Run EmbeddingList search
+
+Use EmbeddingList search when the query itself contains multiple vectors and the target StructArray vector subfield is indexed with a `MAX_SIM*` metric. The result is an entity-level match.
+
+```python
+from pymilvus import MilvusClient
+from pymilvus.client.embedding_list import EmbeddingList
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+query = EmbeddingList()
+query.add([0.12, 0.21, 0.32, 0.44])
+query.add([0.18, 0.23, 0.29, 0.36])
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query],
+    anns_field="chunks[emb_list_vector]",
+    limit=3,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(hit["id"], hit["distance"], hit["entity"])
+```
+
+In this search mode, `limit` controls how many entities are returned for each query. The output can include StructArray subfields, but the hit itself represents the matched parent entity rather than one specific Struct element.
+
+<div class="alert note">
+
+For a full ColBERT or ColPali-style walkthrough, see [Search with Embedding Lists](search-with-embedding-lists.md). This page only covers the basic StructArray search behavior.
+
+</div>
+
+## Run element-level search
+
+Use element-level search when each Struct element should participate in vector search independently. The query is a regular vector, and the target vector subfield must be indexed with a regular vector metric.
+
+```python
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[page]",
+        "chunks[quality_score]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(
+            "doc_id:", hit["id"],
+            "distance:", hit["distance"],
+            "offset:", hit.get("offset"),
+            "entity:", hit["entity"],
+        )
+```
+
+In element-level search, each hit represents a matched Struct element. The `offset` value is the zero-based position of that element in the StructArray field. The same entity can appear more than once if more than one Struct element matches the query. The `limit` value applies to element hits, not unique parent entities.
+
+## Interpret results
+
+| Result item | EmbeddingList search | Element-level search |
+| --- | --- | --- |
+| `id` | Primary key of the matched entity. | Primary key of the entity that contains the matched Struct element. |
+| `distance` or score | Score or distance between the query embedding list and the stored embedding list. | Score or distance between the query vector and the matched Struct element vector. |
+| `offset` | Not applicable. | Zero-based position of the matched Struct element when returned. |
+| Repeated primary keys | Not expected for a single query because results are entity-level. | Possible, because multiple Struct elements in the same entity can match. |
+| Requested StructArray output fields | Returned from the matched entity. | Returned with the element-level hit shape supported by the target API and SDK. |
+
+## Common mistakes
+
+- Using `chunks.emb` instead of the required subfield path syntax `chunks[emb]`.
+
+- Using an EmbeddingList query against a vector subfield indexed with a regular vector metric.
+
+- Using a regular vector query against a vector subfield indexed with a `MAX_SIM*` metric.
+
+- Expecting element-level search `limit` to return that many unique parent entities. It returns element hits.
+
+- Expecting EmbeddingList search to return one specific element offset. It returns entity-level matches.
+
+- Reusing one vector subfield for both search modes. Use separate vector subfields because each vector subfield accepts only one index.
+
+## Next steps
+
+1. To restrict element-level search by scalar conditions, read [Filtered Search with StructArray](filtered-search-with-structarray.md).
+
+2. To search by score or distance boundaries, read [Range Search with StructArray](range-search-with-structarray.md).
+
+3. To return at most one result per parent entity after element-level search, read [Grouping Search with StructArray](grouping-search-with-structarray.md).
+
+4. To combine StructArray search with other vector searches, read [Hybrid Search with StructArray](hybrid-search-with-structarray.md).
+
+5. To review supported data types, metrics, filters, and version-specific limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/search-query-get/boolean/struct-array-operators.md
+++ b/site/en/userGuide/search-query-get/boolean/struct-array-operators.md
@@ -1,114 +1,181 @@
 ---
 id: struct-array-operators.md
 title: "StructArray Operators"
-summary: "Use element filters and match-family operators to filter scalar sub-fields inside StructArray fields."
-beta: Milvus 3.0.x
+summary: "StructArray operators filter entities by evaluating predicates on scalar subfields inside a StructArray field. Use this page as a syntax reference for element_filter and the MATCH_* operator family."
 ---
-
 # StructArray Operators
 
-The Array of Structs, or StructArray, in an entity stores an ordered set of Struct elements. Each Struct in the Array shares the same predefined schema, which comprises multiple vectors and scalar fields. When a scalar sub-field in a Struct is indexed, you can use **element filters** and **operators in the match family** to perform scalar filtering on it.
+StructArray operators filter entities by evaluating predicates on scalar subfields inside a StructArray field. Use this page as a syntax reference for `element_filter` and the `MATCH_*` operator family.
 
-An element filter selects entities that contain at least one value in a StructArray field matching the specified predicate. In contrast, the match family operators are used to find entities that contain specific numbers or proportions of values in a StructArray field matching the specified predicate.
+StructArray filtering has two operator families:
 
-<div class="alert note">
+| Operator family | Main purpose | Result behavior |
+| --- | --- | --- |
+| `element_filter` | Match Struct elements that satisfy a scalar predicate. | In element-level search, matched hits can include element offsets. In row-level query or filtered search, result shape depends on the API and output fields. |
+| `MATCH_*` | Select entities by how many Struct elements satisfy a scalar predicate. | Row-level filtering. These operators do not return element offsets by themselves. |
 
-When building predicates against `$[subField]`, ensure the sub-field is indexed if you are working with large-scale datasets, as these operators require iterating through the array elements for each candidate entity.
+Use scalar subfields in StructArray operators. Vector subfields are used by vector search paths and are not scalar predicate inputs.
 
-</div>
+## When to use which operator
 
-## Element filter
+| Goal | Use |
+| --- | --- |
+| Constrain element-level vector search to elements that match scalar conditions. | `element_filter` |
+| Match multiple scalar conditions within the same Struct element. | `element_filter` |
+| Return only entities where at least one Struct element satisfies a predicate. | `MATCH_ANY` |
+| Return only entities where all Struct elements satisfy a predicate. | `MATCH_ALL` |
+| Return only entities where at least, at most, or exactly `N` Struct elements satisfy a predicate. | `MATCH_LEAST`, `MATCH_MOST`, or `MATCH_EXACT` |
 
-Use element filters when you need to check whether an entity contains the values that match a specific predicate in its StructArray field.
+## Element Filter
+
+Use `element_filter(structArrayField, predicate)` to match Struct elements in a StructArray field.
+
+Inside the predicate, use `$[subfield]` to refer to a scalar subfield of the current Struct element.
 
 ```python
-element_filter(chunks, $[text] LIKE "Red%")
+element_filter(chunks, $[section] == "index")
 ```
 
-As shown in the above element filter expression, the element filter returns entities that contain at least one chunk that starts with "Red" in the `text` sub-field. The first parameter is the name of the StructArray field, while the second parameter is the predicate that applies to the Struct sub-field.
-
-You can use comparison, range, and arithmetic operators to build the condition, and logical operators to concatenate multiple conditions, as shown in [Basic Operators](basic-operators.md).
-
-However, when you build a filter expression that combines both an entity-level predicate and an element filter, you should always place the element fltler at the end, as shown in the following example.
+When multiple conditions are used inside the predicate, all `$[subfield]` references apply to the same Struct element:
 
 ```python
-# correct
-id > 0 && element_filter(chunks, $[x] > 1)
-
-# incorrect, resulting errors
-element_filter(chunks, $[x] > 1) && id > 0
+element_filter(chunks, $[section] == "index" && $[quality_score] > 0.9)
 ```
 
-## Match family operators
+When you combine an entity-level predicate with `element_filter`, place `element_filter` at the end of the expression:
 
-The match family operators work over a StructArray field, too. Instead of simply checking whether an element exists, you can determine how many elements (or what proportion) must satisfy an element predicate.
+```python
+# Correct
+category == "index" && element_filter(chunks, $[quality_score] > 0.9)
 
-- [`MATCH_ANY(identifier, predicate)`](struct-array-operators.md#MATCHANY): returns entities that contain at least one chunk that starts with "Red" in the `text` sub-field; semantically, this is equivalent to `element_filter`.
+# Incorrect
+element_filter(chunks, $[quality_score] > 0.9) && category == "index"
+```
 
-- [`MATCH_ALL(identifier, predicate)`](struct-array-operators.md#MATCHALL): returns entities whose text sub-fields in all chunks start with "Red".
+`element_filter` can appear only once in a filter expression. Do not nest `element_filter` or `MATCH_*` inside another `element_filter`.
 
-- [`MATCH_LEAST(identifier, predicate, k)`](struct-array-operators.md#MATCHLEAST): returns entities that contain at least `k` chunks that start with "Red" in the `text` sub-field.
+## Match Family Operators
 
-- [`MATCH_MOST(identifier, predicate, k)`](struct-array-operators.md#MATCHMOST): returns entities that contain at most `k` chunks that start with "Red" in the `text` sub-field.
+Use `MATCH_*` operators when an entity should be selected based on how many Struct elements satisfy a predicate.
 
-- [`MATCH_EXACT(identifier, predicate, k)`](struct-array-operators.md#MATCHEXACT): returns entities that contain exactly `k` chunks that start with "Red" in the `text` sub-field.
+| Operator | Meaning |
+| --- | --- |
+| `MATCH_ANY(field, predicate)` | At least one Struct element satisfies the predicate. |
+| `MATCH_ALL(field, predicate)` | All Struct elements satisfy the predicate. |
+| `MATCH_LEAST(field, predicate, threshold=N)` | At least `N` Struct elements satisfy the predicate. |
+| `MATCH_MOST(field, predicate, threshold=N)` | At most `N` Struct elements satisfy the predicate. |
+| `MATCH_EXACT(field, predicate, threshold=N)` | Exactly `N` Struct elements satisfy the predicate. |
+
+`MATCH_ANY` and `element_filter` can both express that at least one Struct element satisfies a predicate. Use `MATCH_ANY` when you only need row-level filtering. Use `element_filter` when you need element-level constraints, such as filtering which Struct elements participate in element-level vector search.
 
 ### MATCH_ANY
 
-This operator evaluates to true if **at least one** element in the array satisfies the predicate, which indicates that the structural equivalent of a logical `OR` across all array elements.
-
-MATCH_ANY operators and element filters are semantically the same, and you can use them interchangeably. When you need to express the logic `count(matches) >= 1`, you should use them.
-
-**EXAMPLE:**
-
-The following example returns entities where any part of the document starts with "Red".
+`MATCH_ANY` evaluates to `true` if at least one element in the StructArray satisfies the predicate.
 
 ```python
-MATCH_ANY(chunks, $[text] LIKE 'Red%')
+MATCH_ANY(chunks, $[section] == "index")
 ```
+
+For an empty StructArray, `MATCH_ANY` returns `false`.
 
 ### MATCH_ALL
 
-This operator evaluates to true only if **every single** element in the array satisfies the predicate.
-
-When you need to express the logic `count(matches) == total elements`, use this operator.
-
-**EXAMPLE:**
+`MATCH_ALL` evaluates to `true` if every element in the StructArray satisfies the predicate.
 
 ```python
-MATCH_ALL(chunks, $[text] LIKE 'Red%')
+MATCH_ALL(chunks, $[has_code] == true)
 ```
+
+For an empty StructArray, `MATCH_ALL` returns `true`.
 
 ### MATCH_LEAST
 
-This operator is a quantitative filter that returns true if the number of elements satisfying the predicate is **greater than or equal to** a specified constant $k$.
-
-When you need to express the logic `count(matches) >= k`, use this operator.
-
-**EXAMPLE:**
+`MATCH_LEAST` evaluates to `true` if the number of elements satisfying the predicate is greater than or equal to `threshold`.
 
 ```python
-MATCH_LEAST(chunks, $[text] LIKE 'Red%', 3)
+MATCH_LEAST(chunks, $[quality_score] > 0.9, threshold=2)
 ```
+
+For `MATCH_LEAST`, `threshold` must be a positive integer.
 
 ### MATCH_MOST
 
-This operator is a quantitative filter that returns true if the number of elements satisfying the predicate is **less than or equal to** a specified constant $k$.
-
-This is particularly useful for filtering out entities that over-target a specific keyword (noise reduction).
-
-**EXAMPLE:**
+`MATCH_MOST` evaluates to `true` if the number of elements satisfying the predicate is less than or equal to `threshold`.
 
 ```python
-MATCH_MOST(chunks, $[text] LIKE 'Red%', 3)
+MATCH_MOST(chunks, $[has_code] == true, threshold=1)
 ```
+
+For `MATCH_MOST`, `threshold` can be zero or a positive integer.
 
 ### MATCH_EXACT
 
-This operator is the most restrictive quantitative operator in the family. It returns true if and only if the number of elements satisfying the predicate is **exactly** $k$.
-
-**EXAMPLE:**
+`MATCH_EXACT` evaluates to `true` if the number of elements satisfying the predicate is exactly equal to `threshold`.
 
 ```python
-MATCH_EXACT(chunks, $[text] LIKE 'Red%', 3)
+MATCH_EXACT(chunks, $[section] == "filter", threshold=1)
 ```
+
+For `MATCH_EXACT`, `threshold` can be zero or a positive integer.
+
+## Supported predicates
+
+The `$[...]` syntax represents the scalar value of the current Struct element. Predicate support depends on the scalar subfield type.
+
+| Subfield type | Element-level predicate support |
+| --- | --- |
+| `BOOL` | Scalar predicates such as `$[has_code] == true` or `!($[has_code] == true)`. Avoid bare boolean expressions such as `$[has_code]`. |
+| `INT8`, `INT16`, `INT32`, `INT64` | Comparison, chained range, `in`, `not in`, arithmetic expressions with `+`, `-`, `*`, `/`, or `%` followed by comparison, and logical combinations. |
+| `FLOAT`, `DOUBLE` | Comparison, chained range, `in`, `not in`, arithmetic expressions with `+`, `-`, `*`, or `/` followed by comparison, and logical combinations. The `%` operator is not supported for floating-point subfields. |
+| `VARCHAR` | String comparison, chained range, `in`, `not in`, `like`, `=~`, `!~`, and logical combinations. |
+| Vector subfields | Not supported as `$[...]` scalar predicate inputs. Use vector subfields through EmbeddingList search or element-level vector search instead. |
+
+Logical operators such as `&&`, `\|\|`, and `!` apply to predicate expressions. For example, write `!($[has_code] == true)` instead of `!$[has_code]`.
+
+## Unsupported predicates
+
+Element-level `$[...]` predicates do not support:
+
+- Text match functions, such as `text_match(field, "...")` or `phrase_match(field, "...")`.
+
+- JSON path syntax, `exists` on JSON paths, or JSON functions such as `json_contains`, `json_contains_all`, or `json_contains_any`.
+
+- Array container functions such as `array_contains`, `array_contains_all`, `array_contains_any`, or `array_length`.
+
+- `$[subfield] is null` or `$[subfield] is not null`.
+
+- Geometry / GIS functions.
+
+- Timestamptz expressions.
+
+- `random_sample(...)`.
+
+- Field-level vector predicates.
+
+- Generic filter function calls unless the specific function signature and execution path explicitly support StructArray element-level predicates.
+
+## Syntax rules
+
+- `MATCH_*` operator names are case-insensitive.
+
+- Use `$[subfield]` only inside `element_filter` or `MATCH_*` predicates.
+
+- Do not use `$[subfield]` as a JSON path, array container, or vector field reference.
+
+- Do not nest `element_filter` or `MATCH_*` inside another StructArray operator.
+
+- Use named `threshold=N` for `MATCH_LEAST`, `MATCH_MOST`, and `MATCH_EXACT`.
+
+- `MATCH_ANY` on an empty StructArray returns `false`.
+
+- `MATCH_ALL` on an empty StructArray returns `true`.
+
+## See also
+
+- [Filtered Search with StructArray](filtered-search-with-structarray.md)
+
+- [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md)
+
+- [Index StructArray Fields](index-structarray-fields.md)
+
+- [StructArray Limits](structarray-limits.md)

--- a/site/en/userGuide/search-query-get/choose-an-embeddinglist-search-strategy.md
+++ b/site/en/userGuide/search-query-get/choose-an-embeddinglist-search-strategy.md
@@ -1,0 +1,251 @@
+---
+id: choose-an-embeddinglist-search-strategy.md
+title: "Choose an EmbeddingList Search Strategy"
+summary: "EmbeddingList search strategies decide how Milvus builds an approximate candidate index for EmbeddingList search. The default strategy is tokenann. You can switch to muvera or lemur when the embedding list is large, TokenANN is too expensive, or a learned/compressed row-level representation is a better fit. The final result is still produced by MaxSim reranking when emb_list_rerank is enabled."
+---
+# Choose an EmbeddingList Search Strategy
+
+EmbeddingList search strategies decide how Milvus builds an approximate candidate index for EmbeddingList search. The default strategy is `tokenann`. You can switch to `muvera` or `lemur` when the embedding list is large, TokenANN is too expensive, or a learned/compressed row-level representation is a better fit. The final result is still produced by MaxSim reranking when `emb_list_rerank` is enabled.
+
+## Why Search Strategies Exist
+
+EmbeddingList is designed for rows that contain multiple vectors, such as token embeddings in a text document, patch embeddings in a visual document, or clip embeddings in a video. Instead of comparing one query vector with one row vector, MaxSim compares a query embedding list with a document embedding list and aggregates the best matches.
+
+This gives better representation power, but exact MaxSim is expensive at scale. A brute-force MaxSim search would need to compare the query vectors with every vector in every candidate row. That is usually too slow for production search.
+
+| ### Problem - Each row may contain many vectors. - Exact MaxSim over all rows is expensive. - Index size and search latency can grow quickly. | ### Strategy - Use an approximate first-stage retrieval method. - Retrieve more candidates than the requested topK. - Rerank candidates with exact MaxSim. |
+| --- | --- |
+
+In this sense, `emb_list_strategy` is mainly an index-building and candidate-retrieval strategy. It is configured when building the index, and it determines how the first-stage ANN candidate set is produced. Search-time parameters such as `retrieval_ann_ratio` and `emb_list_rerank` then control how many candidates are retrieved and whether MaxSim reranking is applied.
+
+---
+
+## Available Strategies
+
+| Strategy | Candidate retrieval unit | What it solves | Best fit | Main tradeoff |
+| --- | --- | --- | --- | --- |
+| `tokenann` | Individual vectors inside each row | Keeps the original vectors and avoids compression loss. | Quality-first search, short or medium embedding lists, high-discrimination embeddings. | Larger index and higher candidate retrieval cost. |
+| `muvera` | One encoded vector per row | Compresses an embedding list into a fixed-dimensional FDE representation without training. | Longer documents, high-discrimination embeddings, cases where TokenANN is too heavy. | Random projection introduces approximation loss; FDE dimension affects latency. |
+| `lemur` | One learned vector per row | Learns a corpus-specific compression from embedding lists to fixed-dimensional row vectors. | Low-discrimination embeddings, multimodal or visual-document retrieval, large embedding lists. | Requires training and can be sensitive to corpus distribution and document-length bias. |
+
+## TokenANN
+
+`tokenann` indexes every vector in the embedding list. During search, each query vector performs ANN retrieval, matched vectors are aggregated back to their rows, and the resulting row candidates are reranked with MaxSim.
+
+<div class="alert note">
+
+**Use TokenANN when quality is the first priority.** It is the closest approximation to the original MaxSim computation because it keeps all vectors available in the first-stage index.
+
+</div>
+
+- **Good fit:** short text chunks, rows with a small or moderate number of vectors, strong token-level semantic separation, quality-sensitive baselines.
+
+- **Less suitable:** very long documents, visual pages with thousands of patch vectors, strict memory or latency budgets.
+
+- **Element-level behavior:** TokenANN can retrieve candidates from individual vectors before aggregating them back to rows. The final EmbeddingList search result is still row-level after MaxSim scoring.
+
+## MUVERA
+
+`muvera` encodes each embedding list into a fixed-dimensional vector using random projections. This turns first-stage retrieval into a standard row-level vector search. Candidates are then reranked with MaxSim.
+
+<div class="alert note">
+
+**Use MUVERA when TokenANN is too heavy but you do not want a training step.** It is a practical middle ground between quality and cost.
+
+</div>
+
+- **Good fit:** long text documents, high-discrimination embedding spaces, workloads that need lower index size than TokenANN.
+
+- **Less suitable:** low-discrimination embedding spaces or cases where the FDE representation becomes too high-dimensional for the latency budget.
+
+- **Important parameters:**`muvera_num_projections`, `muvera_num_repeats`, and `muvera_seed`.
+
+## LEMUR
+
+`lemur` trains a model to compress each embedding list into a fixed-dimensional representation. First-stage ANN search runs on the learned row-level vectors, and candidates are reranked with MaxSim.
+
+<div class="alert note">
+
+**Use LEMUR when learned compression is worth the training cost.** It can work well for low-discrimination embedding spaces and multimodal retrieval, but it should be validated against the target corpus because it can be sensitive to document length distribution.
+
+</div>
+
+- **Good fit:** visual-document search, multimodal patch embeddings, low-discrimination embedding spaces, large embedding lists where TokenANN is not practical.
+
+- **Less suitable:** frequently changing corpora, high-discrimination embeddings with highly skewed document lengths, workloads where training cost is unacceptable.
+
+- **Important parameters:**`lemur_hidden_dim`, `lemur_num_train_samples`, `lemur_num_epochs`, `lemur_batch_size`, `lemur_learning_rate`, `lemur_seed`, and `lemur_num_layers`.
+
+---
+
+## Default Behavior and Configuration
+
+The default EmbeddingList strategy in Knowhere is `tokenann`. If you do not specify `emb_list_strategy`, Knowhere uses TokenANN. Search-time defaults include `retrieval_ann_ratio=3.0` and `emb_list_rerank=true`.
+
+## Configuration Items by Strategy
+
+The following table lists the strategy-specific configuration items. In Milvus, build-time items are usually passed in the `params` map when creating an index. If you need server-side defaults, they should be defined in the Milvus configuration file under the `knowhere` section.
+
+| Strategy | Configuration item | Stage | Default | When to change it |
+| --- | --- | --- | --- | --- |
+| `tokenann` | `emb_list_strategy="tokenann"` | Index build | `tokenann` | Use explicitly when you want the default element-vector indexing behavior or when DiskANN is used. |
+| `muvera` | `emb_list_strategy="muvera"` | Index build | `tokenann` | Use when you want row-level encoded retrieval without training. |
+| `muvera` | `muvera_num_projections` | Index build | `4` | Controls SimHash projection count. Higher values create more buckets and may improve encoding quality, but increase encoded dimensionality. |
+| `muvera` | `muvera_num_repeats` | Index build | `7` | Controls how many independent FDE encodings are concatenated. Higher values may improve robustness but increase index/search cost. |
+| `muvera` | `muvera_seed` | Index build | `42` | Set for reproducible random projections, especially in tests and benchmark comparisons. |
+| `lemur` | `emb_list_strategy="lemur"` | Index build | `tokenann` | Use when learned row-level compression is expected to work better than fixed random projection. |
+| `lemur` | `lemur_hidden_dim` | Index build | `256` | Controls the compressed representation size. Increase for more capacity; decrease for lower memory and faster retrieval. |
+| `lemur` | `lemur_num_train_samples` | Index build | `20000` | Increase when the corpus is diverse and the learned compression underfits; reduce only for small tests or faster builds. |
+| `lemur` | `lemur_num_epochs` | Index build | `50` | Increase if training has not converged; reduce when build time is the primary constraint. |
+| `lemur` | `lemur_batch_size` | Index build | `512` | Tune for training throughput and memory usage. |
+| `lemur` | `lemur_learning_rate` | Index build | `0.001` | Adjust when training is unstable or converges too slowly. |
+| `lemur` | `lemur_seed` | Index build | `42` | Set for reproducible training runs. |
+| `lemur` | `lemur_num_layers` | Index build | `2` | Increase only when the corpus needs a more expressive feature extractor and you can afford extra training cost. |
+| All strategies | `retrieval_ann_ratio` | Search | `3.0` | Increase to retrieve more first-stage candidates and improve recall; decrease to reduce latency. |
+| All strategies | `emb_list_rerank` | Search | `true` | Keep enabled for MaxSim reranking. Disable only for controlled experiments where first-stage ANN quality is being measured directly. |
+
+## Configure the Strategy in Milvus
+
+In Milvus, the strategy is passed as an index parameter when creating an index on an EmbeddingList field, such as a StructArray vector sub-field.
+
+```python
+index_params = client.prepare_index_params()
+index_params.add_index(
+    field_name="clips[clip_embedding]",
+    index_type="HNSW",
+    metric_type="MAX_SIM_COSINE",
+    params={
+        "M": 16,
+        "efConstruction": 96,
+        "emb_list_strategy": "muvera",
+        "muvera_num_projections": 4,
+        "muvera_num_repeats": 7,
+        "muvera_seed": 42,
+    },
+)
+```
+
+For LEMUR, provide the LEMUR training parameters in the same `params` map.
+
+```python
+params={
+    "M": 16,
+    "efConstruction": 96,
+    "emb_list_strategy": "lemur",
+    "lemur_hidden_dim": 256,
+    "lemur_num_train_samples": 20000,
+    "lemur_num_epochs": 50,
+    "lemur_batch_size": 512,
+    "lemur_learning_rate": 0.001,
+    "lemur_seed": 42,
+    "lemur_num_layers": 2,
+}
+```
+
+## Configure Server-side Defaults in Milvus
+
+Milvus can also populate index parameters from `milvus.yaml`. The relevant section is `knowhere`. Parameters are organized by index type and stage, using the pattern `knowhere.<INDEX_TYPE>.<stage>.<parameter>`. User-provided index parameters take precedence over these defaults.
+
+```yaml
+knowhere:
+  enable: true
+  HNSW:
+    build:
+      emb_list_strategy: muvera
+      muvera_num_projections: 4
+      muvera_num_repeats: 7
+      muvera_seed: 42
+    search:
+      retrieval_ann_ratio: 3.0
+      emb_list_rerank: true
+```
+
+<div class="alert note">
+
+**Prefer per-index params for strategy selection.** A Milvus config-file default applies broadly to indexes of that type and stage. Use `create_index` parameters when different collections or fields need different EmbeddingList strategies.
+
+</div>
+
+## Configure Candidate Retrieval at Search Time
+
+The strategy decides how the index is built. At search time, use `retrieval_ann_ratio` to control how many first-stage candidates are retrieved before MaxSim reranking. Higher values usually improve recall but increase latency.
+
+```python
+results = client.search(
+    collection_name=collection_name,
+    data=[query_embedding_list],
+    anns_field="clips[clip_embedding]",
+    search_params={
+        "metric_type": "MAX_SIM_COSINE",
+        "params": {
+            "ef": 64,
+            "retrieval_ann_ratio": 3.0,
+            "emb_list_rerank": True,
+        },
+    },
+    limit=10,
+)
+```
+
+| Parameter | Stage | Default | Meaning |
+| --- | --- | --- | --- |
+| `emb_list_strategy` | Index build | `tokenann` | Selects how EmbeddingList candidates are indexed and retrieved. |
+| `retrieval_ann_ratio` | Search | `3.0` | Candidate expansion factor for the first ANN round. |
+| `emb_list_rerank` | Search | `true` | Whether to rerank retrieved candidates with MaxSim. |
+
+<div class="alert note">
+
+**Compatibility notes:** MUVERA and LEMUR currently support fp32 data in Knowhere. DiskANN supports EmbeddingList only with the TokenANN strategy. If you use non-fp32 vector types or DiskANN, verify strategy support before changing the default.
+
+</div>
+
+---
+
+## How to Choose a Strategy
+
+There is no universally best strategy. Choose based on embedding-list length, embedding-space discrimination, latency budget, index size, and whether you can afford a training step.
+
+| Question | Signal | Recommended starting point |
+| --- | --- | --- |
+| Do you need a high-quality baseline? | You want to measure the best practical approximation before optimizing cost. | `tokenann` |
+| Are rows short or moderate in vector count? | Each row has a small number of token, patch, or clip vectors. | `tokenann` |
+| Is TokenANN too large or too slow? | Index size or first-stage retrieval latency is the bottleneck. | `muvera` |
+| Do you want compression without training? | You need a simpler operational model and reproducible encoding. | `muvera` |
+| Is the embedding space low-discrimination? | Token-level ANN candidates are noisy, and random projection does not preserve enough signal. | `lemur` |
+| Is the workload visual or multimodal? | Rows contain many patch vectors, and TokenANN is too expensive. | `lemur` or `muvera` |
+| Is document length highly skewed? | Some rows contain far more vectors than others. | Start with `muvera`; validate `lemur` carefully. |
+
+## Suggested Evaluation Workflow
+
+1. Start with `tokenann` as a quality baseline when the dataset size allows it.
+
+2. Run the same queries with `muvera` and compare recall, nDCG, latency, and index size.
+
+3. Try `lemur` when the embedding list is large, the embedding space is noisy, or the workload is visual or multimodal.
+
+4. Tune `retrieval_ann_ratio` before changing too many build-time parameters. Increase it if recall is low; reduce it if latency is too high.
+
+5. Always validate on representative queries and document-length distributions. A strategy that works on short text may not work on visual documents or long-tail corpora.
+
+| ### Quality-first Start with `tokenann`. Use it as the baseline for MaxSim approximation quality. | ### Balanced Try `muvera` when you need lower cost without adding a training pipeline. | ### Compressed Try `lemur` when learned row-level compression is likely to outperform fixed random projection. |
+| --- | --- | --- |
+
+---
+
+## References Used for This Draft
+
+- Milvus tests for `emb_list_strategy`, `retrieval_ann_ratio`, and `emb_list_rerank`.
+
+- Milvus config-file handling for server-side index defaults under the `knowhere` section.
+
+- Knowhere parameter definitions for default values and supported strategy names.
+
+- Knowhere compatibility checks for fp32-only MUVERA/LEMUR and DiskANN TokenANN-only support.
+
+- Internal evaluation notes comparing TokenANN, MUVERA, and LEMUR for MaxSim candidate retrieval.
+
+<div class="alert note">
+
+**Publishing note:** Before publishing externally, verify which parameters are officially supported in the target Milvus release and whether the product wants to expose all low-level Knowhere parameters or only a smaller documented subset.
+
+</div>

--- a/site/en/userGuide/search-query-get/filtered-search-with-structarray.md
+++ b/site/en/userGuide/search-query-get/filtered-search-with-structarray.md
@@ -1,0 +1,227 @@
+---
+id: filtered-search-with-structarray.md
+title: "Filtered Search with StructArray"
+summary: "Use this page to add scalar filtering to vector search on StructArray fields. StructArray filtering has two levels: row-level filters select parent entities, while element-level filters constrain which Struct elements participate in element-level vector search."
+---
+# Filtered Search with StructArray
+
+Use this page to add scalar filtering to vector search on StructArray fields. StructArray filtering has two levels: row-level filters select parent entities, while element-level filters constrain which Struct elements participate in element-level vector search.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The collection has a StructArray field named `chunks`, with scalar subfields such as `section`, `page`, `quality_score`, and `has_code`, plus vector subfields for search.
+
+## Choose a filter type
+
+| Goal | Use | Result behavior |
+| --- | --- | --- |
+| Filter by a top-level scalar field, such as `category`. | Regular filter expression. | Selects parent entities before or during search. |
+| Constrain element-level vector search to Struct elements that match scalar conditions. | `element_filter`. | Searches only matching Struct elements and can return matched element offsets. |
+| Select entities by whether any, all, or a specific number of Struct elements match a predicate. | `MATCH_ANY`, `MATCH_ALL`, `MATCH_LEAST`, `MATCH_MOST`, or `MATCH_EXACT`. | Row-level filtering. These operators do not return offsets by themselves. |
+
+<div class="alert note">
+
+This page explains how to use StructArray filters in search workflows. For the full syntax rules, supported predicate types, and unsupported predicate matrix, see [StructArray Operators](struct-array-operators.md).
+
+</div>
+
+## Filter by top-level fields
+
+Use regular filter expressions when the condition belongs to the parent entity, not to an individual Struct element. This works with both EmbeddingList search and element-level search.
+
+```python
+from pymilvus import MilvusClient
+from pymilvus.client.embedding_list import EmbeddingList
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+query = EmbeddingList()
+query.add([0.12, 0.21, 0.32, 0.44])
+query.add([0.18, 0.23, 0.29, 0.36])
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query],
+    anns_field="chunks[emb_list_vector]",
+    filter='category == "search"',
+    limit=3,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+    ],
+)
+```
+
+The filter above selects only entities whose top-level `category` field is `"search"`. It does not identify one matched Struct element.
+
+## Filter element-level vector search
+
+Use `element_filter(structArrayField, predicate)` when the scalar conditions must apply to the same Struct element that participates in element-level vector search. Inside the predicate, use `$[subfield]` to refer to scalar subfields of the current Struct element.
+
+```python
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+filter_expr = (
+    'category == "search" && '
+    'element_filter(chunks, '
+    '$[section] == "index" && '
+    '$[quality_score] > 0.9 && '
+    '$[has_code] == true)'
+)
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    filter=filter_expr,
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[page]",
+        "chunks[quality_score]",
+        "chunks[has_code]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(
+            "doc_id:", hit["id"],
+            "distance:", hit["distance"],
+            "offset:", hit.get("offset"),
+            "entity:", hit["entity"],
+        )
+```
+
+In this example, the top-level predicate `category == "search"` selects candidate entities, and `element_filter` restricts element-level vector search to chunks where `section`, `quality_score`, and `has_code` all match in the same Struct element.
+
+<div class="alert note">
+
+Warning
+
+When you combine a top-level predicate with `element_filter`, place `element_filter` at the end of the expression. A filter expression can contain only one `element_filter`, and you cannot nest `element_filter` or `MATCH_*` inside another StructArray operator.
+
+</div>
+
+## Filter entities with MATCH operators
+
+Use `MATCH_*` operators when the filter should decide whether a parent entity qualifies based on its Struct elements. These operators are row-level filters: they select entities, but do not return element offsets by themselves.
+
+| Operator | Use it when | Example |
+| --- | --- | --- |
+| `MATCH_ANY` | At least one Struct element must satisfy the predicate. | `MATCH_ANY(chunks, $[section] == "index")` |
+| `MATCH_ALL` | All Struct elements must satisfy the predicate. | `MATCH_ALL(chunks, $[quality_score] > 0.5)` |
+| `MATCH_LEAST` | At least `N` Struct elements must satisfy the predicate. | `MATCH_LEAST(chunks, $[has_code] == true, threshold=2)` |
+| `MATCH_MOST` | At most `N` Struct elements must satisfy the predicate. | `MATCH_MOST(chunks, $[section] == "appendix", threshold=1)` |
+| `MATCH_EXACT` | Exactly `N` Struct elements must satisfy the predicate. | `MATCH_EXACT(chunks, $[section] == "summary", threshold=1)` |
+
+```python
+filter_expr = (
+    'category == "search" && '
+    'MATCH_ANY(chunks, $[section] == "index" && $[quality_score] > 0.9)'
+)
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query],
+    anns_field="chunks[emb_list_vector]",
+    filter=filter_expr,
+    limit=3,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+Use `MATCH_ANY` here because the EmbeddingList search result is entity-level. The filter requires at least one chunk in the entity to be an `"index"` chunk with high quality, but the search result itself still represents the parent entity.
+
+## Use filters in hybrid search
+
+In hybrid search, apply StructArray filters where the condition should take effect. A top-level filter can be shared by the whole hybrid search. An `element_filter` should be attached to the StructArray element-level request that needs element-level constraints.
+
+```python
+from pymilvus import AnnSearchRequest, RRFRanker
+
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+title_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="title_vector",
+    limit=10,
+)
+
+chunk_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    limit=10,
+    expr='element_filter(chunks, $[section] == "index" && $[quality_score] > 0.9)',
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[title_req, chunk_req],
+    ranker=RRFRanker(),
+    filter='category == "search"',
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+The `filter` argument applies the top-level entity condition, while the `expr` on `chunk_req` constrains only the StructArray element-level vector request. For supported hybrid search combinations and version-specific limits, see [Hybrid Search with StructArray](hybrid-search-with-structarray.md) and [StructArray Limits](structarray-limits.md).
+
+## Predicate support summary
+
+Use scalar subfields in StructArray predicates. Vector subfields are not scalar predicate inputs.
+
+| Subfield type | Typical predicate examples |
+| --- | --- |
+| `BOOL` | `$[has_code] == true`, `!($[has_code] == true)` |
+| Integer types | `$[page] >= 2`, `$[page] in [1, 2, 3]` |
+| `FLOAT`, `DOUBLE` | `$[quality_score] > 0.9`, `0.7 < $[quality_score] < 0.95` |
+| `VARCHAR` | `$[section] == "index"`, `$[text] like "range%"` |
+| Vector subfields | Not supported as `$[...]` scalar predicate inputs. Use vector subfields through vector search instead. |
+
+For unsupported cases such as JSON paths, array container functions, text match functions, null predicates on `$[...]`, Geometry functions, Timestamptz expressions, and generic function calls, see [StructArray Operators](struct-array-operators.md).
+
+## Common mistakes
+
+- Using `$[subfield]` outside `element_filter` or `MATCH_*`.
+
+- Using `chunks.section` instead of StructArray operator syntax such as `element_filter(chunks, $[section] == "index")`.
+
+- Using `element_filter` when you only need row-level filtering. Use `MATCH_ANY` instead if you only need to select entities.
+
+- Expecting `MATCH_*` to return element offsets. These operators select entities and do not identify one matched element by themselves.
+
+- Writing bare boolean predicates such as `$[has_code]`. Use explicit comparisons such as `$[has_code] == true`.
+
+- Putting `element_filter` before a top-level predicate in the same filter expression.
+
+## Next steps
+
+1. To review full StructArray filter syntax, read [StructArray Operators](struct-array-operators.md).
+
+2. To run unfiltered vector searches first, read [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md).
+
+3. To create scalar indexes for frequently used StructArray filters, read [Index StructArray Fields](index-structarray-fields.md).
+
+4. To check version-specific filter and search limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/search-query-get/grouping-search-with-structarray.md
+++ b/site/en/userGuide/search-query-get/grouping-search-with-structarray.md
@@ -1,0 +1,199 @@
+---
+id: grouping-search-with-structarray.md
+title: "Grouping Search with StructArray"
+summary: "Use this page to group StructArray element-level search results by the parent entity. Element-level search can return multiple hits from the same entity when several Struct elements match the query. Grouping collapses those element hits so each parent entity appears at most once."
+---
+# Grouping Search with StructArray
+
+Use this page to group StructArray element-level search results by the parent entity. Element-level search can return multiple hits from the same entity when several Struct elements match the query. Grouping collapses those element hits so each parent entity appears at most once.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The collection has a StructArray field named `chunks`. The `chunks[emb]` vector subfield is indexed for element-level search with a regular vector metric.
+
+## How grouping applies to StructArray
+
+| Search mode | Grouping behavior | Result behavior |
+| --- | --- | --- |
+| EmbeddingList search | Not supported. | Not applicable. |
+| Element-level search | Supported by grouping on the primary key. | Returns at most one result per parent entity. Element-level metadata is preserved, so the selected element index or offset can be returned when exposed by the API or SDK. |
+| Hybrid search | Supported only when all sub-searches target element-level vector fields under the same StructArray field. | Element-level sub-searches are grouped by primary key before final result handling. |
+
+<div class="alert note">
+
+Use grouping when ungrouped element-level search returns too many duplicate parent entities. If you want every matching Struct element as an individual hit, use [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md) without `group_by_field`.
+
+</div>
+
+## Before you begin
+
+Prepare the collection, data, and indexes before running grouping search.
+
+| Requirement | Details |
+| --- | --- |
+| Element-level vector subfield | Use a StructArray vector subfield such as `chunks[emb]`, indexed with a regular vector metric. |
+| Regular vector query | Use a regular query vector, not an `EmbeddingList`. |
+| Primary key grouping | Use the collection primary key as `group_by_field`, such as `doc_id`. |
+| No range parameters | Do not combine grouping search with range-search parameters such as `radius` or `range_filter`. |
+
+For index setup, see [Index StructArray Fields](index-structarray-fields.md).
+
+## Run grouped element-level search
+
+The following example searches individual chunks first, then groups the element hits by the parent entity's primary key.
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    limit=5,
+    group_by_field="doc_id",
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[page]",
+        "chunks[quality_score]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(
+            "doc_id:", hit["id"],
+            "distance:", hit["distance"],
+            "offset:", hit.get("offset"),
+            "entity:", hit["entity"],
+        )
+```
+
+Without grouping, the same `doc_id` can appear multiple times if several chunks match the query. With `group_by_field="doc_id"`, each parent entity appears at most once. Grouping preserves element-level metadata, so the grouped result can still include the selected Struct element index or offset when the API or SDK exposes it.
+
+## Add scalar filters
+
+You can combine grouping search with StructArray scalar filtering. Use `element_filter` when the scalar condition should constrain which Struct elements participate in element-level vector search.
+
+```python
+filter_expr = (
+    'category == "search" && '
+    'element_filter(chunks, '
+    '$[section] == "index" && '
+    '$[quality_score] > 0.9)'
+)
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    filter=filter_expr,
+    limit=5,
+    group_by_field="doc_id",
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+The top-level predicate selects candidate entities. The `element_filter` predicate restricts element-level vector search to matching Struct elements. Grouping then collapses matching element hits by the primary key.
+
+## Use grouping in hybrid search
+
+Hybrid grouping with StructArray is an element-level feature. It is supported only when all sub-searches target element-level vector fields under the same StructArray field. Do not use EmbeddingList-level requests in a grouped StructArray hybrid search.
+
+The following example assumes the `chunks` StructArray field has two element-level vector subfields, `chunks[emb]` and `chunks[code_emb]`, and both are indexed with regular vector metrics.
+
+```python
+from pymilvus import AnnSearchRequest, RRFRanker
+
+index_chunk_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    limit=10,
+    expr='element_filter(chunks, $[section] == "index")',
+)
+
+code_chunk_req = AnnSearchRequest(
+    data=[code_query_vector],
+    anns_field="chunks[code_emb]",
+    limit=10,
+    expr='element_filter(chunks, $[has_code] == true)',
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[index_chunk_req, code_chunk_req],
+    ranker=RRFRanker(),
+    limit=5,
+    group_by_field="doc_id",
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+    ],
+)
+```
+
+In this example, both sub-requests target element-level vector fields under the same StructArray field, `chunks`. A hybrid search does not support element-level group-by if it mixes normal vector fields, different StructArray fields, or EmbeddingList-level requests.
+
+## Interpret grouped results
+
+| Result item | Meaning |
+| --- | --- |
+| `id` | Primary key of the grouped parent entity. |
+| `distance` or score | Score or distance of the selected Struct element for that parent entity. |
+| `offset` | Zero-based position of the selected Struct element when returned. |
+| Repeated primary keys | Not expected when grouping by the primary key. |
+| `limit` | Applies to grouped parent-entity results. |
+
+## Limitations
+
+- Grouping search applies only to element-level StructArray vector search. EmbeddingList search and EmbeddingList-level hybrid search do not support group-by.
+
+- Use the primary key as `group_by_field`. StructArray element-level grouping is not a general-purpose group-by over arbitrary scalar fields.
+
+- Do not combine grouping search with range search.
+
+- Do not use an `EmbeddingList` query or a `MAX_SIM*` metric for grouping search.
+
+- Hybrid grouping is supported only when all sub-searches target element-level vector fields under the same StructArray field.
+
+- Hybrid grouping is not supported when the hybrid search mixes a normal vector field, a different StructArray field, or an EmbeddingList-level request.
+
+## Common mistakes
+
+- Using grouping with `chunks[emb_list_vector]`, which is intended for EmbeddingList search.
+
+- Grouping by a non-primary-key scalar field.
+
+- Grouping by multiple fields. Element-level StructArray grouping supports only primary-key grouping.
+
+- Expecting grouped results to represent every matched Struct element. Grouping returns at most one result per parent entity.
+
+- Assuming grouped element-level search recomputes an EmbeddingList-style `MAX_SIM*` score. Grouping collapses element-level hits; it does not change the scoring model.
+
+- Combining `group_by_field` with `radius` or `range_filter`.
+
+## Next steps
+
+1. To learn ungrouped element-level search first, read [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md).
+
+2. To add scalar filters to grouped search, read [Filtered Search with StructArray](filtered-search-with-structarray.md).
+
+3. To use score or distance boundaries instead of grouping, read [Range Search with StructArray](range-search-with-structarray.md).
+
+4. To check StructArray search limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/search-query-get/hybrid-search-with-structarray.md
+++ b/site/en/userGuide/search-query-get/hybrid-search-with-structarray.md
@@ -1,0 +1,250 @@
+---
+id: hybrid-search-with-structarray.md
+title: "Hybrid Search with StructArray"
+summary: "Use this page to combine StructArray vector search with other vector searches in one hybrid search request. StructArray hybrid search can produce either entity-level results or element-level results, depending on the AnnSearchRequest objects you combine."
+---
+# Hybrid Search with StructArray
+
+Use this page to combine StructArray vector search with other vector searches in one hybrid search request. StructArray hybrid search can produce either entity-level results or element-level results, depending on the `AnnSearchRequest` objects you combine.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The collection has a top-level vector field named `title_vector` and a StructArray field named `chunks`. The `chunks[emb_list_vector]` subfield is indexed for EmbeddingList search, and `chunks[emb]` is indexed for element-level search.
+
+## How hybrid search applies to StructArray
+
+| `AnnSearchRequest` combination | Final candidate scope | Result behavior | `element_scope` |
+| --- | --- | --- | --- |
+| Collection-level vector field + StructArray EmbeddingList subfield | Entity level | Final candidates are keyed by primary key. | Do not use. |
+| Collection-level vector field + StructArray element-level subfield | Entity level | Element-level hits are collapsed to entity-level candidates before hybrid reranking. | Optional collapse config on the StructArray element-level `AnnSearchRequest`. |
+| Multiple element-level subfields under the same StructArray field | Element level | Final candidates are keyed by primary key plus Struct element offset. | Do not use. |
+| Element-level subfields under different StructArray fields | Entity level | Element offsets do not share identity, so each StructArray element-level `AnnSearchRequest` is collapsed before reranking. | Optional collapse config on each StructArray element-level `AnnSearchRequest`. |
+
+<div class="alert note">
+
+Warning
+
+Use `element_scope` only to configure collapse for StructArray element-level `AnnSearchRequest` objects in a non-same-struct element-level hybrid search. Do not use it for EmbeddingList requests, collection-level vector requests, or same-StructArray element-level hybrid search.
+
+</div>
+
+## Before you begin
+
+Prepare the collection, data, and indexes before running hybrid search.
+
+| Requirement | Details |
+| --- | --- |
+| StructArray field | The collection contains a StructArray field such as `chunks`. |
+| Vector subfields | Use separate vector subfields for EmbeddingList search and element-level search. |
+| Indexes | `chunks[emb_list_vector]` uses a `MAX_SIM*` metric. `chunks[emb]` uses a regular vector metric such as `COSINE`, `IP`, or `L2`. |
+| Reranker | Choose a hybrid reranker such as `RRFRanker` or another reranker supported by your application. |
+
+For index setup, see [Index StructArray Fields](index-structarray-fields.md).
+
+## Run hybrid search with an EmbeddingList request
+
+EmbeddingList search on a StructArray vector subfield is entity-level in hybrid search. It behaves like an entity-level vector search request and does not return one matched Struct element offset.
+
+```
+from pymilvus import AnnSearchRequest, MilvusClient, RRFRanker
+from pymilvus.client.embedding_list import EmbeddingList
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+query_list = EmbeddingList()
+query_list.add([0.12, 0.21, 0.32, 0.44])
+query_list.add([0.18, 0.23, 0.29, 0.36])
+
+title_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="title_vector",
+    limit=10,
+)
+
+chunk_list_req = AnnSearchRequest(
+    data=[query_list],
+    anns_field="chunks[emb_list_vector]",
+    limit=10,
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[title_req, chunk_list_req],
+    ranker=RRFRanker(),
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+    ],
+)
+```
+
+In this example, both `AnnSearchRequest` objects produce entity-level candidates. The final result is keyed by the parent entity primary key. Do not add `element_scope` to the EmbeddingList request.
+
+## Run same-StructArray element-level hybrid search
+
+When all `AnnSearchRequest` objects target element-level vector subfields under the same StructArray field, hybrid search can keep element-level candidates through reranking. This is the only StructArray hybrid mode where final results remain element-level.
+
+The following example assumes the `chunks` StructArray field has two element-level vector subfields, `chunks[emb]` and `chunks[code_emb]`, and both use regular vector metrics.
+
+```
+index_chunk_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    limit=10,
+    expr='element_filter(chunks, $[section] == "index")',
+)
+
+code_chunk_req = AnnSearchRequest(
+    data=[code_query_vector],
+    anns_field="chunks[code_emb]",
+    limit=10,
+    expr='element_filter(chunks, $[has_code] == true)',
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[index_chunk_req, code_chunk_req],
+    ranker=RRFRanker(),
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(
+            "doc_id:", hit["id"],
+            "distance:", hit["distance"],
+            "offset:", hit.get("offset"),
+            "entity:", hit["entity"],
+        )
+```
+
+Both `AnnSearchRequest` objects search vector subfields under `chunks`. The same zero-based offset refers to the same Struct element, so the hybrid reranker can rank element candidates directly. Do not set `element_scope` in this mode because no entity-level collapse is performed.
+
+## Collapse element-level hits for entity-level hybrid search
+
+If a hybrid search mixes a StructArray element-level `AnnSearchRequest` with a collection-level vector request, an EmbeddingList request, or an element-level request under a different StructArray field, the final candidate scope is entity-level. In this case, each StructArray element-level `AnnSearchRequest` is collapsed to entity-level candidates before hybrid reranking.
+
+Use `element_scope` inside the `params` of the StructArray element-level `AnnSearchRequest` when you need to control how multiple matched elements from the same entity are collapsed.
+
+```
+title_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="title_vector",
+    limit=10,
+)
+
+chunk_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    param={
+        "params": {
+            "element_scope": {
+                "collapse": {
+                    "strategy": "topk_sum",
+                    "topk": 3,
+                },
+            },
+        },
+    },
+    limit=30,
+    expr='element_filter(chunks, $[quality_score] > 0.8)',
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[title_req, chunk_req],
+    ranker=RRFRanker(),
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+In this example, `title_req` is entity-level, so the final hybrid result is also entity-level. The `chunk_req` request first returns element hits from `chunks[emb]`, then collapses the returned elements from the same entity by summing the best three element scores. If `element_scope` is omitted when entity-level collapse is needed, the collapse strategy defaults to `max`.
+
+## Choose a collapse strategy
+
+| Strategy | Behavior | `topk` | Metric requirement |
+| --- | --- | --- | --- |
+| `max` | Keep the best returned element score for the entity. | Not allowed. | Any supported regular vector metric. |
+| `sum` | Sum all returned element scores for the entity. | Not allowed. | Positive-correlation metrics only, such as `IP` or `COSINE`. |
+| `avg` | Average all returned element scores for the entity. | Not allowed. | Any supported regular vector metric. |
+| `topk_sum` | Sum the best `K` returned element scores for the entity. | Required and must be positive. | Positive-correlation metrics only, such as `IP` or `COSINE`. |
+| `topk_avg` | Average the best `K` returned element scores for the entity. | Required and must be positive. | Any supported regular vector metric. |
+
+Collapse uses only the element hits returned by that StructArray element-level `AnnSearchRequest`. It does not scan every Struct element in the entity after ANN search. Set the request `limit` high enough to provide the elements you want available for collapse.
+
+## Add filters, range search, and grouping
+
+You can attach `element_filter` to a StructArray element-level `AnnSearchRequest` when scalar conditions should apply to the same Struct elements that participate in vector search. You can also use a top-level `filter` on `hybrid_search()` for parent-entity conditions.
+
+StructArray element-level vector fields support range search in hybrid search. Add `radius` and, optionally, `range_filter` to the element-level `AnnSearchRequest`. EmbeddingList-level StructArray requests do not support range search.
+
+Element-level hybrid grouping is supported only when all `AnnSearchRequest` objects target element-level vector fields under the same StructArray field, and `group_by_field` must be the primary key. Hybrid grouping is not supported when the request mixes collection-level vector fields, different StructArray fields, or EmbeddingList-level requests. Do not combine range search with grouping.
+
+## Interpret hybrid results
+
+| Final candidate scope | Result key | Offset behavior | When it happens |
+| --- | --- | --- | --- |
+| Entity level | Primary key. | No element offset in the final result. | The hybrid request includes a collection-level vector field, an EmbeddingList request, or element-level requests under different StructArray fields. |
+| Element level | Primary key plus parent StructArray field plus element offset. | The selected element offset can be returned when exposed by the API or SDK. | All `AnnSearchRequest` objects are element-level and under the same StructArray field. |
+
+## Limitations
+
+- Use `element_scope` only for StructArray element-level `AnnSearchRequest` objects that must be collapsed to entity-level candidates in hybrid search.
+
+- Do not use `element_scope` for EmbeddingList requests, collection-level vector requests, or same-StructArray element-level hybrid search.
+
+- `sum` and `topk_sum` collapse strategies require positive-correlation metrics, such as `IP` or `COSINE`. Do not use them with `L2`.
+
+- `topk_sum` and `topk_avg` require a positive `topk` value. Other collapse strategies must not include `topk`.
+
+- EmbeddingList-level StructArray requests do not support range search or group-by.
+
+- Hybrid group-by is supported only for same-StructArray element-level hybrid search and only by primary key.
+
+- Do not combine range search with group-by.
+
+## Common mistakes
+
+- Adding `element_scope` to a same-StructArray element-level hybrid request. That request remains element-level and does not perform entity-level collapse.
+
+- Adding `element_scope` to `chunks[emb_list_vector]`. EmbeddingList search is already entity-level.
+
+- Assuming two StructArray fields share element offsets. Offset `3` in `chunks` and offset `3` in another StructArray field are different elements, so the hybrid request becomes entity-level.
+
+- Using `topk_sum` with `L2`. Use `max`, `avg`, or `topk_avg` for negative distance metrics.
+
+- Expecting entity-level hybrid results to include the selected Struct element offset after collapse.
+
+## Next steps
+
+1. To learn the two basic StructArray vector search modes, read [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md).
+
+1. To add scalar filters to hybrid search, read [Filtered Search with StructArray](filtered-search-with-structarray.md).
+
+1. To use score or distance boundaries in hybrid search, read [Range Search with StructArray](range-search-with-structarray.md).
+
+1. To group element-level hybrid results by parent entity, read [Grouping Search with StructArray](grouping-search-with-structarray.md).
+
+1. To check StructArray search limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/search-query-get/range-search-with-structarray.md
+++ b/site/en/userGuide/search-query-get/range-search-with-structarray.md
@@ -1,0 +1,215 @@
+---
+id: range-search-with-structarray.md
+title: "Range Search with StructArray"
+summary: "Use this page to run range search on StructArray vector subfields. Range search returns vector hits whose score or distance falls within a specified boundary. For StructArray fields, use range search with element-level vector search, where each Struct element is searched independently."
+---
+# Range Search with StructArray
+
+Use this page to run range search on StructArray vector subfields. Range search returns vector hits whose score or distance falls within a specified boundary. For StructArray fields, use range search with element-level vector search, where each Struct element is searched independently.
+
+This page uses the `tech_articles` collection from [Create a StructArray Field](create-structarray-field.md). The collection has a StructArray field named `chunks`. The `chunks[emb]` vector subfield is indexed for element-level search with a regular vector metric such as `COSINE`, `IP`, or `L2`.
+
+## How range search applies to StructArray
+
+| Search mode | Range search behavior | Result granularity |
+| --- | --- | --- |
+| EmbeddingList search | Not supported. | Not applicable. |
+| Element-level search | Use a regular vector query with `radius` and, optionally, `range_filter`. | Struct element level. |
+| Hybrid search | Supported when the StructArray request targets an element-level vector field. EmbeddingList-level requests do not support range search. | Element-level sub-search, then hybrid reranking. |
+
+<div class="alert note">
+
+If you only need the nearest Struct elements, start with [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md). Use range search when the result must satisfy a score or distance boundary instead of only a top-K ranking.
+
+</div>
+
+## Before you begin
+
+Prepare the collection, data, and indexes before running range search.
+
+| Requirement | Details |
+| --- | --- |
+| StructArray field | The collection contains a StructArray field such as `chunks`. |
+| Element-level vector subfield | The target vector subfield is `chunks[emb]`, not `chunks[emb_list_vector]`. |
+| Index metric | The vector subfield is indexed with a regular vector metric, such as `COSINE`, `IP`, or `L2`. |
+| Query data | The query is a regular vector, not an `EmbeddingList`. |
+
+For index setup, see [Index StructArray Fields](index-structarray-fields.md).
+
+## Use radius and range_filter
+
+Set `radius` to define the search boundary. Set `range_filter` when you need an inner boundary as well. The direction depends on whether a smaller distance is better or a larger similarity score is better.
+
+| Metric type | Higher score is better? | Range condition when `range_filter` is used |
+| --- | --- | --- |
+| `L2` | No. Smaller distance is better. | `range_filter <= distance < radius` |
+| `IP`, `COSINE` | Yes. Larger score is better. | `radius < distance <= range_filter` |
+
+When only `radius` is set, the range search returns hits that satisfy the outer boundary for the metric. Choose values according to the score or distance scale of your embeddings.
+
+## Run element-level range search
+
+The following example searches individual chunks whose `chunks[emb]` vectors are similar enough to the query vector. Each result hit represents a matched Struct element.
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus",
+)
+
+query_vector = [0.19, 0.24, 0.30, 0.37]
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    search_params={
+        "params": {
+            "radius": 0.80,
+            "range_filter": 0.95,
+        },
+    },
+    limit=10,
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[page]",
+        "chunks[quality_score]",
+    ],
+)
+
+for hits in results:
+    for hit in hits:
+        print(
+            "doc_id:", hit["id"],
+            "distance:", hit["distance"],
+            "offset:", hit.get("offset"),
+            "entity:", hit["entity"],
+        )
+```
+
+In this example, `COSINE` is a similarity-style metric, so the result range is greater than `radius` and less than or equal to `range_filter`. The `offset` value identifies the matched Struct element in the `chunks` array when returned.
+
+## Add scalar filters
+
+You can combine element-level range search with StructArray scalar filtering. Use a top-level predicate for parent-entity fields, and use `element_filter` to constrain which Struct elements participate in the vector range search.
+
+```python
+filter_expr = (
+    'category == "search" && '
+    'element_filter(chunks, '
+    '$[section] == "index" && '
+    '$[quality_score] > 0.9)'
+)
+
+results = client.search(
+    collection_name="tech_articles",
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    search_params={
+        "params": {
+            "radius": 0.80,
+            "range_filter": 0.95,
+        },
+    },
+    filter=filter_expr,
+    limit=10,
+    output_fields=[
+        "doc_id",
+        "title",
+        "category",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+The top-level predicate selects candidate entities. The `element_filter` predicate restricts vector range search to matching Struct elements. For more filtering examples, see [Filtered Search with StructArray](filtered-search-with-structarray.md).
+
+## Use range search in hybrid search
+
+StructArray element-level vector fields support range search in hybrid search. Add `radius` and, optionally, `range_filter` to the `AnnSearchRequest` that targets the StructArray element-level vector field.
+
+```python
+from pymilvus import AnnSearchRequest, RRFRanker
+
+title_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="title_vector",
+    limit=10,
+)
+
+chunk_req = AnnSearchRequest(
+    data=[query_vector],
+    anns_field="chunks[emb]",
+    param={
+        "params": {
+            "radius": 0.80,
+            "range_filter": 0.95,
+        },
+    },
+    limit=10,
+    expr='element_filter(chunks, $[section] == "index")',
+)
+
+results = client.hybrid_search(
+    collection_name="tech_articles",
+    reqs=[title_req, chunk_req],
+    ranker=RRFRanker(),
+    limit=5,
+    output_fields=[
+        "doc_id",
+        "title",
+        "chunks[text]",
+        "chunks[section]",
+        "chunks[quality_score]",
+    ],
+)
+```
+
+In this example, only the `chunks[emb]` sub-request uses range-search parameters. The StructArray request still follows element-level semantics: the range boundary applies to Struct element hits before the hybrid search combines and reranks results.
+
+## Interpret range results
+
+| Result item | Meaning |
+| --- | --- |
+| `id` | Primary key of the entity that contains the matched Struct element. |
+| `distance` or score | The score or distance between the query vector and the matched Struct element vector. |
+| `offset` | Zero-based position of the matched Struct element in the StructArray field when returned. |
+| Repeated primary keys | Possible. More than one Struct element in the same entity can fall within the specified range. |
+| `limit` | Applies to element hits, not unique parent entities. |
+
+## Limitations
+
+- Do not use an `EmbeddingList` query or a `MAX_SIM*` metric for range search on StructArray vector subfields. EmbeddingList-level search does not support range search.
+
+- Do not combine range search with grouping search. If you need one result per parent entity, run an element-level search without range parameters and use grouping where supported.
+
+- Hybrid range search is supported for StructArray element-level vector fields. It is not supported for EmbeddingList-level StructArray requests.
+
+## Common mistakes
+
+- Running range search against `chunks[emb_list_vector]`, which is intended for EmbeddingList search.
+
+- Using `MAX_SIM_COSINE` instead of a regular metric such as `COSINE` for element-level range search.
+
+- Using an `EmbeddingList` query instead of a regular vector query.
+
+- Expecting range search results to be unique by parent entity. Range search returns matching Struct element hits.
+
+- Using `chunks.emb` instead of the required subfield path syntax `chunks[emb]`.
+
+## Next steps
+
+1. To learn the two basic StructArray vector search modes, read [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md).
+
+2. To add scalar filters to range search, read [Filtered Search with StructArray](filtered-search-with-structarray.md).
+
+3. To return at most one result per parent entity where supported, read [Grouping Search with StructArray](grouping-search-with-structarray.md).
+
+4. To check version-specific search limits, read [StructArray Limits](structarray-limits.md).

--- a/site/en/userGuide/search-query-get/search-with-embedding-lists.md
+++ b/site/en/userGuide/search-query-get/search-with-embedding-lists.md
@@ -1,16 +1,17 @@
 ---
 id: search-with-embedding-lists.md
-title: "Search with Embedding Lists"
-summary: "This page explains how to set up a ColBERT text retrieval system and a ColPali text retrieval system using the array of structs in Milvus, which enables you to store a document along with its vectorized chunks in embedding lists."
+title: "Search with EmbeddingLists: ColBERT and ColPali"
+summary: "This tutorial shows how to build ColBERT-style and ColPali-style retrieval systems with EmbeddingList search on StructArray vector subfields in Milvus. Use it when your query and stored data are both represented as lists of vectors and you want entity-level late-interaction retrieval with MAX_SIM* metrics."
 ---
+# Search with EmbeddingLists: ColBERT and ColPali
 
-# Search with Embedding Lists
+This tutorial shows how to build ColBERT-style and ColPali-style retrieval systems with EmbeddingList search on StructArray vector subfields in Milvus. Use it when your query and stored data are both represented as lists of vectors and you want entity-level late-interaction retrieval with `MAX_SIM*` metrics.
 
-This page explains how to set up a ColBERT text retrieval system and a ColPali text retrieval system using the array of structs in Milvus, which enables you to store a document along with its vectorized chunks in embedding lists. 
+For the StructArray basics behind this tutorial, see [Create a StructArray Field](create-structarray-field.md), [Index StructArray Fields](index-structarray-fields.md), and [Basic Vector Search with StructArray](basic-vector-search-with-structarray.md). This tutorial focuses on the ColBERT and ColPali workflows rather than general StructArray syntax.
 
 ## Overview
 
-To build a text retrieval system, you might need to split documents into chunks and store each chunk along with its embeddings as an entity in a vector database to ensure precision and accuracy, especially for long documents where full-text embeddings could dilute semantic specificity or exceed model input limits. 
+To build a text retrieval system, you might need to split documents into chunks and store each chunk along with its embeddings as an entity in a vector database to ensure precision and accuracy, especially for long documents where full-text embeddings could dilute semantic specificity or exceed model input limits.
 
 However, storing data in chunks leads to chunk-wise search results, meaning that retrieval initially identifies relevant *segments* rather than cohesive *documents*. To address this, you should perform additional post-search processing.
 
@@ -20,7 +21,7 @@ ColBERT (arXiv: [2004.12832](https://arxiv.org/abs/2004.12832)) is a text-text r
 
 During data ingestion in ColBERT, each document is split into tokens, which are then vectorized and stored as an embedding list, as in $d \rightarrow E_d = [e_{d1}, e_{d2}, \dots, e_{dn}] ∈ \R^{n×d}$. When a query arrives, it is also tokenized, vectorized, and stored as an embedding list, as in $q \rightarrow E_q = [e_{q1}, e_{q2}, \dots, e_{qm}] ∈ \R^{m×d}$.
 
-In the above formulae, 
+In the above formulae,
 
 - $d$: a document
 
@@ -38,13 +39,11 @@ In the above formulae,
 
 Once vectorization is complete, the query embedding list is compared with each document embedding list, token by token, to determine the final similarity score.
 
-![Late Interaction](../../../../assets/late-interaction.png)
-
-As shown in the diagram above, the query contains two tokens, namely `machine` and `learning`, and the document in the window has four tokens: `neural`, `network`, `python`, and `tutorial`. Once these tokens are vectorized, the vector embeddings of each query token are compared with those in the document to get a list of similarity scores. Then the highest scores from each score list are summed to produce the final score. The process for determining a document's final score is known as maximum similarity (**MAX_SIM**). For details on maximum similarity, refer to [Maximum similarity](metric.md#Maximum-similarity).
+As shown in the diagram above, the query contains two tokens, namely `machine` and `learning`, and the document in the window has four tokens: `neural`, `network`, `python`, and `tutorial`. Once these tokens are vectorized, the vector embeddings of each query token are compared with those in the document to get a list of similarity scores. Then the highest scores from each score list are summed to produce the final score. The process for determining a document's final score is known as maximum similarity (**MAX_SIM**). For details on maximum similarity, refer to Maximum similarity.
 
 <div class="alert note">
 
-When implementing a ColBERT-like text retrieval system in Milvus, you are not limited to splitting documents into tokens. 
+When implementing a ColBERT-like text retrieval system in Milvus, you are not limited to splitting documents into tokens.
 
 Instead, you can divide the documents into segments of any appropriate size, embed each segment to create an embedding list, and store the document along with its embedded segments in an entity.
 
@@ -56,21 +55,19 @@ Based on ColBERT, ColPali (arXiv: [2407.01449](https://arxiv.org/abs/2407.01449?
 
 This method preserves non-textual information, such as the document layout, images, and table structures, which are lost when using text-only retrieval systems.
 
-![Copali Extension](../../../../assets/copali-extension.png)
-
 The VLM used in ColPali is called PaliGemma (arXiv: [2407.07726](https://arxiv.org/html/2407.07726v2#S1)), which comprises an image encoder (**SigLIP-400M**), a decoder-only language model (**Gemma2-2B**), and a linear layer that projects the image encoder's output into the language model's vector space, as shown in the above diagram.
 
-During data ingestion, a document page, represented as a raw image, is divided into multiple visual patches, each of which is embedded to generate a list of vector embeddings. Then they are projected into the language model's vector space to obtain the final embedding list, as in $d \rightarrow E_d = [e_{d1}, e_{d2}, \dots, e_{dn}] ∈ \R^{n×d}$. When a query arrives, it is tokenized, and each token is embedded to generate a list of vector embeddings, as in $q \rightarrow E_q = [e_{q1}, e_{q2}, \dots, e_{qm}] ∈ \R^{m×d}$. Then, **MAX_SIM** has been applied to compare the two embedding lists and obtain the final score between the query and the document page. 
+During data ingestion, a document page, represented as a raw image, is divided into multiple visual patches, each of which is embedded to generate a list of vector embeddings. Then they are projected into the language model's vector space to obtain the final embedding list, as in $d \rightarrow E_d = [e_{d1}, e_{d2}, \dots, e_{dn}] ∈ \R^{n×d}$. When a query arrives, it is tokenized, and each token is embedded to generate a list of vector embeddings, as in $q \rightarrow E_q = [e_{q1}, e_{q2}, \dots, e_{qm}] ∈ \R^{m×d}$. Then, **MAX_SIM** has been applied to compare the two embedding lists and obtain the final score between the query and the document page.
 
 ## ColBERT text retrieval system
 
-In this section, we are going to set up a ColBERT text retrieval system using Milvus' Array of Structs. Before that, set up a Milvus v2.6.x instanceZilliz Cloud cluster compatible with Milvus v2.6.x, obtain a Cohere access token.
+In this section, we are going to set up a ColBERT text retrieval system using StructArray. Before that, set up a Milvus v2.6.x instance, and obtain a Cohere access token.
 
 ### Step 1: Install the dependencies
 
 Run the following command to install the dependencies.
 
-```shell
+```Shell
 pip install --upgrade huggingface-hub transformers datasets pymilvus cohere
 ```
 
@@ -83,40 +80,21 @@ from datasets import load_dataset
 
 lang = "simple"
 docs = load_dataset(
-    "Cohere/wikipedia-2023-11-embed-multilingual-v3", 
-    lang, 
+    "Cohere/wikipedia-2023-11-embed-multilingual-v3",
+    lang,
     split="train[:10000]"
 )
 ```
 
 Running the above scripts will download the dataset if it is not available locally. Each record in the dataset is a paragraph from a Wikipedia page. The following table shows the structure of this dataset.
 
-<table>
-   <tr>
-     <th><p>Column Name</p></th>
-     <th><p>Description</p></th>
-   </tr>
-   <tr>
-     <td><p><code>_id</code></p></td>
-     <td><p>A record ID</p></td>
-   </tr>
-   <tr>
-     <td><p><code>url</code></p></td>
-     <td><p>The URL of the current record.</p></td>
-   </tr>
-   <tr>
-     <td><p><code>title</code></p></td>
-     <td><p>The title of the source document.</p></td>
-   </tr>
-   <tr>
-     <td><p><code>text</code></p></td>
-     <td><p>A paragraph from the source document.</p></td>
-   </tr>
-   <tr>
-     <td><p><code>emb</code></p></td>
-     <td><p>Embeddings of the text from the source document.</p></td>
-   </tr>
-</table>
+| Column Name | Description |
+| --- | --- |
+| `_id` | A record ID |
+| `url` | The URL of the current record. |
+| `title` | The title of the source document. |
+| `text` | A paragraph from the source document. |
+| `emb` | Embeddings of the text from the source document. |
 
 ### Step 3: Group paragraphs by title
 
@@ -142,7 +120,7 @@ In this code, we store the grouped paragraphs as documents and include them in t
 
 ### Step 4: Create a collection for the Cohere dataset
 
-Once the data is ready, we will create a collection. In the collection, there is a field named `paragraphs`, which is an Array of Structs.
+Once the data is ready, we will create a collection. In the collection, `paragraphs` is a StructArray field. For a general explanation of StructArray schemas, see [Create a StructArray Field](create-structarray-field.md).
 
 ```python
 from pymilvus import MilvusClient, DataType
@@ -177,8 +155,8 @@ index_params.add_index(
 
 # Create a collection
 client.create_collection(
-    collection_name='wiki_documents', 
-    schema=schema, 
+    collection_name='wiki_documents',
+    schema=schema,
     index_params=index_params
 )
 ```
@@ -189,7 +167,7 @@ Now we can insert the prepared data into the collection we created above.
 
 ```python
 client.insert(
-    collection_name='wiki_documents', 
+    collection_name='wiki_documents',
     data=data
 )
 ```
@@ -238,9 +216,6 @@ results = client.search(
     collection_name="wiki_documents",
     data=[query_emb_list],
     anns_field="paragraphs[emb]",
-    search_params={
-        "metric_type": "MAX_SIM_COSINE"
-    },
     limit=10,
     output_fields=["title"]
 )
@@ -264,21 +239,21 @@ The output of the above code is similar to the following:
 # Document Computer science: 1.9460
 ```
 
-The cosine similarity score ranges from `-1` to `1`, and the similarity scores in the above output clearly demonstrate the sum of multiple token-level similarity scores.
+Each pairwise cosine similarity score ranges from `-1` to `1`. The final `MAX_SIM_COSINE` score can be greater than `1` because it aggregates multiple token-level maximum similarity scores.
 
-## ColPali text retrieval system
+## ColPali document retrieval system
 
-In this section, we will set up a ColPali-based text retrieval system using Milvus' Array of Structs. Before that, set up a Milvus v2.6.x instanceZilliz Cloud cluster compatible with Milvus v2.6.x.
+In this section, we will set up a ColPali-based document retrieval system using StructArray. Before that, set up a Milvus v2.6.x instance.
 
 ### Step 1: Install the dependencies
 
-```shell
+```Shell
 pip install --upgrade huggingface-hub transformers datasets pymilvus 'colpali-engine>=0.3.0,<0.4.0'
 ```
 
 ### Step 2: Load the Vidore dataset
 
-In this section, we will use a Vidore dataset named **vidore_v2_finance_en**. This dataset is a corpus of annual reports from the banking sector, intended for long-document understanding tasks. It is one of the 10 corpora comprising the ViDoRe v3 Benchmark. You can find details about this dataset on [this page](https://huggingface.co/datasets/vidore/vidore_v3_finance_en). 
+In this section, we will use a Vidore dataset named **vidore_v2_finance_en**. This dataset is a corpus of annual reports from the banking sector, intended for long-document understanding tasks. It is one of the 10 corpora comprising the ViDoRe v3 Benchmark. You can find details about this dataset on [this page](https://huggingface.co/datasets/vidore/vidore_v3_finance_en).
 
 ```python
 from datasets import load_dataset
@@ -289,32 +264,16 @@ df = ds['test'].to_pandas()
 
 Running the above scripts will download the dataset if it is not available locally. Each record in the dataset is a page from a financial report. The following table shows the structure of this dataset.
 
-<table>
-   <tr>
-     <th><p>Column Name</p></th>
-     <th><p>Description</p></th>
-   </tr>
-   <tr>
-     <td><p><code>corpus_id</code></p></td>
-     <td><p>A record in the corpus</p></td>
-   </tr>
-   <tr>
-     <td><p><code>image</code></p></td>
-     <td><p>The page image in bytes.</p></td>
-   </tr>
-   <tr>
-     <td><p><code>doc_id</code></p></td>
-     <td><p>The descriptive document ID.</p></td>
-   </tr>
-   <tr>
-     <td><p><code>page_number_in_doc</code></p></td>
-     <td><p>The page number of the current page in the doc.</p></td>
-   </tr>
-</table>
+| Column Name | Description |
+| --- | --- |
+| `corpus_id` | A record in the corpus |
+| `image` | The page image in bytes. |
+| `doc_id` | The descriptive document ID. |
+| `page_number_in_doc` | The page number of the current page in the doc. |
 
 ### Step 3: Generate embeddings for the page images
 
-As illustrated in the [Overview](search-with-embedding-lists.md#ColPali-extension) section, the ColPali model is a VLM that projects images into the vector space of a text model. In this step, we will use the latest ColPali model **vidore/colpali-v1.3**. You can find details about this model on [this page](https://huggingface.co/vidore/colpali-v1.3). 
+As illustrated in the [Overview](search-with-embedding-lists.md#overview) section, the ColPali model is a VLM that projects images into the vector space of a text model. In this step, we will use the latest ColPali model **vidore/colpali-v1.3**. You can find details about this model on [this page](https://huggingface.co/vidore/colpali-v1.3).
 
 ```python
 import torch
@@ -338,15 +297,17 @@ Once the model is ready, you can try to generate patches for a specific image as
 from PIL import Image
 from io import BytesIO
 
-# Use the iterrow() generator to get the first row
+# Use the iterrows() generator to get the first row.
 row = next(df.iterrows())[1]
 
-# Include the image in the above row in a list
-images = [ Image.open(row['image']['bytes'] ]
-patches = processor.process_images(images).to(model.device)
-patches_embeddings = model(**patches_in_pixels)[0]
+# Decode the image bytes and generate patch embeddings.
+images = [Image.open(BytesIO(row["image"]["bytes"]))]
+batch_images = processor.process_images(images).to(model.device)
 
-# Check the shape of the embeddings generated for the patches
+with torch.no_grad():
+    patches_embeddings = model(**batch_images)[0]
+
+# Check the shape of the embeddings generated for the patches.
 print(patches_embeddings.shape)
 
 # [1031, 128]
@@ -359,24 +320,26 @@ You can generate embeddings for all the images using a loop as follows:
 ```python
 data = []
 
-for index, row in df.iterrows():
-  row = next(df.iterrows())[1]
-  corpus_id = row['corpus_id']
-  
-  images = [Image.open(BytesIO(row['image']['bytes']))]
-  batch_images = processor.process_images(images).to(model.device)
-  patches = model(**batch_images)[0]
+for _, row in df.iterrows():
+    corpus_id = row["corpus_id"]
+    images = [Image.open(BytesIO(row["image"]["bytes"]))]
+    batch_images = processor.process_images(images).to(model.device)
 
-  doc_id = row['doc_id']
-  markdown = row['markdown']
-  page_number_in_doc = row['page_number_in_doc']
+    with torch.no_grad():
+        patches = model(**batch_images)[0]
 
-  data.append({
-      "corpus_id": corpus_id,
-      "patches": [ {"emb": emb} for emb in patches ],
-      "doc_id": markdown,
-      "page_number_in_doc": row['page_number_in_doc']
-  })
+    doc_id = row["doc_id"]
+    page_number_in_doc = row["page_number_in_doc"]
+
+    data.append({
+        "corpus_id": corpus_id,
+        "patches": [
+            {"emb": emb.float().cpu().tolist()}
+            for emb in patches
+        ],
+        "doc_id": doc_id,
+        "page_number_in_doc": page_number_in_doc,
+    })
 ```
 
 <div class="alert note">
@@ -387,7 +350,7 @@ This step is relatively time-consuming due to the large amount of data that need
 
 ### Step 4: Create a collection for the financial reports dataset
 
-Once the data is ready, we will create a collection. In the collection, a field named `patches` is an Array of Structs.
+Once the data is ready, we will create a collection. In the collection, `patches` is a StructArray field. Each Struct element stores one patch embedding. For index requirements on StructArray vector subfields, see [Index StructArray Fields](index-structarray-fields.md).
 
 ```python
 from pymilvus import MilvusClient, DataType
@@ -458,6 +421,12 @@ client.insert(
 )
 ```
 
+<div class="alert note">
+
+Inserting the financial reports can take a long time. Each page can contain more than one thousand patch vectors, and each vector is stored inside the `patches` StructArray field. For larger datasets, split `data` into smaller batches and insert one batch at a time.
+
+</div>
+
 From the output, you can find that all pages from the Vidore dataset are inserted.
 
 ### Step 6: Search within the financial reports
@@ -474,20 +443,16 @@ queries = [
 batch_queries = processor.process_queries(queries).to(model.device)
 
 with torch.no_grad():
-  query_embeddings = model(**batch_queries)
+    query_embeddings = model(**batch_queries)
 
 query_emb_list = EmbeddingList()
-query_emb_list.add_batch(query_embeddings[0].cpu())
+query_emb_list.add_batch(query_embeddings[0].float().cpu().tolist())
 
 results = client.search(
     collection_name="financial_reports",
     data=[query_emb_list],
     anns_field="patches[emb]",
-    search_params={
-        "metric_type": "MAX_SIM_COSINE"
-    },
     limit=10,
     output_fields=["doc_id", "page_number_in_doc"]
 )
-
 ```


### PR DESCRIPTION
## Summary
- Add StructArray schema docs under Schema & Data Fields
- Add StructArray search docs under Search / Query / Get
- Update StructArray operators and EmbeddingList docs, and restructure menu entries

## Verification
- `node check-link.js`
- `node -e "JSON.parse(require('fs').readFileSync('site/en/menuStructure/en.json','utf8')); console.log('menu JSON ok')"`
- `git diff --check upstream/preview...HEAD`
