### PR TITLE
docs: add ARRAY_APPEND and ARRAY_REMOVE operator docs

### DIFF
--- a/site/en/userGuide/insert-and-delete/upsert-entities.md
+++ b/site/en/userGuide/insert-and-delete/upsert-entities.md
@@ -34,6 +34,8 @@ To perform a merge, set `partial_update` to `True` in the `upsert` request along
 
 Upon receiving such a request, Milvus performs a query with strong consistency to retrieve the entity, updates the field values based on the data in the request, inserts the modified data, and then deletes the existing entity with the original primary key carried in the request.
 
+For `ARRAY` fields, merge mode supports two operators in Milvus v2.6.17 and later: `ARRAY_APPEND` and `ARRAY_REMOVE`. These operators let you append elements to or remove matching elements from an existing `ARRAY` field, without first querying the entity to retrieve its current value. For details, see [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).
+
 ### Upsert behaviors: special notes
 
 There are several special notes you should consider before using the merge feature. The following cases assume that you have a collection with two scalar fields named `title` and `issue`, along with a primary key `id` and a vector field called `vector`. 
@@ -65,6 +67,22 @@ There are several special notes you should consider before using the merge featu
     Suppose that the example collection has a schema-defined JSON field named `extras`, and the key-value pairs in this JSON field of an entity are similar to `{"author": "John", "year": 2020, "tags": ["fiction"]}`.
 
     When you upsert the `extras` field of an entity with modified JSON data, note that the JSON field is treated as a whole, and you cannot update individual keys selectively. In other words, the JSON field **DOES NOT** support upsert in **merge** mode.
