### PR TITLE
docs: bump Woodpecker service image to v0.1.36

### DIFF
--- a/site/en/Variables.json
+++ b/site/en/Variables.json
@@ -20,7 +20,7 @@
   "milvus_restful_sdk_real_version": "2.4.1",
   "milvus_operator_version": "1.3.0",
   "milvus_helm_chart_version": "5.0.22",
-  "woodpecker_release_version": "0.1.34",
+  "woodpecker_release_version": "0.1.36",
   "milvus_image": "2.4.1",
   "attu_release": "2.3.10",
   "milvus_backup_release": "0.5.10",


### PR DESCRIPTION
## Summary

- bump the centralized Woodpecker service-mode image version from v0.1.34 to v0.1.36
- keep the Woodpecker Helm examples driven by the shared woodpecker_release_version variable

## Validation

- jq empty site/en/Variables.json
- git diff --check