### PR TITLE
docs: note support for S3-compatible object stores

### DIFF
--- a/site/en/adminGuide/deploy_s3.md
+++ b/site/en/adminGuide/deploy_s3.md
@@ -7,7 +7,7 @@ summary: Learn how to set up S3 storage for Milvus with Docker Compose or Helm.
 
 # Configure Object Storage with Docker Compose or Helm
 
-Milvus uses MinIO for object storage by default, but it also supports using [Amazon Simple Storage Service (S3)](https://aws.amazon.com/s3/) as persistent object storage for log and index files. This topic describes how to configure S3 for Milvus. You can skip this topic if you are satisfied with MinIO.
+Milvus uses MinIO for object storage by default, but it also supports using [Amazon Simple Storage Service (S3)](https://aws.amazon.com/s3/) and other S3-compatible object stores (for example Backblaze B2 or Cloudflare R2) as persistent object storage for log and index files. This topic describes how to configure S3 for Milvus. You can skip this topic if you are satisfied with MinIO.
 
 You can configure S3 with [Docker Compose](https://docs.docker.com/get-started/overview/) or on K8s. 
 

--- a/site/en/adminGuide/deploy_s3.md
+++ b/site/en/adminGuide/deploy_s3.md
@@ -7,7 +7,7 @@ summary: Learn how to set up S3 storage for Milvus with Docker Compose or Helm.
 
 # Configure Object Storage with Docker Compose or Helm
 
-Milvus uses MinIO for object storage by default, but it also supports using [Amazon Simple Storage Service (S3)](https://aws.amazon.com/s3/) and other S3-compatible object stores (for example Backblaze B2 or Cloudflare R2) as persistent object storage for log and index files. This topic describes how to configure S3 for Milvus. You can skip this topic if you are satisfied with MinIO.
+Milvus uses MinIO for object storage by default, but it also supports using [Amazon Simple Storage Service (S3)](https://aws.amazon.com/s3/) and other S3-compatible object stores (for example, Backblaze B2 or Cloudflare R2) as persistent object storage for log and index files. This topic describes how to configure S3 for Milvus. You can skip this topic if you are satisfied with MinIO.
 
 You can configure S3 with [Docker Compose](https://docs.docker.com/get-started/overview/) or on K8s. 
 


### PR DESCRIPTION
## What

- Note in the object storage guide (`adminGuide/deploy_s3.md`) that Milvus supports Amazon S3 and other S3-compatible object stores (for example Backblaze B2 or Cloudflare R2), not only AWS S3. Milvus already talks to these through the existing `minio` config (`cloudProvider: aws` for SigV4-compatible stores); this just makes that discoverable.

## Notes

- Documentation only: one sentence, no configuration or default changes.
- `reference/sys_config/configure_minio.md` is generated from `configs/milvus.yaml`, so it is intentionally left untouched.

## Verification

- `git diff --check` is clean.


Related to https://github.com/milvus-io/milvus/pull/50955