+
+- **Upsert an** `ARRAY` **field.**
+
+    By default, an `ARRAY` field in merge mode follows **REPLACE** semantics: the value carried in the request overwrites the existing array. For finer-grained updates, Milvus v2.6.17 and later also supports two operators:
+
+    - `ARRAY_APPEND` appends the elements in the request payload to the existing array.
+
+    - `ARRAY_REMOVE` removes every element from the existing array that matches a value in the request payload.
+
+    For operator syntax, supported element types, and other constraints, see [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).
+
+- **Upsert a StructArray field.**
+
+    Upserting a StructArray field in an entity overwrites the field value. To do so, you need to provide a list of dictionaries, each of which contains all subfields defined in the struct schema, even when you perform the upsert in merge mode.
+
+    For details, refer to [Upsert StructArray field in merge mode](upsert-entities.md#Upsert-StructArray-field-in-merge-mode).
 
 ### Limits & Restrictions
 
@@ -566,3 +584,351 @@ curl -X POST "http://localhost:19530/v2/vectordb/entities/upsert" \
 # }
 ```
 
+## Upsert ARRAY fields in merge mode
+
+Before Milvus v2.6.17, updating part of an `ARRAY` field required a client-side read-modify-write flow: query the existing array, change it in application code, and upsert the full replacement value. Partial-update operators (`ARRAY_APPEND` and `ARRAY_REMOVE`) let you send only the elements to append or remove, which reduces client-side logic and avoids the extra read before the upsert.
+
+Suppose the entity with primary key `1` already has `tags = ["new", "trial"]`. Before partial-update operators, adding element `"premium"` to an array required upserting the full replacement array:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#go">Go</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+client.upsert(
+    collection_name="users",
+    # highlight-start
+    data=[{"pk": 1, "tags": ["new", "trial", "premium"]}],
+    partial_update=True,
+    # highlight-end
+)
+```
+
+```java
+List<JsonObject> replacementData = Collections.singletonList(
+        gson.fromJson("{\"pk\": 1, \"tags\": [\"new\", \"trial\", \"premium\"]}", JsonObject.class)
+);
+
+client.upsert(UpsertReq.builder()
+        .collectionName("users")
+        // highlight-start
+        .partialUpdate(true)
+        .data(replacementData)
+        // highlight-end
+        .build());
+```
+
+```javascript
+// nodejs
+```
+
+```go
+// go
+```
+
+```bash
+# restful
+```
+
+With `ARRAY_APPEND`, send only the element to add:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#go">Go</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+client.upsert(
+    collection_name="users",
+    # highlight-start
+    data=[{"pk": 1, "tags": ["premium"]}],
+    field_ops={"tags": FieldOp.array_append()},
+    # highlight-end
+)
+```
+
+```java
+List<JsonObject> appendData = Collections.singletonList(
+        gson.fromJson("{\"pk\": 1, \"tags\": [\"premium\"]}", JsonObject.class)
+);
+
+UpsertReq.FieldPartialUpdateOp appendTags = UpsertReq.FieldPartialUpdateOp.builder()
+        .fieldName("tags")
+        .opType(UpsertReq.FieldPartialUpdateOp.OpType.ARRAY_APPEND)
+        .build();
+
+client.upsert(UpsertReq.builder()
+        .collectionName("users")
+        // highlight-start
+        .data(appendData)
+        .fieldOps(Collections.singletonList(appendTags))
+        // highlight-end
+        .build());
+```
+
+```javascript
+// nodejs
+```
+
+```go
+// go
+```
+
+```bash
+# restful
+```
+
+With `ARRAY_REMOVE`, send only the matching element to remove:
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#go">Go</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+client.upsert(
+    collection_name="users",
+    # highlight-start
+    data=[{"pk": 1, "tags": ["trial"]}],
+    field_ops={"tags": FieldOp.array_remove()},
+    # highlight-end
+)
+```
+
+```java
+List<JsonObject> removeData = Collections.singletonList(
+        gson.fromJson("{\"pk\": 1, \"tags\": [\"trial\"]}", JsonObject.class)
+);
+
+UpsertReq.FieldPartialUpdateOp removeTags = UpsertReq.FieldPartialUpdateOp.builder()
+        .fieldName("tags")
+        .opType(UpsertReq.FieldPartialUpdateOp.OpType.ARRAY_REMOVE)
+        .build();
+
+client.upsert(UpsertReq.builder()
+        .collectionName("users")
+        // highlight-start
+        .data(removeData)
+        .fieldOps(Collections.singletonList(removeTags))
+        // highlight-end
+        .build());
+```
+
+```javascript
+// nodejs
+```
+
+```go
+// go
+```
+
+```bash
+# restful
+```
+
+<div class="alert note">
+
+Attaching either operator to a field via `field_ops` implicitly enables partial-update semantics. Therefore, you do **not** need to pass `partial_update=True` alongside `field_ops`.
+
+</div>
+
+### Limits
+
+- The payload values must match the `element_type` of the target `ARRAY` field. For example, if the target field is `ARRAY<VARCHAR>`, the payload must contain string values.
+
+- In Milvus v2.6.17 and later, `ARRAY_APPEND` and `ARRAY_REMOVE` support `ARRAY` fields whose `element_type` is `BOOL`, `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT`, `DOUBLE`, or `VARCHAR`.
+
+- After an `ARRAY_APPEND` operation, the resulting array length must not exceed the field's `max_capacity`.
+
+- Concurrent upserts to the same entity are not atomic across requests. If two requests update the same `ARRAY` field at the same time, the later write can overwrite the earlier one. Use application-level coordination if you need to preserve all concurrent changes.
+
+### Example
+
+The following example uses a small `users` collection with a primary key `pk`, a `tags` field of type `ARRAY<VARCHAR>`, and an `embedding` vector field. It first inserts two entities with initial `tags` values, then uses `ARRAY_APPEND` and `ARRAY_REMOVE` to show how each operator changes the stored array.
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#go">Go</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+from pymilvus import DataType, FieldOp, MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+# 1. Create a collection with an ARRAY<VARCHAR> field
+schema = client.create_schema(enable_dynamic_field=False)
+schema.add_field("pk", DataType.INT64, is_primary=True)
+schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=5)
+schema.add_field(
+    "tags",
+    DataType.ARRAY,
+    element_type=DataType.VARCHAR,
+    max_capacity=8,
+    max_length=32,
+)
+
+index_params = client.prepare_index_params()
+index_params.add_index(
+    field_name="embedding",
+    index_type="AUTOINDEX",
+    metric_type="L2",
+)
+
+client.create_collection(
+    collection_name="users",
+    schema=schema,
+    index_params=index_params
+)
+
+# 2. Seed two entities
+client.insert(
+    collection_name="users",
+    data=[
+        {"pk": 1, "embedding": [0.1, 0.2, 0.3, 0.4, 0.5], "tags": ["new"]},
+        {"pk": 2, "embedding": [0.6, 0.7, 0.8, 0.9, 1.0], "tags": ["new", "trial"]},
+    ],
+)
+
+# 3. Append tags without reading the existing ARRAY values
+client.upsert(
+    collection_name="users",
+    # highlight-start
+    data=[
+        {"pk": 1, "tags": ["premium", "vip"]},
+        {"pk": 2, "tags": ["premium"]},
+    ],
+    field_ops={"tags": FieldOp.array_append()},
+    # highlight-end
+)
+
+res = client.query(
+    collection_name="users",
+    filter="pk in [1, 2]",
+    output_fields=["pk", "tags"],
+)
+print(res)
+
+# Example output:
+# data: [
+#   "{'pk': 1, 'tags': ['new', 'premium', 'vip']}",
+#   "{'pk': 2, 'tags': ['new', 'trial', 'premium']}"
+# ]
+
+# 4. Remove matching tags without replacing the full ARRAY field
+client.upsert(
+    collection_name="users",
+    # highlight-start
+    data=[
+        {"pk": 1, "tags": ["new"]},
+        {"pk": 2, "tags": ["trial"]},
+    ],
+    field_ops={"tags": FieldOp.array_remove()},
+    # highlight-end
+)
+
+res = client.query(
+    collection_name="users",
+    filter="pk in [1, 2]",
+    output_fields=["pk", "tags"],
+)
+print(res)
+
+# Example output:
+# data: [
+#   "{'pk': 1, 'tags': ['premium', 'vip']}",
+#   "{'pk': 2, 'tags': ['new', 'premium']}"
+# ]
+```
+
+```java
+// java
+```
+
+```javascript
+// nodejs
+```
+
+```go
+// go
+```
+
+```bash
+# restful
+```
+
+## Upsert StructArray field in merge mode
+
+Upserting a StructArray field in an entity overwrites the field value. That means you need to include all subfields defined in the struct schema when you upsert a StructArray field.
+
+The following example demonstrates how to upsert the `chunks` field in merge mode, a StructArray field with 6 subfields. When the operation completes, the `chunks` field of the entity with id 1 is set to the array with the two-element structs provided in the request.
+
+<div class="multipleCode">
+    <a href="#python">Python</a>
+    <a href="#java">Java</a>
+    <a href="#javascript">NodeJS</a>
+    <a href="#go">Go</a>
+    <a href="#bash">cURL</a>
+</div>
+
+```python
+client.upsert(
+    collection_name="books",
+    # highlight-start
+    data=[{
+        "id": 1,
+        "chunks": [
+            {
+              "text": "Use HNSW efSearch to trade recall for latency.",
+              "section": "index",
+              "page": 1,
+              "quality_score": 0.92,
+              "has_code": True,
+              "emb_list_vector": [0.11, 0.21, 0.31, 0.41]
+            },
+            {
+              "text": "Range search returns vectors within a distance boundary.",
+              "section": "search",
+              "page": 2,
+              "quality_score": 0.86,
+              "has_code": False,
+              "emb_list_vector": [0.18, 0.23, 0.29, 0.36]
+            }
+        ]
+    }],
+    # highlight-end
+    partial_update=True
+)
+```
+
+```java
+// java
+```
+
+```javascript
+// nodejs
+```
+
+```go
+// go
+```
+
+```bash
+# restful
+```

--- a/site/en/userGuide/insert-and-delete/upsert-entities.md
+++ b/site/en/userGuide/insert-and-delete/upsert-entities.md
@@ -584,7 +584,7 @@ curl -X POST "http://localhost:19530/v2/vectordb/entities/upsert" \
 # }
 ```
 
