### PR TITLE
docs: add pinyin analyzer filter

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -643,45 +643,51 @@
                     "children": []
                   },
                   {
+                    "label": "Pinyin",
+                    "id": "pinyin-filter.md",
+                    "order": 5,
+                    "children": []
+                  },
+                  {
                     "label": "Length",
                     "id": "length-filter.md",
-                    "order": 5,
+                    "order": 6,
                     "children": []
                   },
                   {
                     "label": "Stop",
                     "id": "stop-filter.md",
-                    "order": 6,
+                    "order": 7,
                     "children": []
                   },
                   {
                     "label": "Decompounder",
                     "id": "decompounder-filter.md",
-                    "order": 7,
+                    "order": 8,
                     "children": []
                   },
                   {
                     "label": "Stemmer",
                     "id": "stemmer-filter.md",
-                    "order": 8,
+                    "order": 9,
                     "children": []
                   },
                   {
                     "label": "Remove Punct",
                     "id": "removepunct-filter.md",
-                    "order": 9,
+                    "order": 10,
                     "children": []
                   },
                   {
                     "label": "Regex",
                     "id": "regex-filter.md",
-                    "order": 10,
+                    "order": 11,
                     "children": []
                   },
                   {
                     "label": "Synonym",
                     "id": "synonym-filter.md",
-                    "order": 11,
+                    "order": 12,
                     "children": []
                   }
                 ]

--- a/site/en/userGuide/schema/analyzer/analyzer-overview.md
+++ b/site/en/userGuide/schema/analyzer/analyzer-overview.md
@@ -326,6 +326,8 @@ Filters in a custom analyzer can be either **built-in** or **custom**, depending
 
     - `cncharonly`: Removes tokens that contain any non-Chinese characters. For details, refer to [Cncharonly](cncharonly-filter.md).
 
+    - `pinyin`: Adds Pinyin token forms for Chinese tokens, enabling Pinyin-based matching for Chinese text. For details, refer to [Pinyin](pinyin-filter.md).
+
     **Example of using a built-in filter:**
 
     <div class="multipleCode">
@@ -945,4 +947,3 @@ After configuring an analyzer, you can integrate with text retrieval features pr
 - [Text Match](keyword-match.md)
 
 - [Phrase Match](phrase-match.md)
-

--- a/site/en/userGuide/schema/analyzer/analyzer/chinese-analyzer.md
+++ b/site/en/userGuide/schema/analyzer/analyzer/chinese-analyzer.md
@@ -18,6 +18,12 @@ The `chinese` analyzer consists of:
 
 The functionality of the `chinese` analyzer is equivalent to the following custom analyzer configuration:
 
+<div class="alert note">
+
+The built-in `chinese` analyzer does not emit Pinyin tokens. To match Chinese text with Pinyin query terms, use a custom analyzer with the `jieba` tokenizer and the [`pinyin`](pinyin-filter.md) filter.
+
+</div>
+
 <div class="multipleCode">
     <a href="#python">Python</a>
     <a href="#java">Java</a>
