### PR TITLE
docs: update 2.6 to 3.0 beta upgrade guides

### DIFF
--- a/site/en/Variables.json
+++ b/site/en/Variables.json
@@ -19,7 +19,7 @@
   "milvus_restful_sdk_version": "2.4.x",
   "milvus_restful_sdk_real_version": "2.4.1",
   "milvus_operator_version": "1.3.0",
-  "milvus_helm_chart_version": "5.0.0",
+  "milvus_helm_chart_version": "5.0.22",
   "woodpecker_release_version": "0.1.34",
   "milvus_image": "2.4.1",
   "attu_release": "2.3.10",

--- a/site/en/adminGuide/upgrade_milvus_cluster-docker.md
+++ b/site/en/adminGuide/upgrade_milvus_cluster-docker.md
@@ -1,123 +1,19 @@
 ---
 id: upgrade_milvus_cluster-docker.md
-summary: Learn how to upgrade Milvus cluster with Docker Compose.
+summary: Learn which deployment methods support upgrading a Milvus cluster.
 title: Upgrade Milvus Cluster with Docker Compose
+deprecate: true
 ---
-
-{{tab}}
 
 # Upgrade Milvus Cluster with Docker Compose
 
-This topic describes how to upgrade your Milvus using Docker Compose. 
+The Milvus 2.6.20 and Milvus v{{var.milvus_release_version}} release assets do not include a Docker Compose configuration for cluster deployments. The release assets provide Docker Compose configurations for standalone deployments only.
 