-## Upsert ARRAY fields in merge mode
+## Upsert ARRAY fields in merge mode | Milvus 2.6.17+
 
 Before Milvus v2.6.17, updating part of an `ARRAY` field required a client-side read-modify-write flow: query the existing array, change it in application code, and upsert the full replacement value. Partial-update operators (`ARRAY_APPEND` and `ARRAY_REMOVE`) let you send only the elements to append or remove, which reduces client-side logic and avoids the extra read before the upsert.
 

--- a/site/en/userGuide/schema/array_data_type.md
+++ b/site/en/userGuide/schema/array_data_type.md
@@ -524,6 +524,12 @@ curl --request POST \
 }'
 ```
 
+<div class="alert note">
+
+Beyond inserting full arrays, `ARRAY` fields also support the `ARRAY_APPEND` and `ARRAY_REMOVE` partial-update operators on the `upsert` API in Milvus v2.6.17 and later. These let you append elements to or remove matching elements from an existing array without first retrieving its current value, which avoids the client-side read-modify-write pattern. For details, see [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).
+
+</div>
+
 ## Query with filter expressions
 
 After inserting entities, use the `query` method to retrieve entities that match the specified filter expressions.

--- a/site/en/userGuide/search-query-get/boolean/array-operators.md
+++ b/site/en/userGuide/search-query-get/boolean/array-operators.md
@@ -1,12 +1,12 @@
 ---
 id: array-operators.md
 title: "ARRAY Operators"
-summary: "Milvus provides powerful operators to query array fields, allowing you to filter and retrieve entities based on the contents of arrays."
+summary: "Milvus provides ARRAY operators for filtering ARRAY fields and partially updating ARRAY field values."
 ---
 
 # ARRAY Operators
 
-Milvus provides powerful operators to query array fields, allowing you to filter and retrieve entities based on the contents of arrays. 
+Milvus provides ARRAY operators for filtering ARRAY fields and partially updating ARRAY field values.
 
 <div class="alert note">
 
@@ -14,17 +14,24 @@ All elements within an array must be the same type, and nested structures within
 
 </div>
 
-## Available ARRAY Operators
+ARRAY operators in Milvus cover two usage scenarios:
 
-The ARRAY operators allow for fine-grained querying of array fields in Milvus. These operators are:
+- Filter expressions for query and search.
 
-- [`ARRAY_CONTAINS(identifier, expr)`](array-operators.md#ARRAYCONTAINS): checks if a specific element exists in an array field.
+- Partial updates in `upsert` requests.
 
-- [`ARRAY_CONTAINS_ALL(identifier, expr)`](array-operators.md#ARRAYCONTAINSALL): ensures that all elements of the specified list are present in the array field.
+## Available ARRAY operators
 
-- [`ARRAY_CONTAINS_ANY(identifier, expr)`](array-operators.md#ARRAYCONTAINSANY): checks if any of the elements from the specified list are present in the array field.
+The following table lists ARRAY operators available in Milvus.
 
-- [`ARRAY_LENGTH(identifier)`](array-operators.md#ARRAYLENGTH): returns the number of elements in an array field and can be combined with comparison operators for filtering.
+| Operator | Use in | Description |
+| --- | --- | --- |
+| [ARRAY_CONTAINS(identifier, expr)](array-operators.md#ARRAYCONTAINS) | Filter expression | Checks whether a specific element exists in an ARRAY field. |
+| [ARRAY_CONTAINS_ALL(identifier, expr)](array-operators.md#ARRAYCONTAINSALL) | Filter expression | Checks whether all elements in a specified list exist in an ARRAY field. |
+| [ARRAY_CONTAINS_ANY(identifier, expr)](array-operators.md#ARRAYCONTAINSANY) | Filter expression | Checks whether any element in a specified list exists in an ARRAY field. |
+| [ARRAY_LENGTH(identifier)](array-operators.md#ARRAYLENGTH) | Filter expression | Returns the number of elements in an ARRAY field and can be combined with comparison operators for filtering. |
+| [ARRAY_APPEND](array-operators.md#ARRAYAPPEND) | `upsert` with `field_ops` | Appends payload elements to an existing ARRAY field. Available in Milvus v2.6.17 and later. |
+| [ARRAY_REMOVE](array-operators.md#ARRAYREMOVE) | `upsert` with `field_ops` | Removes every element from an existing ARRAY field that matches a value in the request payload. Available in Milvus v2.6.17 and later. |
 
 ## ARRAY_CONTAINS
 
@@ -81,3 +88,51 @@ filter = 'ARRAY_LENGTH(history_temperatures) < 10'
 ```
 
 This will return all entities where the `history_temperatures` array has fewer than 10 elements.
