### PR TITLE
docs: fix Gemini RAG image links in preview

### DIFF
--- a/site/en/integrations/build_RAG_with_milvus_and_gemini.md
+++ b/site/en/integrations/build_RAG_with_milvus_and_gemini.md
@@ -435,7 +435,7 @@ for query in text_queries:
 
 
     
-![Vanilla RAG Pipeline](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/build_RAG_with_milvus_and_gemini_38_1.png)
+![Vanilla RAG Pipeline](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/advanced_rag/vanilla_rag.png)
     
 
 
@@ -446,7 +446,7 @@ for query in text_queries:
 
 
     
-![HyDE](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/build_RAG_with_milvus_and_gemini_38_3.png)
+![HyDE](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/advanced_rag/hyde.png)
     
 
 
@@ -457,7 +457,7 @@ for query in text_queries:
 
 
     
-![Hybrid Retrieval and Reranking](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/build_RAG_with_milvus_and_gemini_38_5.png)
+![Hybrid Retrieval and Reranking](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/advanced_rag/hybrid_and_rerank.png)
     
 
 


### PR DESCRIPTION
## Summary

- Propagate the Gemini RAG image-link fix from the production documentation to Preview.
- Replace three inaccessible S3 URLs with the existing `advanced_rag` assets for the Vanilla RAG, HyDE, and hybrid reranking diagrams.

## Validation

- `node check-link.js`
- `git diff --check upstream/preview...HEAD`
- Confirmed all three replacement URLs return `200 image/png`.
- Confirmed the replacement images are pixel-identical to the original diagrams.

## Scope

- One documentation file changed.
- No navigation, front matter, code examples, or internal page links changed.

## Production change

- Production PR #3568 has already been merged into `v3.0.x`.
