### PR TITLE
docs: clarify num_random_samplings description

### DIFF
--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -157,7 +157,7 @@ The following table lists the parameters that can be configured in `search_param
    </tr>
    <tr>
      <td><p><code>num_random_samplings</code></p></td>
-     <td><p>A parameter used in the CAGRA approximate nearest neighbor search algorithm to define the number of iterations for the initial random seed node selection. Its value must be at least <code>1</code>. Available in Milvus 2.6.20+.</p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, which may improve recall but can increase search latency. The value must be at least <code>1</code>.</p></td>
      <td><p><code>1</code></p></td>
    </tr>
    <tr>


### PR DESCRIPTION
## Summary

- Clarify how `num_random_samplings` controls the selection of initial entry points during CAGRA graph search.
- Document the recall and search-latency tradeoff of increasing the parameter.
- Retain the minimum supported value of `1`.

## Test plan

- [x] Verified the rendered table markup and parameter description.
- [x] Ran `git diff --check`.
- [x] Confirmed the PR contains only the intended documentation change.

> Note: This repository does not define an automated test suite (`npm test` is the default placeholder script).