### PR TITLE
docs: propagate CAGRA sampling parameter to 3.0 staging

### DIFF
--- a/site/en/userGuide/indexes/gpu/gpu-cagra.md
+++ b/site/en/userGuide/indexes/gpu/gpu-cagra.md
@@ -156,6 +156,11 @@ The following table lists the parameters that can be configured in `search_param
      <td><p>Empty</p></td>
    </tr>
    <tr>
+     <td><p><code>num_random_samplings</code></p></td>
+     <td><p>Controls how much random sampling CAGRA performs when choosing initial entry points for graph search. A larger value gives CAGRA more chances to start from better points, improving recall at the cost of increased search latency. The value must be at least <code>1</code>. Available in Milvus 2.6.20+.</p></td>
+     <td><p><code>1</code></p></td>
+   </tr>
+   <tr>
      <td><p><code>min_iterations</code> / <code>max_iterations</code></p></td>
      <td><p>Controls the search iteration process. By default, they are set to <code>0</code>, and CAGRA automatically determines the number of iterations based on <code>itopk_size</code> and <code>search_width</code>. Adjusting these values manually can help balance performance and accuracy.</p></td>
      <td><p><code>0</code></p></td>


### PR DESCRIPTION
## Summary

- document the GPU CAGRA num_random_samplings search parameter in Milvus 3.0 staging
- include its default value, minimum value, and recall-versus-latency tradeoff

## Source evidence

The wording is propagated from the released v2.6.x documentation, where the parameter is available from Milvus 2.6.20 onward.

## Validation

- exact one-file scope check
- byte-level comparison of the added table row with v2.6.x
- git diff --check