### PR TITLE
docs: add database name length limit

### DIFF
--- a/site/en/about/limitations.md
+++ b/site/en/about/limitations.md
@@ -12,6 +12,7 @@ Milvus is committed to providing the best vector databases to power AI applicati
 
 | Resource      | Limit  |
 | ----------- | ----------- |
+| Database      | 255 characters      |
 | Collection      | 255 characters      |
 | Field   | 255 characters        |
 | Index   | 255 characters       |


### PR DESCRIPTION
## What this PR does

Propagates the production documentation fix from #3570 to the `preview` branch. Adds the database name limit to the resource name length table: 255 characters.

## Source evidence

- [`ValidateDatabaseName`](https://github.com/milvus-io/milvus/blob/v3.0-beta/internal/proxy/util.go#L295-L303) validates database names against `proxy.maxNameLength`.
- [`proxy.maxNameLength`](https://github.com/milvus-io/milvus/blob/v3.0-beta/configs/milvus.yaml#L321) defaults to 255.

## Validation

- `git diff --check`
- Verified the front-matter ID matches the filename.
- Verified the Preview row matches the merged production row.