### PR TITLE
docs: note num_random_samplings availability in preview

### DIFF
--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -157,7 +157,7 @@ The following table lists the parameters that can be configured in `search_param
    </tr>
    <tr>
      <td><p><code>num_random_samplings</code></p></td>
-     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, improving recall at the cost of increased search latency. The value must be at least <code>1</code>.</p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, improving recall at the cost of increased search latency. The value must be at least <code>1</code>. Available in Milvus 2.6.20+.</p></td>
      <td><p><code>1</code></p></td>
    </tr>
    <tr>


### PR DESCRIPTION
## Summary

- Cherry-pick the `num_random_samplings` availability clarification from the `v2.6.x` follow-up PR #3561.
- Clarify that the parameter is available starting with Milvus 2.6.20.

## Cherry-picked commit

- `1d608b04` — note CAGRA sampling parameter availability

## Test plan

- [x] Ran `git diff --check`.
- [x] Confirmed the PR changes only the target parameter description in `gpu-cagra.md`.
- [x] Confirmed the resulting file is identical to the corresponding `v2.6.x` commit.