+
+## ARRAY_APPEND | Milvus 2.6.17+
+
+The `ARRAY_APPEND` operator appends payload elements to an existing ARRAY field during an `upsert` request. It is not a filter expression. Use it when you want to add values to an array without first querying the current array value.
+
+The following Python example appends `"premium"` to the `tags` ARRAY field of the entity whose primary key is `1`:
+
+```python
+from pymilvus import FieldOp, MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+client.upsert(
+    collection_name="users",
+    data=[{"pk": 1, "tags": ["premium"]}],
+    # highlight-next-line
+    field_ops={"tags": FieldOp.array_append()},
+)
+```
+
+Attaching `ARRAY_APPEND` to a field through `field_ops` enables partial-update semantics for that field. For the full workflow, supported element types, and limits, refer to [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).
+
+## ARRAY_REMOVE | Milvus 2.6.17+
+
+The `ARRAY_REMOVE` operator removes every element from an existing ARRAY field that matches a value in the request payload during an `upsert` request. It is not a filter expression. Use it when you want to remove matching values from an array without first querying the current array value.
+
+The following Python example removes `"trial"` from the `tags` ARRAY field of the entity whose primary key is `1`:
+
+```python
+from pymilvus import FieldOp, MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+client.upsert(
+    collection_name="users",
+    data=[{"pk": 1, "tags": ["trial"]}],
+    # highlight-next-line
+    field_ops={"tags": FieldOp.array_remove()},
+)
+```
+
+Attaching `ARRAY_REMOVE` to a field through `field_ops` enables partial-update semantics for that field. For the full workflow, supported element types, and limits, refer to [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).


### PR DESCRIPTION
## What

- Document `ARRAY_APPEND` and `ARRAY_REMOVE` in ARRAY Operators.
- Add ARRAY partial-update guidance to Upsert Entities.
- Add a note from ARRAY field docs to the upsert ARRAY workflow.

## Validation

- `git diff --check`
- Parsed updated Python code blocks with `ast.parse`
