### PR TITLE
docs: recommend stable versions for Woodpecker service mode

### DIFF
--- a/site/en/adminGuide/woodpecker.md
+++ b/site/en/adminGuide/woodpecker.md
@@ -239,7 +239,7 @@ docker restart milvus-standalone
 
 <div class="alert note">
 
-When deploying Milvus with Woodpecker in service mode, use **Milvus 3.0.1 or later** together with **Woodpecker v0.1.36 or later**. The Woodpecker client dependency in Milvus 3.0.0 does not include the compaction cleanup that reclaims storage used by obsolete data or the group commit optimization.
+For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.36 or later for compaction cleanup and group commit optimizations.
 
 </div>
 

--- a/site/en/adminGuide/woodpecker.md
+++ b/site/en/adminGuide/woodpecker.md
@@ -237,6 +237,12 @@ docker restart milvus-standalone
 
 ### Enable Woodpecker service mode for a Milvus Cluster (Helm)
 
+<div class="alert note">
+
+When deploying Milvus with Woodpecker in service mode, use **Milvus 3.0.1 or later** together with **Woodpecker v0.1.36 or later**. The Woodpecker client dependency in Milvus 3.0.0 does not include the compaction cleanup that reclaims storage used by obsolete data or the group commit optimization.
+
+</div>
+
 Woodpecker **service mode** is a **Milvus 3.0** feature. For distributed/cluster deployments, you can run Woodpecker as a **dedicated service** (separate pods) instead of embedded in the streaming node by setting `streaming.woodpecker.embedded=false`:
 
 ```bash

--- a/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
+++ b/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
@@ -86,6 +86,12 @@ helm install my-release zilliztech/milvus \
 
 **Deploy Milvus cluster:**
 
+<div class="alert note">
+
+When deploying Milvus with Woodpecker in service mode, use **Milvus 3.0.1 or later** together with **Woodpecker v0.1.36 or later**. The Woodpecker client dependency in Milvus 3.0.0 does not include the compaction cleanup that reclaims storage used by obsolete data or the group commit optimization.
+
+</div>
+
 The following command deploys a Milvus cluster with optimized settings for v{{var.milvus_release_version}}, using Woodpecker as the recommended message queue:
 
 ```bash

--- a/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
+++ b/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
@@ -88,7 +88,7 @@ helm install my-release zilliztech/milvus \
 
 <div class="alert note">
 
-When deploying Milvus with Woodpecker in service mode, use **Milvus 3.0.1 or later** together with **Woodpecker v0.1.36 or later**. The Woodpecker client dependency in Milvus 3.0.0 does not include the compaction cleanup that reclaims storage used by obsolete data or the group commit optimization.
+For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.36 or later for compaction cleanup and group commit optimizations.
 
 </div>
 


### PR DESCRIPTION
## What this PR does

- Adds a compatibility note before the Woodpecker service-mode Helm installation instructions.
- Recommends the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.36 or later.
- Highlights the compaction cleanup and group commit optimizations available with the recommended versions.

## Verification

- git diff --check
- Parsed both updated Markdown pages with the repository's Showdown dependency