### PR TITLE
docs: fix BM25 length normalization description

### DIFF
--- a/site/en/userGuide/search-query-get/full-text-search.md
+++ b/site/en/userGuide/search-query-get/full-text-search.md
@@ -450,7 +450,7 @@ export indexParams='[
    </tr>
    <tr>
      <td><p><code>params.bm25_b</code></p></td>
-     <td><p>Controls the extent to which document length is normalized. Values between 0 and 1 are typically used, with a common default around 0.75. A value of 1 means no length normalization, while a value of 0 means full normalization.</p></td>
+     <td><p>Controls the extent to which document length is normalized. Values between 0 and 1 are typically used, with a default value of 0.75. A value of 0 means no length normalization, while a value of 1 means full length normalization.</p></td>
    </tr>
 </table>
 


### PR DESCRIPTION
## Summary

- Fix the reversed boundary descriptions for bm25_b.
- Clarify that b=0 disables document length normalization and b=1 applies full length normalization.
- Align the production wording with the BM25 metric page and the preview branch.

## Validation

- Ran git diff --check.
- Verified the front matter ID still matches the filename.
- Verified that the change does not modify links, navigation, examples, or page structure.
- Compared the corrected wording with the preview branch.