### PR TITLE
docs: refine num_random_samplings tradeoff wording

### DIFF
--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -157,7 +157,7 @@ The following table lists the parameters that can be configured in `search_param
    </tr>
    <tr>
      <td><p><code>num_random_samplings</code></p></td>
-     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, which may improve recall but can increase search latency. The value must be at least <code>1</code>.</p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, improving recall at the cost of increased search latency. The value must be at least <code>1</code>.</p></td>
      <td><p><code>1</code></p></td>
    </tr>
    <tr>


### PR DESCRIPTION
## Summary

- Follow up on #3558 by refining the `num_random_samplings` description.
- State the recall and latency tradeoff directly: larger values improve recall at the cost of increased search latency.

## Test plan

- [x] Ran `git diff --check`.
- [x] Confirmed the PR contains only the intended wording change.

> Note: This repository does not define an automated test suite (`npm test` is the default placeholder script).