### PR TITLE
docs: fix search aggregation section anchors

### DIFF
--- a/site/en/userGuide/search-query-get/search-aggregation.md
+++ b/site/en/userGuide/search-query-get/search-aggregation.md
@@ -57,10 +57,10 @@ Choose the example that matches what you want to configure:
 
 | Goal | Key settings | Example |
 |---|---|---|
-| Build bucket keys | `fields`, `size` | [Build bucket keys](#build-bucket-keys) |
-| Calculate statistics and order buckets | `metrics`, `order` | [Calculate metrics and order buckets](#calculate-metrics-and-order-buckets) |
-| Return and sort representative hits | `top_hits`, `TopHits.size`, `TopHits.sort` | [Return and sort representative hits](#return-and-sort-representative-hits) |
-| Create hierarchical results | `sub_aggregation` | [Create nested buckets](#create-nested-buckets) |
+| Build bucket keys | `fields`, `size` | [Build bucket keys](#Build-bucket-keys) |
+| Calculate statistics and order buckets | `metrics`, `order` | [Calculate metrics and order buckets](#Calculate-metrics-and-order-buckets) |
+| Return and sort representative hits | `top_hits`, `TopHits.size`, `TopHits.sort` | [Return and sort representative hits](#Return-and-sort-representative-hits) |
+| Create hierarchical results | `sub_aggregation` | [Create nested buckets](#Create-nested-buckets) |
 
 The examples below use a product collection with brand, category, color, price, and rating fields. Expand the following section to create the collection and define the shared search variables.
 
@@ -325,7 +325,7 @@ aggregation = SearchAggregation(
 
 This configuration can produce keys such as `(Nike, black)`, `(Nike, blue)`, and `(Adidas, white)`. Two entities share a bucket only when both values match. Milvus preserves the list order, so `brand` is the first key component and `color` is the second. Pass multiple strings in one flat list; nested lists are not supported.
 
-`size=6` is the maximum number of composite buckets returned at this aggregation level. The example data contains five distinct brand-color combinations, so all five can be returned. In the [returned-entry limit](#limits), this request contributes `1 query vector × 6 buckets × 1 = 6` configured result entries.
+`size=6` is the maximum number of composite buckets returned at this aggregation level. The example data contains five distinct brand-color combinations, so all five can be returned. In the [returned-entry limit](#Limits), this request contributes `1 query vector × 6 buckets × 1 = 6` configured result entries.
 
 ### Calculate metrics and order buckets
 


### PR DESCRIPTION
## Summary

- Fix the four same-page links in the Search Aggregation example table so they match the case-sensitive heading IDs generated by the docs site.
- Fix the returned-entry limit link so it resolves to the `Limits` section.

## Validation

- Confirmed all five edited internal links exactly match their rendered heading IDs.
- Compared the targets with the HTML generated on the upstream Preview branch; all 11 unique same-page links resolve after the change.
- Ran `git diff --check`.
- Confirmed the front matter `id` still matches the filename.