@@ -233,4 +239,3 @@ if err != nil {
 ```python
 Chinese analyzer output: ['Milvus', '是', '一个', '高性', '性能', '高性能', '可', '扩展', '的', '向量', '数据', '据库', '数据库']
 ```
-

--- a/site/en/userGuide/schema/analyzer/choose-the-right-analyzer-for-your-use-case.md
+++ b/site/en/userGuide/schema/analyzer/choose-the-right-analyzer-for-your-use-case.md
@@ -67,6 +67,13 @@ The following table summarizes common problems caused by improper analyzer selec
      <td><p><a href="english-analyzer.md"><code>english</code></a> analyzer</p></td>
      <td><p>Use a language-specific analyzer, such as <a href="chinese-analyzer.md"><code>chinese</code></a>.</p></td>
    </tr>
+   <tr>
+     <td><p>Input method mismatch</p></td>
+     <td><p>Users type Pinyin, but the indexed text uses Chinese characters.</p></td>
+     <td><p>Chinese text: <code>"足球"</code>; query text: <code>"zuqiu"</code></p></td>
+     <td><p>Analyzer that emits only Chinese-character tokens</p></td>
+     <td><p>Use a custom analyzer with the <a href="jieba-tokenizer.md"><code>jieba</code></a> tokenizer and <a href="pinyin-filter.md"><code>pinyin</code></a> filter.</p></td>
+   </tr>
 </table>
 
 ## First question: Do you need to choose an analyzer?
@@ -442,6 +449,12 @@ These filters handle specific language characteristics:
      <td><p>Keeps only Chinese characters</p></td>
      <td><ul><li><p>Input: <code>["Hello", "世界", "123"]</code></p></li><li><p>Output: <code>[[], ['世界'], []]</code></p></li></ul></td>
    </tr>
+   <tr>
+     <td><p><a href="pinyin-filter.md"><code>pinyin</code></a></p></td>
+     <td><p>Chinese</p></td>
+     <td><p>Emits Pinyin token forms for Chinese tokens</p></td>
+     <td><ul><li><p>Input: <code>["中文"]</code></p></li><li><p>Output: <code>[['中文', 'zhong', 'wen']]</code></p></li></ul></td>
+   </tr>
 </table>
 
 ### Step 3: Combine and implement
@@ -574,6 +587,15 @@ analyzer_params = {
 For Simplified Chinese, `cnalphanumonly` removes all tokens except Chinese characters, alphanumeric text, and digits. This prevents punctuation from affecting search quality.
 
 </div>
+
+If users may search Chinese text by typing Pinyin, use a custom analyzer with the `jieba` tokenizer and the [`pinyin`](pinyin-filter.md) filter instead of the built-in `chinese` analyzer.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    "filter": ["pinyin"]
+}
+```
 
 ### Japanese content
 

--- a/site/en/userGuide/schema/analyzer/filter/pinyin-filter.md
+++ b/site/en/userGuide/schema/analyzer/filter/pinyin-filter.md
@@ -1,0 +1,146 @@
+---
+id: pinyin-filter.md
+title: "Pinyin"
+summary: "The pinyin filter converts Chinese character tokens into Pinyin tokens during text analysis, enabling Pinyin-based matching for Chinese text."
+beta: Milvus 3.0.x
+---
+
+# Pinyin
+
+Chinese text search often requires users to enter Chinese characters exactly as they appear in the indexed text. In name lookup, autocomplete, and search-as-you-type workflows, users frequently type Pinyin instead of Chinese characters. For example, a user may type `zuqiu` to search for `足球`. The `pinyin` filter adds Pinyin tokens to the analyzer output so Chinese text can match Pinyin input without maintaining a separate Pinyin field.
+
+The `pinyin` filter is typically used with the [Jieba](jieba-tokenizer.md) tokenizer for Chinese text. It works in a custom analyzer filter pipeline and can emit multiple Pinyin token forms for the same Chinese token.
+
+## Configuration
+
+To use the default options, specify `"pinyin"` in the `filter` section of `analyzer_params`.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    # highlight-next-line
+    "filter": ["pinyin"],
+}
+```
+
+This shorthand keeps the original Chinese tokens and emits character-level Pinyin tokens. It does not emit joined Pinyin or Pinyin initials unless you enable those options explicitly.
+
+For full control, specify the filter as an object and configure the Pinyin token forms that Milvus emits.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    # highlight-start
+    "filter": [
+        {
+            "type": "pinyin",
+            "keep_original": True,
+            "keep_full_pinyin": True,
+            "keep_joined_full_pinyin": False,
+            "keep_separate_first_letter": False,
+        }
+    ],
+    # highlight-end
+}
+```
+
+The filter accepts the following parameters.
+
+
+| Parameter                    | Type    | Default | Description                                                                               |
+| ---------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------- |
+| `keep_original`              | Boolean | `true`  | Keeps the original Chinese token in the analyzer output.                                   |
+| `keep_full_pinyin`           | Boolean | `true`  | Emits character-level Pinyin tokens. For example, `中文` produces `zhong` and `wen`.        |
+| `keep_joined_full_pinyin`    | Boolean | `false` | Emits a joined Pinyin token for each source token. For example, `中文` produces `zhongwen`. |
+| `keep_separate_first_letter` | Boolean | `false` | Emits a Pinyin-initials token for each source token. For example, `中文` produces `zw`.     |
+
+
+The filter operates on tokens produced by the tokenizer. For Chinese text, use it with a tokenizer such as `jieba`.
+
+## Examples
+
+Before applying the analyzer configuration to your collection schema, verify its behavior with `run_analyzer`.
+
+```python
+from pymilvus import MilvusClient
+
+client = MilvusClient(uri="http://localhost:19530")
+
+sample_text = "中文测试"
+```
+
+### Match Chinese text with character-level Pinyin
+
+The default `pinyin` filter keeps the original Chinese tokens and emits character-level Pinyin tokens.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    "filter": ["pinyin"],
+}
+
+result = client.run_analyzer(sample_text, analyzer_params)
+print(result)
+```
+
+Expected output:
+
+```plaintext
+['中文', 'zhong', 'wen', '测试', 'ce', 'shi']
+```
+
+### Match Chinese terms with joined Pinyin
+
+Enable `keep_joined_full_pinyin` when you need a Chinese term to match its full joined Pinyin form.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    "filter": [
+        {
+            "type": "pinyin",
+            "keep_original": True,
+            "keep_full_pinyin": False,
+            "keep_joined_full_pinyin": True,
+            "keep_separate_first_letter": False,
+        }
+    ],
+}
+
+result = client.run_analyzer(sample_text, analyzer_params)
+print(result)
+```
+
+Expected output:
+
+```plaintext
+['中文', 'zhongwen', '测试', 'ceshi']
+```
+
+### Match Chinese terms with Pinyin initials
+
+Enable `keep_separate_first_letter` when you need a Chinese term to match the initials of its Pinyin form.
+
+```python
+analyzer_params = {
+    "tokenizer": "jieba",
+    "filter": [
+        {
+            "type": "pinyin",
+            "keep_original": True,
+            "keep_full_pinyin": False,
+            "keep_joined_full_pinyin": False,
+            "keep_separate_first_letter": True,
+        }
+    ],
+}
+
+result = client.run_analyzer(sample_text, analyzer_params)
+print(result)
+```
+
+Expected output:
+
+```plaintext
+['中文', 'zw', '测试', 'cs']
+```


### PR DESCRIPTION
## Summary
- Add the Pinyin analyzer filter page with configuration options and PyMilvus examples
- Add Pinyin filter discovery in analyzer navigation, overview, chooser, and Chinese analyzer docs
- Document that the built-in Chinese analyzer does not emit Pinyin tokens

## Validation
- Parsed `site/en/menuStructure/en.json`
- Ran `git diff --cached --check`
- Validated PyMilvus `run_analyzer` examples through Manta against Milvus master image `milvusdb/milvus:master-20260703-331cf54b`

## Notes
- `npm test` is not configured in this repo and exits with `Error: no test specified`
