### PR TITLE
docs: add CAGRA random sampling parameter to preview

### DIFF
--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -157,7 +157,7 @@ The following table lists the parameters that can be configured in `search_param
    </tr>
    <tr>
      <td><p><code>num_random_samplings</code></p></td>
-     <td><p>A parameter used in the CAGRA approximate nearest neighbor search algorithm to define the number of iterations for the initial random seed node selection. Its value must be at least <code>1</code>. Available in Milvus 2.6.20+.</p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, which may improve recall but can increase search latency. The value must be at least <code>1</code>.</p></td>
      <td><p><code>1</code></p></td>
    </tr>
    <tr>

--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -156,6 +156,11 @@ The following table lists the parameters that can be configured in `search_param
      <td><p>Empty</p></td>
    </tr>
    <tr>
+     <td><p><code>num_random_samplings</code></p></td>
+     <td><p>A parameter used in the CAGRA approximate nearest neighbor search algorithm to define the number of iterations for the initial random seed node selection. Its value must be at least <code>1</code>. Available in Milvus 2.6.20+.</p></td>
+     <td><p><code>1</code></p></td>
+   </tr>
+   <tr>
      <td><p><code>min_iterations</code> / <code>max_iterations</code></p></td>
      <td><p>Controls the search iteration process. By default, they are set to <code>0</code>, and CAGRA automatically determines the number of iterations based on <code>itopk_size</code> and <code>search_width</code>. Adjusting these values manually can help balance performance and accuracy.</p></td>
      <td><p><code>0</code></p></td>

--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -157,7 +157,7 @@ The following table lists the parameters that can be configured in `search_param
    </tr>
    <tr>
      <td><p><code>num_random_samplings</code></p></td>
-     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, which may improve recall but can increase search latency. The value must be at least <code>1</code>.</p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, improving recall at the cost of increased search latency. The value must be at least <code>1</code>.</p></td>
      <td><p><code>1</code></p></td>
    </tr>
    <tr>


### PR DESCRIPTION
## Summary

- Cherry-pick the GPU CAGRA `num_random_samplings` documentation changes from `v2.6.x` into `preview`.
- Add the parameter default, minimum value, and recall/search-latency tradeoff.

## Source PRs

- #3557
- #3558
- #3559

## Cherry-picked commits

- `b9fc1a46` — add `num_random_samplings`
- `084e6484` — clarify the parameter behavior
- `b083aa6c` — refine the recall/latency tradeoff wording

## Test plan

- [x] Ran `git diff --check`.
- [x] Confirmed the PR changes only `site/en/userGuide/indexes/gpu/gpu-cagra.md`.
- [x] Confirmed the resulting file is identical to the version on `v2.6.x`.