### PR TITLE
docs: distinguish regex analyzer and filter expressions

### DIFF
--- a/site/en/userGuide/schema/analyzer/filter/regex-filter.md
+++ b/site/en/userGuide/schema/analyzer/filter/regex-filter.md
@@ -1,13 +1,19 @@
 ---
 id: regex-filter.md
-title: "Regex"
-summary: "The regex filter is a regular expression filter: any token produced by the tokenizer is kept only if it matches the expression you provide; everything else is discarded."
+title: "Regex Analyzer Filter"
+summary: "The regex analyzer filter keeps tokens that match a regular expression and discards the rest."
 beta: Milvus 2.5.11+
 ---
 
-# Regex
+# Regex Analyzer Filter
 
 The `regex` filter is a regular expression filter: any token produced by the tokenizer is kept only if it matches the expression you provide; everything else is discarded.
+
+<div class="alert note">
+
+This page describes the `regex` filter in the analyzer pipeline. It filters tokens produced by a tokenizer and affects the terms generated during text analysis. To filter entities with scalar expressions such as `field =~ "pattern"` or `field !~ "pattern"` in `query`, `search`, or hybrid search, refer to [Pattern Matching](pattern-matching.md).
+
+</div>
 
 ## Configuration
 

--- a/site/en/userGuide/search-query-get/boolean/pattern-matching.md
+++ b/site/en/userGuide/search-query-get/boolean/pattern-matching.md
@@ -10,6 +10,12 @@ In agentic search applications, vector search and grep-style pattern matching of
 
 In Milvus, you can express these pattern constraints in scalar filters with `LIKE` for simple wildcard matching, and `=~` or `!~` for [RE2](https://github.com/google/re2/wiki/syntax) regular expressions. You can combine these filters with `query`, `search`, or hybrid search.
 
+<div class="alert note">
+
+This page describes pattern matching in scalar filter expressions used by `query`, `search`, and hybrid search. These expressions evaluate field values and do not change the tokens produced by an analyzer. To filter tokens during text analysis, refer to [Regex Analyzer Filter](regex-filter.md).
+
+</div>
+
 Pattern matching expressions are written in the `filter` parameter. For example, the following query matches log messages that contain an error code such as `E1001`:
 
 ```python


### PR DESCRIPTION
## Summary

- Rename the analyzer page title to **Regex Analyzer Filter** while preserving its existing slug and document ID.
- Add reciprocal notes that distinguish analyzer token filtering from scalar filter expressions using `=~` and `!~`.
- Link the analyzer and pattern-matching pages so readers can navigate to the intended regex feature.

## Version context

- Targets the `preview` branch.
- Regex filter expressions were introduced by milvus-io/milvus#48952 for Milvus 3.0.
- The documentation can be propagated or adapted to `v3.0.x` during GA work.

## Validation

- `git diff --check`
- `node check-link.js`
- Verified that both front-matter IDs still match their filenames.