### PR TITLE
docs: complete ARRAY partial-update operator references

### DIFF
--- a/site/en/userGuide/schema/array_data_type.md
+++ b/site/en/userGuide/schema/array_data_type.md
@@ -526,6 +526,12 @@ curl --request POST \
 }'
 ```
 
+<div class="alert note">
+
+Beyond inserting full arrays, `ARRAY` fields also support the `ARRAY_APPEND` and `ARRAY_REMOVE` partial-update operators on the `upsert` API in Milvus v2.6.17 and later. These let you append elements to or remove matching elements from an existing array without first retrieving its current value, which avoids the client-side read-modify-write pattern. For details, see [Upsert ARRAY fields with partial-update operators](upsert-entities.md#Upsert-ARRAY-fields-with-partial-update-operators).
+
+</div>
+
 ## Query with filter expressions
 
 After inserting entities, use the `query` method to retrieve entities that match the specified filter expressions.

--- a/site/en/userGuide/search-query-get/boolean/array-operators.md
+++ b/site/en/userGuide/search-query-get/boolean/array-operators.md
@@ -1,12 +1,12 @@
 ---
 id: array-operators.md
 title: "ARRAY Operators"
-summary: "Milvus provides powerful operators to query array fields, allowing you to filter and retrieve entities based on the contents of arrays."
+summary: "Milvus provides ARRAY operators for filtering ARRAY fields and partially updating ARRAY field values."
 ---
 
 # ARRAY Operators
 
-Milvus provides powerful operators to query array fields, allowing you to filter and retrieve entities based on the contents of arrays. 
+Milvus provides ARRAY operators for filtering ARRAY fields and partially updating ARRAY field values.
 
 <div class="alert note">
 
@@ -14,17 +14,24 @@ All elements within an array must be the same type, and nested structures within
 
 </div>
 
-## Available ARRAY Operators
+ARRAY operators in Milvus cover two usage scenarios:
 
-The ARRAY operators allow for fine-grained querying of array fields in Milvus. These operators are:
+- Filter expressions for query and search.
 
-- [`ARRAY_CONTAINS(identifier, expr)`](array-operators.md#ARRAYCONTAINS): checks if a specific element exists in an array field.
+- Partial updates in `upsert` requests.
 
-- [`ARRAY_CONTAINS_ALL(identifier, expr)`](array-operators.md#ARRAYCONTAINSALL): ensures that all elements of the specified list are present in the array field.
+## Available ARRAY operators
 
-- [`ARRAY_CONTAINS_ANY(identifier, expr)`](array-operators.md#ARRAYCONTAINSANY): checks if any of the elements from the specified list are present in the array field.
+The following table lists ARRAY operators available in Milvus.
 
-- [`ARRAY_LENGTH(identifier)`](array-operators.md#ARRAYLENGTH): returns the number of elements in an array field and can be combined with comparison operators for filtering.
+| Operator | Use in | Description |
+| --- | --- | --- |
+| [ARRAY_CONTAINS(identifier, expr)](array-operators.md#ARRAYCONTAINS) | Filter expression | Checks whether a specific element exists in an ARRAY field. |
+| [ARRAY_CONTAINS_ALL(identifier, expr)](array-operators.md#ARRAYCONTAINSALL) | Filter expression | Checks whether all elements in a specified list exist in an ARRAY field. |
+| [ARRAY_CONTAINS_ANY(identifier, expr)](array-operators.md#ARRAYCONTAINSANY) | Filter expression | Checks whether any element in a specified list exists in an ARRAY field. |
+| [ARRAY_LENGTH(identifier)](array-operators.md#ARRAYLENGTH) | Filter expression | Returns the number of elements in an ARRAY field and can be combined with comparison operators for filtering. |
+| [ARRAY_APPEND](array-operators.md#ARRAYAPPEND) | `upsert` with `field_ops` | Appends payload elements to an existing ARRAY field. Available in Milvus v2.6.17 and later. |
+| [ARRAY_REMOVE](array-operators.md#ARRAYREMOVE) | `upsert` with `field_ops` | Removes every element from an existing ARRAY field that matches a value in the request payload. Available in Milvus v2.6.17 and later. |
 
 ## ARRAY_CONTAINS
 
@@ -81,3 +88,51 @@ filter = 'ARRAY_LENGTH(history_temperatures) < 10'
 ```
 
 This will return all entities where the `history_temperatures` array has fewer than 10 elements.
+
+## ARRAY_APPEND | Milvus 2.6.17+
+
+The `ARRAY_APPEND` operator appends payload elements to an existing ARRAY field during an `upsert` request. It is not a filter expression. Use it when you want to add values to an array without first querying the current array value.
+
+The following Python example appends `"premium"` to the `tags` ARRAY field of the entity whose primary key is `1`:
+
+```python
+from pymilvus import FieldOp, MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+client.upsert(
+    collection_name="users",
+    data=[{"pk": 1, "tags": ["premium"]}],
+    # highlight-next-line
+    field_ops={"tags": FieldOp.array_append()},
+)
+```
+
+Attaching `ARRAY_APPEND` to a field through `field_ops` enables partial-update semantics for that field. For the full workflow, supported element types, and limits, refer to [Upsert ARRAY fields with partial-update operators](upsert-entities.md#Upsert-ARRAY-fields-with-partial-update-operators).
+
+## ARRAY_REMOVE | Milvus 2.6.17+
+
+The `ARRAY_REMOVE` operator removes every element from an existing ARRAY field that matches a value in the request payload during an `upsert` request. It is not a filter expression. Use it when you want to remove matching values from an array without first querying the current array value.
+
+The following Python example removes `"trial"` from the `tags` ARRAY field of the entity whose primary key is `1`:
+
+```python
+from pymilvus import FieldOp, MilvusClient
+
+client = MilvusClient(
+    uri="http://localhost:19530",
+    token="root:Milvus"
+)
+
+client.upsert(
+    collection_name="users",
+    data=[{"pk": 1, "tags": ["trial"]}],
+    # highlight-next-line
+    field_ops={"tags": FieldOp.array_remove()},
+)
+```
+
+Attaching `ARRAY_REMOVE` to a field through `field_ops` enables partial-update semantics for that field. For the full workflow, supported element types, and limits, refer to [Upsert ARRAY fields with partial-update operators](upsert-entities.md#Upsert-ARRAY-fields-with-partial-update-operators).


### PR DESCRIPTION
## Summary

- add ARRAY_APPEND and ARRAY_REMOVE to the ARRAY operator reference
- link the ARRAY data type guide to the existing partial-update workflow
- preserve the more complete v2.6.x upsert guide and adapt links to its current heading

## Version evidence

ARRAY_APPEND and ARRAY_REMOVE are available in Milvus 2.6.17 and later. The main v2.6.x upsert guide already documents the workflow; this PR completes the missing cross-reference and operator pages.

## Validation

- full repository internal link check
- target heading and anchor validation
- exact two-file scope check
- git diff --check