-In normal cases, you can [upgrade Milvus by changing its image](#Upgrade-Milvus-by-changing-its-image). However, you need to [migrate the metadata](#Migrate-the-metadata) before any upgrade from v2.1.x to v{{var.milvus_release_version}}.
+Do not use the legacy component-by-component Docker Compose procedure for a 2.6.x to v{{var.milvus_release_version}} upgrade. That procedure references coordinator and IndexNode containers that do not represent the target architecture.
 
-<div class="alert note">
+To upgrade a Milvus cluster, use one of the documented Kubernetes deployment methods:
 
-{{fragments/mq_upgrade_limitation.md}}
+- [Upgrade Milvus Cluster with Milvus Operator](upgrade_milvus_cluster-operator.md)
+- [Upgrade Milvus Cluster with Helm Chart](upgrade_milvus_cluster-helm.md)
 
-</div>
-
-## Upgrade Milvus by changing its image
-
-In normal cases, you can upgrade Milvus as follows:
-
-1. Change the Milvus image tags in `docker-compose.yaml`.
-
-    Note that you need to change the image tags for the Proxy, all coordinators, and all worker nodes.
-
-    ```yaml
-    ...
-    rootcoord:
-      container_name: milvus-rootcoord
-      image: milvusdb/milvus:v{{var.milvus_release_version}}
-    ...
-    proxy:
-      container_name: milvus-proxy
-      image: milvusdb/milvus:v{{var.milvus_release_version}}
-    ...
-    querycoord:
-      container_name: milvus-querycoord
-      image: milvusdb/milvus:v{{var.milvus_release_version}}  
-    ...
-    querynode:
-      container_name: milvus-querynode
-      image: milvusdb/milvus:v{{var.milvus_release_version}}
-    ...
-    indexcoord:
-      container_name: milvus-indexcoord
-      image: milvusdb/milvus:v{{var.milvus_release_version}}
-    ...
-    indexnode:
-      container_name: milvus-indexnode
-      image: milvusdb/milvus:v{{var.milvus_release_version}} 
-    ...
-    datacoord:
-      container_name: milvus-datacoord
-      image: milvusdb/milvus:v{{var.milvus_release_version}}   
-    ...
-    datanode:
-      container_name: milvus-datanode
-      image: milvusdb/milvus:v{{var.milvus_release_version}}
-    ```
-
-2. Run the following commands to perform the upgrade.
-
-    ```shell
-    docker compose down
-    docker compose up -d
-    ```
-
-## Migrate the metadata
-
-1. Stop all Milvus components.
-
-    ```
-    docker stop <milvus-component-docker-container-name>
-    ```
-
-2. Prepare the configuration file `migrate.yaml` for meta migration.
-
-    ```yaml
-    # migration.yaml
-    cmd:
-      # Option: run/backup/rollback
-      type: run
-      runWithBackup: true
-    config:
-      sourceVersion: 2.1.4   # Specify your milvus version
-      targetVersion: {{var.milvus_release_version}}
-      backupFilePath: /tmp/migration.bak
-    metastore:
-      type: etcd
-    etcd:
-      endpoints:
-        - milvus-etcd:2379  # Use the etcd container name
-      rootPath: by-dev # The root path where data is stored in etcd
-      metaSubPath: meta
-      kvSubPath: kv
-    ```
-
-3. Run the migration container.
-
-    ```
-    # Suppose your docker-compose run with the default milvus network,
-    # and you put migration.yaml in the same directory with docker-compose.yaml.
-    docker run --rm -it --network milvus -v $(pwd)/migration.yaml:/milvus/configs/migration.yaml milvus/meta-migration:v2.2.0 /milvus/bin/meta-migration -config=/milvus/configs/migration.yaml
-    ```
-
-4. Start Milvus components again with the new Milvus image.
-
-    ```
-    Update the milvus image tag in the docker-compose.yaml
-    docker compose down
-    docker compose up -d
-    ```
-
-## What's next
-- You might also want to learn how to:
-  - [Scale a Milvus cluster](scaleout.md)
-- If you are ready to deploy your cluster on clouds:
-  - Learn how to [Deploy Milvus on Amazon EKS with Terraform](eks.md)
-  - Learn how to [Deploy Milvus Cluster on GCP with Kubernetes](gcp.md)
-  - Learn how to [Deploy Milvus on Microsoft Azure With Kubernetes](azure.md)
+If you maintain a custom container-based cluster deployment, reproduce the deployment in a non-production environment and validate the complete upgrade with the engineering team before changing the production system.

--- a/site/en/adminGuide/upgrade_milvus_cluster-helm.md
+++ b/site/en/adminGuide/upgrade_milvus_cluster-helm.md
@@ -12,46 +12,55 @@ title: Upgrade Milvus Cluster with Helm Chart
 
 # Upgrade Milvus Cluster with Helm Chart
 
-This guide describes how to upgrade your Milvus cluster from v2.5.x to v{{var.milvus_release_version}} using Helm Chart.
+This guide describes how to upgrade your Milvus 2.6.x cluster to v{{var.milvus_release_version}} using Helm.
 
-## Before you start
+<div class="alert note">
 
-### What's new in v{{var.milvus_release_version}}
+This procedure has been validated from Milvus 2.6.20 to Milvus v{{var.milvus_release_version}} with Milvus Helm Chart 5.0.22. If you use another Milvus 2.6.x patch release or Helm Chart version, validate the upgrade in a non-production environment first.
 
-Upgrading from Milvus 2.5.x to {{var.milvus_release_version}} involves significant architectural changes:
+</div>
 
-- **Coordinator consolidation**: Legacy separate coordinators (`dataCoord`, `queryCoord`, `indexCoord`) have been consolidated into a single `mixCoord`
-- **New components**: Introduction of Streaming Node for enhanced data processing
-- **Component removal**: `indexNode` removed and consolidated
+## Prerequisites
 
-This upgrade process ensures proper migration to the new architecture. For more information on architecture changes, refer to [Milvus Architecture Overview](architecture_overview.md).
-
-### Requirements
-
-**System requirements:**
-- Helm version >= 3.14.0
-- Kubernetes version >= 1.20.0
-- Milvus cluster deployed via Helm Chart
-
-**Compatibility requirements:**
-- Milvus v2.6.0-rc1 is **not compatible** with v{{var.milvus_release_version}}. Direct upgrades from release candidates are not supported.
-- If you are currently running v2.6.0-rc1 and need to preserve your data, please refer to [this community guide](https://github.com/milvus-io/milvus/issues/43538#issuecomment-3112808997) for migration assistance.
-- You **must** upgrade to v2.5.16 or later with `mixCoordinator` enabled before upgrading to v{{var.milvus_release_version}}.
+- Helm 3.14.0 or later
+- An existing Milvus 2.6.x deployment managed by Helm
+- The Helm values used for the existing deployment
+- A current backup of Milvus metadata and persistent data
 
 {{fragments/mq_upgrade_limitation.md}}
 
-<div class="alert note">
-Since Milvus Helm chart version 4.2.21, we introduced pulsar-v3.x chart as dependency. For backward compatibility, please upgrade your Helm to v3.14 or later version, and be sure to add the <code>--reset-then-reuse-values</code> option whenever you use <code>helm upgrade</code>.
+<div class="alert warning">
+
+Do not change or downgrade the Helm Chart as part of this procedure. Keep the Chart version already installed for your Helm release. The tested baseline retained Helm Chart 5.0.22 and changed only the Milvus image tag to `v{{var.milvus_release_tag}}`.
+
+This procedure does not validate a downgrade or rollback by changing the Milvus image back to 2.6.x. After v{{var.milvus_release_version}} writes data, an image-only rollback can fail to read the updated state. If the upgrade fails, stop writes and use a recovery plan that restores the pre-upgrade metadata and persistent data backups. Validate the recovery plan in a non-production environment first.
+
 </div>
 
 ## Upgrade process
 
-### Step 1: Upgrade Helm Chart
+The validated Milvus 2.6.20 deployment created with Helm Chart 5.0.22 used MixCoord and StreamingNode and did not run IndexNode. You do not need a separate coordinator-migration step when your deployment uses the same topology.
 
-First, upgrade your Milvus Helm chart to version {{var.milvus_helm_chart_version}}:
+### Step 1: Confirm the current topology
+
+Save the complete values of the current release and check the running Pods:
 
 ```bash
-helm repo add zilliztech https://zilliztech.github.io/milvus-helm
+helm get values <release-name> \
+  --namespace <namespace> \
+  --all > milvus-values-before-upgrade.yaml
+
+kubectl get pods --namespace <namespace>
+```
+
+Confirm that the cluster uses MixCoord and StreamingNode and that no IndexNode Pod is running. The upgrade command later in this guide preserves the existing Helm values. If your current values enable IndexNode or use another component topology, do not run this image-only upgrade. Reproduce the topology in a non-production environment and obtain an engineering-approved migration plan first.
+
+### Step 2: Update the Helm repository
+
+Add or update the Milvus Helm repository:
+
+```bash
+helm repo add zilliztech https://zilliztech.github.io/milvus-helm --force-update
 helm repo update zilliztech
 ```
 
@@ -59,79 +68,39 @@ helm repo update zilliztech
 The Milvus Helm Charts repo at <code>https://milvus-io.github.io/milvus-helm/</code> has been archived. Use the new repo <code>https://zilliztech.github.io/milvus-helm/</code> for chart versions 4.0.31 and later.
 </div>
 
-To check Helm chart version compatibility with Milvus versions:
+### Step 3: Upgrade Milvus
+
+Check the Chart version installed for your Helm release:
 
 ```bash
-helm search repo zilliztech/milvus --versions
+helm list --namespace <namespace>
 ```
 
-This guide assumes you are installing the latest version. If you need to install a specific version, specify the `--version` parameter accordingly.
-
-### Step 2: Upgrade to v2.5.16 with mixCoordinator
-
-Check if your cluster currently uses separate coordinators:
+In the `CHART` column, remove the `milvus-` prefix from the value and use the remaining version as `<current-chart-version>`. Then run the upgrade command:
 
 ```bash
-kubectl get pods
-```
-
-If you see separate coordinator pods (`datacoord`, `querycoord`, `indexcoord`), upgrade to v2.5.16 and enable `mixCoordinator`:
-
-```bash
-helm upgrade my-release zilliztech/milvus \
-  --set image.all.tag="v2.5.16" \
-  --set mixCoordinator.enabled=true \
-  --set rootCoordinator.enabled=false \
-  --set indexCoordinator.enabled=false \
-  --set queryCoordinator.enabled=false \
-  --set dataCoordinator.enabled=false \
-  --reset-then-reuse-values \
-  --version=4.2.58
-```
-
-<div class="alert-note">
-
-If your cluster already uses `mixCoordinator`, simply upgrade the image:
-
-```bash
-helm upgrade my-release zilliztech/milvus \
-  --set image.all.tag="v2.5.16" \
-  --reset-then-reuse-values \
-  --version=4.2.58
-```
-
-</div>
-
-Wait for the upgrade to complete:
-
-```bash
-# Verify all pods are ready
-kubectl get pods
-```
-
-### Step 3: Upgrade to v{{var.milvus_release_version}}
-
-Once v2.5.16 is running successfully with `mixCoordinator`, upgrade to v{{var.milvus_release_version}}:
-
-```bash
-helm upgrade my-release zilliztech/milvus \
+helm upgrade <release-name> zilliztech/milvus \
+  --namespace <namespace> \
+  --version <current-chart-version> \
   --set image.all.tag="v{{var.milvus_release_tag}}" \
-  --set streaming.enabled=true \
-  --set indexNode.enabled=false \
   --reset-then-reuse-values \
-  --version={{var.milvus_helm_chart_version}}
+  --wait \
+  --timeout 30m
 ```
+
+The `--reset-then-reuse-values` option retains the values from the previous release while applying the explicit image override against the selected Chart defaults.
 
 ## Verify the upgrade
 
-Confirm your cluster is running the new version:
+Check the Helm revision, Pod status, and container images:
 
 ```bash
-# Check pod status
-kubectl get pods
+helm history <release-name> --namespace <namespace>
 
-# Verify Helm release
-helm list
+kubectl get pods --namespace <namespace>
+
+kubectl get pods --namespace <namespace> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
 ```
 
-For additional support, consult the [Milvus documentation](https://milvus.io/docs) or [community forum](https://github.com/milvus-io/milvus/discussions).
+Verify that all required workloads are ready, all Milvus components use `v{{var.milvus_release_tag}}`, and your existing collections remain queryable and searchable. Complete these checks before you enable any v{{var.milvus_release_version}}-specific feature.

--- a/site/en/adminGuide/upgrade_milvus_cluster-operator.md
+++ b/site/en/adminGuide/upgrade_milvus_cluster-operator.md
@@ -12,128 +12,96 @@ title: Upgrade Milvus Cluster with Milvus Operator
 
 # Upgrade Milvus Cluster with Milvus Operator
 
-This guide describes how to upgrade your Milvus cluster from v2.5.x to v{{var.milvus_release_version}} using Milvus Operator.
+This guide describes how to upgrade a Milvus 2.6.x cluster to v{{var.milvus_release_version}} with Milvus Operator.
 
-## Before you start
+<div class="alert note">
 
-### What's new in v{{var.milvus_release_version}}
-
-Upgrading from Milvus 2.5.x to {{var.milvus_release_version}} involves significant architectural changes:
-
-- **Coordinator consolidation**: Legacy separate coordinators (`dataCoord`, `queryCoord`, `indexCoord`) have been consolidated into a single `mixCoord`
-- **New components**: Introduction of Streaming Node for enhanced data processing
-- **Component removal**: `indexNode` removed and consolidated
-
-This upgrade process ensures proper migration to the new architecture. For more information on architecture changes, refer to [Milvus Architecture Overview](architecture_overview.md).
-
-### Requirements
-
-**System requirements:**
-- Kubernetes cluster with Milvus deployed via Milvus Operator
-- `kubectl` configured to access your cluster  
-- Helm 3.x installed
-
-**Compatibility requirements:**
-- Milvus v2.6.0-rc1 is **not compatible** with v{{var.milvus_release_version}}. Direct upgrades from release candidates are not supported.
-- If you are currently running v2.6.0-rc1 and need to preserve your data, please refer to [this community guide](https://github.com/milvus-io/milvus/issues/43538#issuecomment-3112808997) for migration assistance.
-- You **must** upgrade to v2.5.16 or later with `mixCoord` enabled before upgrading to v{{var.milvus_release_version}}.
-
-{{fragments/mq_upgrade_limitation.md}}
-
-## Upgrade process
-
-### Step 1: Upgrade Milvus Operator
-
-First, upgrade your Milvus Operator to v{{var.milvus_operator_version}}:
-
-```bash
-helm repo add zilliztech-milvus-operator https://zilliztech.github.io/milvus-operator/
-helm repo update zilliztech-milvus-operator
-helm -n milvus-operator upgrade milvus-operator zilliztech-milvus-operator/milvus-operator
-```
-
-Verify the operator upgrade:
-
-```bash
-kubectl -n milvus-operator get pods
-```
-
-### Step 2: Upgrade your Milvus cluster
-
-#### 2.1 Check current coordinator configuration
-
-Check if your cluster already uses `mixCoord`:
-
-```bash
-kubectl get pods
-```
-
-If you see separate coordinator pods (`datacoord`, `querycoord`, `indexcoord`) instead, you need to enable `mixCoord` in the next step.
-
-#### 2.2 Upgrade to v2.5.16 with mixCoord
-
-<div class="alert-note">
-
-Skip this step if your cluster is already running v2.5.16 or higher with `mixCoord` enabled.
+This procedure has been validated from Milvus 2.6.20 to Milvus v{{var.milvus_release_version}} with Milvus Operator 1.3.0, MixCoord, StreamingNode, Woodpecker, in-cluster etcd, and in-cluster MinIO. If you use another Milvus 2.6.x patch release, Operator version, component topology, message queue, or dependency configuration, validate the upgrade in a non-production environment first.
 
 </div>
 
-Create a configuration file `milvusupgrade.yaml` to enable `mixCoord` and upgrade to v2.5.16:
+## Prerequisites
+
+- A Kubernetes cluster with a Milvus 2.6.x cluster managed by Milvus Operator
+- `kubectl` access to the cluster
+- The complete Milvus custom resource (CR) manifest used for the existing deployment
+- The installation method and manifests used for the existing Milvus Operator
+- A current backup of Milvus metadata and persistent data
+
+{{fragments/mq_upgrade_limitation.md}}
+
+<div class="alert warning">
+
+Apply the complete Milvus CR for this upgrade. Do not use an image-only merge patch. The Operator can default omitted zero-replica component fields, which can re-enable a component that the existing 2.6.x deployment disabled.
+
+This procedure does not validate a downgrade or rollback by changing the Milvus image back to 2.6.x. After v{{var.milvus_release_version}} writes data, an image-only rollback can fail to read the updated state. If the upgrade fails, stop writes and use a recovery plan that restores the pre-upgrade metadata and persistent data backups. Validate the recovery plan in a non-production environment first.
+
+</div>
+
+## Upgrade process
+
+### Step 1: Back up the current Milvus CR
+
+Save the current CR before changing the deployment:
+
+```bash
+kubectl get milvus <instance-name> \
+  --namespace <namespace> \
+  --output yaml > milvus-before-upgrade.yaml
+```
+
+Use the source manifest for your existing deployment as the upgrade manifest. Do not apply the exported backup file directly without first removing server-managed metadata and status fields.
+
+### Step 2: Confirm the Milvus Operator version
+
+Check the image used by the installed Milvus Operator:
+
+```bash
+kubectl get deployments --all-namespaces \
+  -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{range .spec.template.spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' \
+  | grep milvus-operator
+```
+
+The validated upgrade kept Milvus Operator at version 1.3.0. Keep the Operator version that currently manages your Milvus 2.6.x deployment unless your support policy requires a separate Operator upgrade. Do not downgrade a newer Operator to the tested version. If you need to change the Operator version, use the same Helm or `kubectl` installation method and the same release name and namespace as the existing installation, then validate the Operator change before updating the Milvus CR.
+
+### Step 3: Update the Milvus image
+
+In the complete Milvus CR manifest, change `spec.components.image` to the target version. Preserve the current mode, component topology, message queue, etcd, storage, and other dependency settings. The following excerpt shows the fields to confirm; do not replace your complete CR with this excerpt.
+
+Before applying the target CR, confirm that `indexNode.replicas` is `0`. The validated Milvus 2.6.20 configuration already used this setting. Keep the explicit zero-replica setting in the target CR.
 
 ```yaml
 apiVersion: milvus.io/v1beta1
 kind: Milvus
 metadata:
-  name: my-release  # Replace with your actual release name
-spec:
-  components:
-    mixCoord:
-      replicas: 1
-    image: milvusdb/milvus:v2.5.16
-```
-
-Apply the configuration:
-
-```bash
-kubectl patch -f milvusupgrade.yaml --patch-file milvusupgrade.yaml --type merge
-```
-
-Wait for completion:
-
-```bash
-# Verify all pods are ready
-kubectl get pods
-```
-
-#### 2.3 Upgrade to v{{var.milvus_release_version}}
-
-Once v2.5.16 is running successfully with `mixCoord`, upgrade to v{{var.milvus_release_version}}:
-
-Update your configuration file (`milvusupgrade.yaml` in this example):
-
-```yaml
-apiVersion: milvus.io/v1beta1
-kind: Milvus
-metadata:
-  name: my-release  # Replace with your actual release name
+  name: <instance-name>
+  namespace: <namespace>
 spec:
   components:
     image: milvusdb/milvus:v{{var.milvus_release_tag}}
+    indexNode:
+      replicas: 0
 ```
 
-Apply the final upgrade:
+Apply the complete CR manifest:
 
 ```bash
-kubectl patch -f milvusupgrade.yaml --patch-file milvusupgrade.yaml --type merge
+kubectl apply --filename milvus.yaml
 ```
 
 ## Verify the upgrade
 
-Confirm your cluster is running the new version:
+Check the CR status, Pod status, and container images:
 
 ```bash
-# Check pod status
-kubectl get pods
+kubectl get milvus <instance-name> \
+  --namespace <namespace> \
+  --output jsonpath='{.status.status}{"\t"}{.status.currentImage}{"\n"}'
+
+kubectl get pods --namespace <namespace>
+
+kubectl get pods --namespace <namespace> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
 ```
 
-For additional support, consult the [Milvus documentation](https://milvus.io/docs) or [community forum](https://github.com/milvus-io/milvus/discussions).
+Verify that the Milvus CR reports `Healthy`, all Milvus components use `milvusdb/milvus:v{{var.milvus_release_tag}}`, no IndexNode Pod is running, and the existing collections remain queryable and searchable. Complete these checks before you enable any v{{var.milvus_release_version}}-specific feature.

--- a/site/en/adminGuide/upgrade_milvus_standalone-docker.md
+++ b/site/en/adminGuide/upgrade_milvus_standalone-docker.md
@@ -1,7 +1,7 @@
 ---
 id: upgrade_milvus_standalone-docker.md
 label: Docker Compose
-order: 1
+order: 2
 group: upgrade_milvus_standalone-operator.md
 related_key: upgrade Milvus Standalone
 summary: Learn how to upgrade Milvus standalone with Docker Compose.
@@ -12,113 +12,76 @@ title: Upgrade Milvus Standalone with Docker Compose
 
 # Upgrade Milvus Standalone with Docker Compose
 
-This guide describes how to upgrade your Milvus standalone deployment from v2.5.x to v{{var.milvus_release_version}} using Docker Compose.
+This guide describes how to upgrade a Milvus 2.6.x standalone deployment to v{{var.milvus_release_version}} with Docker Compose.
 
-## Before you start
+<div class="alert note">
 
-### What's new in v{{var.milvus_release_version}}
+This procedure has been validated with the official Milvus 2.6.20 standalone Docker Compose configuration. The upgrade retained etcd, MinIO, Woodpecker, and the existing data directories, and changed only the Milvus image to `milvusdb/milvus:v{{var.milvus_release_tag}}`.
 
-Upgrading from Milvus 2.5.x to {{var.milvus_release_version}} involves significant architectural changes:
+</div>
 
-- **Coordinator consolidation**: Legacy separate coordinators (`dataCoord`, `queryCoord`, `indexCoord`) have been consolidated into a single `mixCoord`
-- **New components**: Introduction of Streaming Node for enhanced data processing
-- **Component removal**: `indexNode` removed and consolidated
+## Prerequisites
 
-This upgrade process ensures proper migration to the new architecture. For more information on architecture changes, refer to [Milvus Architecture Overview](architecture_overview.md).
-
-### Requirements
-
-**System requirements:**
-- Docker and Docker Compose installed
-- Milvus standalone deployed via Docker Compose
-
-**Compatibility requirements:**
-- Milvus v2.6.0-rc1 is **not compatible** with v{{var.milvus_release_version}}. Direct upgrades from release candidates are not supported.
-- If you are currently running v2.6.0-rc1 and need to preserve your data, please refer to [this community guide](https://github.com/milvus-io/milvus/issues/43538#issuecomment-3112808997) for migration assistance.
-- You **must** upgrade to v2.5.16 or later before upgrading to v{{var.milvus_release_version}}.
+- Docker Engine and Docker Compose V2
+- An existing Milvus 2.6.x standalone deployment managed by Docker Compose
+- The Docker Compose file and configuration used for the existing deployment
+- A current backup of Milvus metadata and persistent data
 
 {{fragments/mq_upgrade_limitation.md}}
 
-<div class="alter note">
+<div class="alert warning">
 
-Due to security concerns, Milvus upgrades its MinIO to {{var.minio_release}} with the release of v{{var.milvus_release_version}}.
+Do not replace your current Compose file or change dependency versions as part of this procedure. Keep the existing etcd, object storage, message queue, volumes, and configuration. Update only the Milvus image tag.
+
+This procedure does not validate a downgrade or rollback by changing the Milvus image back to 2.6.x. After v{{var.milvus_release_version}} writes data, an image-only rollback can fail to read the updated state. If the upgrade fails, stop writes and use a recovery plan that restores the pre-upgrade metadata and persistent data backups. Validate the recovery plan in a non-production environment first.
 
 </div>
 
 ## Upgrade process
 
-### Step 1: Upgrade to v2.5.16
+### Step 1: Back up the current configuration
 
-<div class="alert note">
+Save a copy of the current Compose file and any mounted Milvus configuration files:
 
-Skip this step if your standalone deployment is already running v2.5.16 or higher.
+```bash
+cp docker-compose.yml docker-compose-before-upgrade.yml
+```
 
-</div>
+Confirm that the current containers are healthy before starting the upgrade:
 
-1. Edit your existing `docker-compose.yaml` file and update the Milvus image tag to v2.5.16:
+```bash
+docker compose ps
+```
 
-    ```yaml
-    ...
-    standalone:
-      container_name: milvus-standalone
-      image: milvusdb/milvus:v2.5.16
-    ...
-    ```
+### Step 2: Update the Milvus image
 
-2. Apply the upgrade to v2.5.16:
+In the existing Compose file, update only the image for the `standalone` service:
 
-    ```bash
-    docker compose down
-    docker compose up -d
-    ```
+```yaml
+services:
+  standalone:
+    image: milvusdb/milvus:v{{var.milvus_release_tag}}
+```
 
-3. Verify the v2.5.16 upgrade:
+Pull the target image and recreate only the Milvus container:
 
-    ```bash
-    docker compose ps
-    ```
+```bash
+docker compose pull standalone
+docker compose up --detach standalone
+```
 
-### Step 2: Upgrade to v{{var.milvus_release_version}}
-
-Once v2.5.16 is running successfully, upgrade to v{{var.milvus_release_version}}:
-
-1. Edit your existing `docker-compose.yaml` file and update both the Milvus and MinIO image tags:
-
-    ```yaml
-    ...
-    minio:
-      container_name: milvus-minio
-      image: minio/minio:{{var.minio_release}}
-
-    ...
-    standalone:
-      container_name: milvus-standalone
-      image: milvusdb/milvus:v{{var.milvus_release_tag}}
-    ```
-
-2. Apply the final upgrade:
-
-    ```bash
-    docker compose down
-    docker compose up -d
-    ```
+Docker Compose keeps the existing etcd and object-storage containers running and reuses the configured data directories.
 
 ## Verify the upgrade
 
-Confirm your standalone deployment is running the new version:
+Check the container status and the image used by the Milvus container:
 
 ```bash
-# Check container status
 docker compose ps
 
-# Check Milvus version
-docker compose logs standalone | grep "version"
+docker compose images standalone
+
+docker compose logs --tail 100 standalone
 ```
 
-## What's next
-- You might also want to learn how to:
-  - [Scale a Milvus cluster](scaleout.md)
-- If you are ready to deploy your cluster on clouds:
-  - Learn how to [Deploy Milvus on Amazon EKS with Terraform](eks.md)
-  - Learn how to [Deploy Milvus Cluster on GCP with Kubernetes](gcp.md)
-  - Learn how to [Deploy Milvus on Microsoft Azure With Kubernetes](azure.md)
+Verify that the `standalone` service is healthy, its image is `milvusdb/milvus:v{{var.milvus_release_tag}}`, and the existing collections remain queryable and searchable. Complete these checks before you enable any v{{var.milvus_release_version}}-specific feature.

--- a/site/en/adminGuide/upgrade_milvus_standalone-helm.md
+++ b/site/en/adminGuide/upgrade_milvus_standalone-helm.md
@@ -10,49 +10,41 @@ title: Upgrade Milvus Standalone with Helm Chart
 
 {{tab}}
 
-
 # Upgrade Milvus Standalone with Helm Chart
 
-This guide describes how to upgrade your Milvus standalone deployment from v2.5.x to v{{var.milvus_release_version}} using Helm Chart.
+This guide describes how to upgrade your Milvus 2.6.x standalone deployment to v{{var.milvus_release_version}} using Helm.
 
-## Before you start
+<div class="alert note">
 
-### What's new in v{{var.milvus_release_version}}
+This procedure has been validated from Milvus 2.6.20 to Milvus v{{var.milvus_release_version}} with Milvus Helm Chart 5.0.22. If you use another Milvus 2.6.x patch release or Helm Chart version, validate the upgrade in a non-production environment first.
 
-Upgrading from Milvus 2.5.x to {{var.milvus_release_version}} involves significant architectural changes:
+</div>
 
-- **Coordinator consolidation**: Legacy separate coordinators (`dataCoord`, `queryCoord`, `indexCoord`) have been consolidated into a single `mixCoord`
-- **New components**: Introduction of Streaming Node for enhanced data processing
-- **Component removal**: `indexNode` removed and consolidated
+## Prerequisites
 
-This upgrade process ensures proper migration to the new architecture. For more information on architecture changes, refer to [Milvus Architecture Overview](architecture_overview.md).
-
-### Requirements
-
-**System requirements:**
-- Helm version >= 3.14.0
-- Kubernetes version >= 1.20.0
-- Milvus standalone deployed via Helm Chart
-
-**Compatibility requirements:**
-- Milvus v2.6.0-rc1 is **not compatible** with v{{var.milvus_release_version}}. Direct upgrades from release candidates are not supported.
-- If you are currently running v2.6.0-rc1 and need to preserve your data, please refer to [this community guide](https://github.com/milvus-io/milvus/issues/43538#issuecomment-3112808997) for migration assistance.
-- You **must** upgrade to v2.5.16 or later before upgrading to v{{var.milvus_release_version}}.
+- Helm 3.14.0 or later
+- An existing Milvus 2.6.x deployment managed by Helm
+- The Helm values used for the existing deployment
+- A current backup of Milvus metadata and persistent data
 
 {{fragments/mq_upgrade_limitation.md}}
 
-<div class="alert note">
-Since Milvus Helm chart version 4.2.21, we introduced pulsar-v3.x chart as dependency. For backward compatibility, please upgrade your Helm to v3.14 or later version, and be sure to add the <code>--reset-then-reuse-values</code> option whenever you use <code>helm upgrade</code>.
+<div class="alert warning">
+
+Do not change or downgrade the Helm Chart as part of this procedure. Keep the Chart version already installed for your Helm release. The tested baseline retained Helm Chart 5.0.22 and changed only the Milvus image tag to `v{{var.milvus_release_tag}}`.
+
+This procedure does not validate a downgrade or rollback by changing the Milvus image back to 2.6.x. After v{{var.milvus_release_version}} writes data, an image-only rollback can fail to read the updated state. If the upgrade fails, stop writes and use a recovery plan that restores the pre-upgrade metadata and persistent data backups. Validate the recovery plan in a non-production environment first.
+
 </div>
 
 ## Upgrade process
 
-### Step 1: Upgrade Helm Chart
+### Step 1: Update the Helm repository
 
-First, upgrade your Milvus Helm chart to version {{var.milvus_helm_chart_version}}:
+Add or update the Milvus Helm repository:
 
 ```bash
-helm repo add zilliztech https://zilliztech.github.io/milvus-helm
+helm repo add zilliztech https://zilliztech.github.io/milvus-helm --force-update
 helm repo update zilliztech
 ```
 
@@ -60,56 +52,39 @@ helm repo update zilliztech
 The Milvus Helm Charts repo at <code>https://milvus-io.github.io/milvus-helm/</code> has been archived. Use the new repo <code>https://zilliztech.github.io/milvus-helm/</code> for chart versions 4.0.31 and later.
 </div>
 
-To check Helm chart version compatibility with Milvus versions:
+### Step 2: Upgrade Milvus
+
+Check the Chart version installed for your Helm release:
 
 ```bash
-helm search repo zilliztech/milvus --versions
+helm list --namespace <namespace>
 ```
 
-This guide assumes you are installing the latest version. If you need to install a specific version, specify the `--version` parameter accordingly.
-
-### Step 2: Upgrade to v2.5.16
-
-<div class="alert-note">
-
-Skip this step if your standalone deployment is already running v2.5.16 or higher.
-
-</div>
-
-Upgrade your Milvus standalone to v2.5.16:
+In the `CHART` column, remove the `milvus-` prefix from the value and use the remaining version as `<current-chart-version>`. Then run the upgrade command:
 
 ```bash
-helm upgrade my-release zilliztech/milvus \
-  --set image.all.tag="v2.5.16" \
-  --reset-then-reuse-values \
-  --version=4.2.58
-```
-
-Wait for the upgrade to complete:
-
-```bash
-# Verify all pods are ready
-kubectl get pods
-```
-
-### Step 3: Upgrade to v{{var.milvus_release_version}}
-
-Once v2.5.16 is running successfully, upgrade to v{{var.milvus_release_version}}:
-
-```bash
-helm upgrade my-release zilliztech/milvus \
+helm upgrade <release-name> zilliztech/milvus \
+  --namespace <namespace> \
+  --version <current-chart-version> \
   --set image.all.tag="v{{var.milvus_release_tag}}" \
   --reset-then-reuse-values \
-  --version={{var.milvus_helm_chart_version}}
+  --wait \
+  --timeout 20m
 ```
+
+The `--reset-then-reuse-values` option retains the values from the previous release while applying the explicit image override against the selected Chart defaults.
 
 ## Verify the upgrade
 
-Confirm your standalone deployment is running the new version:
+Check the Helm revision, Pod status, and container images:
 
 ```bash
-# Check pod status
-kubectl get pods
+helm history <release-name> --namespace <namespace>
+
+kubectl get pods --namespace <namespace>
+
+kubectl get pods --namespace <namespace> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
 ```
 
-For additional support, consult the [Milvus documentation](https://milvus.io/docs) or [community forum](https://github.com/milvus-io/milvus/discussions).
+Verify that all required workloads are ready, Milvus uses `v{{var.milvus_release_tag}}`, and your existing collections remain queryable and searchable. Complete these checks before you enable any v{{var.milvus_release_version}}-specific feature.

--- a/site/en/adminGuide/upgrade_milvus_standalone-operator.md
+++ b/site/en/adminGuide/upgrade_milvus_standalone-operator.md
@@ -4,7 +4,7 @@ label: Milvus Operator
 order: 0
 group: upgrade_milvus_standalone-operator.md
 related_key: upgrade Milvus Standalone
-summary: Learn how to upgrade Milvus standalone with Milvus operator.
+summary: Learn how to upgrade Milvus standalone with Milvus Operator.
 title: Upgrade Milvus Standalone with Milvus Operator
 ---
 
@@ -12,116 +12,90 @@ title: Upgrade Milvus Standalone with Milvus Operator
 
 # Upgrade Milvus Standalone with Milvus Operator
 
-This guide describes how to upgrade your Milvus standalone deployment from v2.5.x to v{{var.milvus_release_version}} using Milvus Operator.
+This guide describes how to upgrade a Milvus 2.6.x standalone deployment to v{{var.milvus_release_version}} with Milvus Operator.
 
-## Before you start
+<div class="alert note">
 
-### What's new in v{{var.milvus_release_version}}
-
-Upgrading from Milvus 2.5.x to {{var.milvus_release_version}} involves significant architectural changes:
-
-- **Coordinator consolidation**: Legacy separate coordinators (`dataCoord`, `queryCoord`, `indexCoord`) have been consolidated into a single `mixCoord`
-- **New components**: Introduction of Streaming Node for enhanced data processing
-- **Component removal**: `indexNode` removed and consolidated
-
-This upgrade process ensures proper migration to the new architecture. For more information on architecture changes, refer to [Milvus Architecture Overview](architecture_overview.md).
-
-### Requirements
-
-**System requirements:**
-- Kubernetes cluster with Milvus standalone deployed via Milvus Operator
-- `kubectl` configured to access your cluster  
-- Helm 3.x installed
-
-**Compatibility requirements:**
-- Milvus v2.6.0-rc1 is **not compatible** with v{{var.milvus_release_version}}. Direct upgrades from release candidates are not supported.
-- If you are currently running v2.6.0-rc1 and need to preserve your data, please refer to [this community guide](https://github.com/milvus-io/milvus/issues/43538#issuecomment-3112808997) for migration assistance.
-- You **must** upgrade to v2.5.16 or later before upgrading to v{{var.milvus_release_version}}.
-
-{{fragments/mq_upgrade_limitation.md}}
-
-## Upgrade process
-
-### Step 1: Upgrade Milvus Operator
-
-First, upgrade your Milvus Operator to v{{var.milvus_operator_version}}:
-
-```bash
-helm repo add zilliztech-milvus-operator https://zilliztech.github.io/milvus-operator/
-helm repo update zilliztech-milvus-operator
-helm -n milvus-operator upgrade milvus-operator zilliztech-milvus-operator/milvus-operator
-```
-
-Verify the operator upgrade:
-
-```bash
-kubectl -n milvus-operator get pods
-```
-
-### Step 2: Upgrade your Milvus standalone
-
-#### 2.1 Upgrade to v2.5.16
-
-<div class="alert-note">
-
-Skip this step if your standalone deployment is already running v2.5.16 or higher.
+This procedure has been validated from Milvus 2.6.20 to Milvus v{{var.milvus_release_version}} with Milvus Operator 1.3.0, Woodpecker, in-cluster etcd, and in-cluster MinIO. If you use another Milvus 2.6.x patch release, Operator version, message queue, or dependency configuration, validate the upgrade in a non-production environment first.
 
 </div>
 
-Create a configuration file `milvusupgrade.yaml` to upgrade to v2.5.16:
+## Prerequisites
+
+- A Kubernetes cluster with a Milvus 2.6.x standalone deployment managed by Milvus Operator
+- `kubectl` access to the cluster
+- The complete Milvus custom resource (CR) manifest used for the existing deployment
+- The installation method and manifests used for the existing Milvus Operator
+- A current backup of Milvus metadata and persistent data
+
+{{fragments/mq_upgrade_limitation.md}}
+
+<div class="alert warning">
+
+This procedure does not validate a downgrade or rollback by changing the Milvus image back to 2.6.x. After v{{var.milvus_release_version}} writes data, an image-only rollback can fail to read the updated state. If the upgrade fails, stop writes and use a recovery plan that restores the pre-upgrade metadata and persistent data backups. Validate the recovery plan in a non-production environment first.
+
+</div>
+
+## Upgrade process
+
+### Step 1: Back up the current Milvus CR
+
+Save the current CR before changing the deployment:
+
+```bash
+kubectl get milvus <instance-name> \
+  --namespace <namespace> \
+  --output yaml > milvus-before-upgrade.yaml
+```
+
+Use the source manifest for your existing deployment as the upgrade manifest. Do not apply the exported backup file directly without first removing server-managed metadata and status fields.
+
+### Step 2: Confirm the Milvus Operator version
+
+Check the image used by the installed Milvus Operator:
+
+```bash
+kubectl get deployments --all-namespaces \
+  -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{range .spec.template.spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' \
+  | grep milvus-operator
+```
+
+The validated upgrade kept Milvus Operator at version 1.3.0. Keep the Operator version that currently manages your Milvus 2.6.x deployment unless your support policy requires a separate Operator upgrade. Do not downgrade a newer Operator to the tested version. If you need to change the Operator version, use the same Helm or `kubectl` installation method and the same release name and namespace as the existing installation, then validate the Operator change before updating the Milvus CR.
+
+### Step 3: Update the Milvus image
+
+In the complete Milvus CR manifest, change only `spec.components.image`. Keep the existing mode, component settings, message queue, etcd, storage, and other dependency settings. The following excerpt shows the field to change; do not replace your complete CR with this excerpt.
 
 ```yaml
 apiVersion: milvus.io/v1beta1
 kind: Milvus
 metadata:
-  name: my-release  # Replace with your actual release name
-spec:
-  components:
-    image: milvusdb/milvus:v2.5.16
-```
-
-Apply the configuration:
-
-```bash
-kubectl patch -f milvusupgrade.yaml --patch-file milvusupgrade.yaml --type merge
-```
-
-Wait for completion:
-
-```bash
-# Verify all pods are ready
-kubectl get pods
-```
-
-#### 2.2 Upgrade to v{{var.milvus_release_version}}
-
-Once v2.5.16 is running successfully, upgrade to v{{var.milvus_release_version}}:
-
-Update your configuration file (`milvusupgrade.yaml` in this example):
-
-```yaml
-apiVersion: milvus.io/v1beta1
-kind: Milvus
-metadata:
-  name: my-release  # Replace with your actual release name
+  name: <instance-name>
+  namespace: <namespace>
 spec:
   components:
     image: milvusdb/milvus:v{{var.milvus_release_tag}}
 ```
 
-Apply the final upgrade:
+Apply the complete CR manifest:
 
 ```bash
-kubectl patch -f milvusupgrade.yaml --patch-file milvusupgrade.yaml --type merge
+kubectl apply --filename milvus.yaml
 ```
 
 ## Verify the upgrade
 
-Confirm your standalone deployment is running the new version:
+Check the CR status, Pod status, and container images:
 
 ```bash
-# Check pod status
-kubectl get pods
+kubectl get milvus <instance-name> \
+  --namespace <namespace> \
+  --output jsonpath='{.status.status}{"\t"}{.status.currentImage}{"\n"}'
+
+kubectl get pods --namespace <namespace>
+
+kubectl get pods --namespace <namespace> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
 ```
 
-For additional support, consult the <a href="https://milvus.io/docs">Milvus documentation</a> or <a href="https://github.com/milvus-io/milvus/discussions">community forum</a>.
+Verify that the Milvus CR reports `Healthy`, the current image is `milvusdb/milvus:v{{var.milvus_release_tag}}`, and the existing collections remain queryable and searchable. Complete these checks before you enable any v{{var.milvus_release_version}}-specific feature.


### PR DESCRIPTION
## Summary

- Rewrite the Milvus Operator, Helm, and Docker Compose upgrade guidance from the stale 2.5.x-to-2.6.x flow to the supported 2.6.x-to-3.0 Beta flow.
- Update `milvus_helm_chart_version` from 5.0.0 to the 5.0.22 baseline used by the 3.0 Beta documentation and validation.
- Keep the user's installed Helm Chart version during image upgrades instead of forcing a Chart change.
- Require Operator users to update and apply the complete Milvus CR. Cluster upgrades explicitly preserve `indexNode.replicas: 0`.
- Add topology gates, backup prerequisites, post-upgrade checks, and warnings against image-only rollback.
- Deprecate the orphaned Cluster Docker Compose page without deleting its URL because the 2.6.20 and 3.0 Beta release assets do not provide an official Cluster Compose configuration.
- Restore the Standalone tab order to Milvus Operator, Helm, and Docker Compose.

## Upgrade validation

Validated from Milvus `v2.6.20` to `v3.0-beta` on five supported paths:

- Helm Standalone, Chart 5.0.22
- Helm Cluster, Chart 5.0.22
- Milvus Operator Standalone, Operator 1.3.0
- Milvus Operator Cluster, Operator 1.3.0
- Standalone Docker Compose

For every path:

- Query IDs before and after upgrade: `[1, 2, 3, 4]`
- Search IDs before and after upgrade: `[1, 2]`
- Top search result ID: `1`
- Before/after JSON evidence matched exactly

The rerun captured the upgrade commands, stdout/stderr, workload images, and rollout timelines. The Milvus Cell environment was returned to its default policy and `Sleeping` state after validation.

## Safety findings reflected in the docs

- An image-only merge patch for a Cluster Operator deployment can default `indexNode.replicas: 0` back to `1`; the guide therefore uses the complete CR with `kubectl apply`.
- Cluster Helm image-only upgrades are limited to the validated MixCoord and StreamingNode topology with no IndexNode. Custom topologies must stop and obtain a validated migration plan.
- A reverse image change after 3.0 Beta writes produced Woodpecker `BlockHeaderRecord not found`; the guides prohibit image-only rollback and require restoring pre-upgrade metadata and persistent-data backups through a validated recovery plan.

## Checks

- [x] `git diff --check`
- [x] Full internal link check with `node check-link.js`
- [x] `Variables.json` parsing and Helm Chart value assertion
- [x] Front matter ID, tab group, tab order, and deprecated-page assertions
- [x] Exact seven-file scope assertion
- [x] Stale 2.5.16, release-candidate, and legacy Coordinator instruction scan
- [x] Helm repository, current-values, Operator image-inspection, and complete-CR command checks
- [x] Pre-landing documentation review with no open P0/P1 findings

## Limitations and follow-up

- The functional baseline covers Milvus 2.6.20, Helm Chart 5.0.22, and Milvus Operator 1.3.0. Other 2.6.x patches, Operator configurations, component topologies, and message queues still need engineering confirmation.
- A full deployed Preview-site rendering was not run.
- `site/en/adminGuide/use-pulsar-v2.md` still says “upgrade to v2.5.x” while linking to an upgraded page; it should be handled in a separate focused follow-up.
