### PR TITLE
docs: promote Yandex Cloud and DashScope Ranker to v3.0.x

### DIFF
--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -1319,6 +1319,12 @@
                 "id": "google-gemini.md",
                 "order": 11,
                 "children": []
+              },
+              {
+                "label": "Yandex Cloud",
+                "id": "yandex-cloud.md",
+                "order": 12,
+                "children": []
               }
             ]
           },
@@ -1433,9 +1439,15 @@
                     "children": []
                   },
                   {
+                    "label": "DashScope Ranker",
+                    "id": "dashscope-ranker.md",
+                    "order": 6,
+                    "children": []
+                  },
+                  {
                     "label": "Hugging Face Ranker",
                     "id": "hugging-face-ranker.md",
-                    "order": 6,
+                    "order": 7,
                     "children": []
                   }
                 ]

--- a/site/en/userGuide/embeddings-reranking/embedding-function/embedding-function-overview.md
+++ b/site/en/userGuide/embeddings-reranking/embedding-function/embedding-function-overview.md
@@ -53,6 +53,12 @@ The Function module in Milvus allows you to transform raw text data into vector 
      <td><p>API key</p></td>
    </tr>
    <tr>
+     <td><p><a href="yandex-cloud.md">Yandex Cloud</a></p></td>
+     <td><p>Yandex Cloud AI Studio text vectorization models</p></td>
+     <td><p><code>FLOAT_VECTOR</code></p></td>
+     <td><p>API key</p></td>
+   </tr>
+   <tr>
      <td><p><a href="bedrock.md">Bedrock</a></p></td>
      <td><p>amazon.titan-embed-text-v2</p></td>
      <td><p><code>FLOAT_VECTOR</code></p></td>

--- a/site/en/userGuide/embeddings-reranking/embedding-function/yandex-cloud.md
+++ b/site/en/userGuide/embeddings-reranking/embedding-function/yandex-cloud.md
@@ -1,0 +1,124 @@
+---
+id: yandex-cloud.md
+title: "Yandex Cloud"
+summary: "This topic describes how to configure and use Yandex Cloud embedding functions in Milvus."
+beta: Milvus 2.6.x
+---
+
+# Yandex Cloud
+
+This topic describes how to configure and use Yandex Cloud embedding functions in Milvus.
+
+## Choose an embedding model
+
+Milvus supports Yandex Cloud AI Studio text vectorization models through the `yc` provider. In the Function parameters, set `model_name` to the Yandex Cloud model URI that Milvus should call.
+
+For example, Yandex Text Embeddings for documents use a model URI such as `emb://<folder_ID>/text-search-doc/latest` and return 256-dimensional vectors. For available model URIs and dimensions, refer to [Text vectorization models](https://aistudio.yandex.ru/docs/en/ai-studio/concepts/embeddings).
+
+## Configure credentials
+
+Milvus must know your Yandex Cloud API key before it can request embeddings. You can configure the API key in `milvus.yaml` or through an environment variable.
+
+### Option 1: Configuration file
+
+Store your API key in `milvus.yaml` and point the Yandex Cloud provider to the credential label.
+
+```yaml
+# milvus.yaml
+credential:
+  yandex_apikey:
+    apikey: <YOUR_YC_API_KEY>
+
+function:
+  textEmbedding:
+    providers:
+      yc:
+        credential: yandex_apikey
+        # url: https://llm.api.cloud.yandex.net/foundationModels/v1/textEmbedding
+```
+
+### Option 2: Environment variable
+
+If no matching credential is configured in `milvus.yaml`, Milvus can read the Yandex Cloud API key from the following environment variable:
+
+<table>
+   <tr>
+     <th><p>Variable</p></th>
+     <th><p>Required?</p></th>
+     <th><p>Description</p></th>
+   </tr>
+   <tr>
+     <td><p><code>MILVUS_YC_API_KEY</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>Yandex Cloud API key used by the Milvus service to call Yandex Cloud AI Studio.</p></td>
+   </tr>
+</table>
+
+## Use embedding function
+
+Once credentials are configured, define a schema with an input text field and an output vector field, then add a Yandex Cloud embedding Function to the schema.
+
+```python
+from pymilvus import MilvusClient, DataType, Function, FunctionType
+
+client = MilvusClient(uri="http://localhost:19530")
+
+schema = client.create_schema()
+schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+schema.add_field("document", DataType.VARCHAR, max_length=9000)
+schema.add_field("dense", DataType.FLOAT_VECTOR, dim=256)
+
+text_embedding_function = Function(
+    name="yandex_cloud_embedding",
+    function_type=FunctionType.TEXTEMBEDDING,
+    input_field_names=["document"],
+    output_field_names=["dense"],
+    params={
+        "provider": "yc",
+        "model_name": "emb://<folder_ID>/text-search-doc/latest",
+        "credential": "yandex_apikey",
+        "dim": "256",
+    },
+)
+
+schema.add_function(text_embedding_function)
+```
+
+### Yandex Cloud-specific parameters
+
+<table>
+   <tr>
+     <th><p>Parameter</p></th>
+     <th><p>Required?</p></th>
+     <th><p>Description</p></th>
+     <th><p>Value / Example</p></th>
+   </tr>
+   <tr>
+     <td><p><code>provider</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>The embedding model provider to use.</p></td>
+     <td><p><code>"yc"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>model_name</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>The Yandex Cloud model URI to call.</p></td>
+     <td><p><code>"emb://&lt;folder_ID&gt;/text-search-doc/latest"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>credential</code></p></td>
+     <td><p>No</p></td>
+     <td><p>The label of a credential defined in the top-level <code>credential:</code> section of <code>milvus.yaml</code>.</p></td>
+     <td><p><code>"yandex_apikey"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>dim</code></p></td>
+     <td><p>No</p></td>
+     <td><p>The output vector dimension. If set, the value must match the dimension of the output vector field.</p></td>
+     <td><p><code>"256"</code></p></td>
+   </tr>
+</table>
+
+## Next steps
+
+After configuring the embedding function, refer to [Embedding Function Overview](embedding-function-overview.md) for guidance on creating indexes, inserting data, and running semantic search.

--- a/site/en/userGuide/embeddings-reranking/reranking/dashscope-ranker.md
+++ b/site/en/userGuide/embeddings-reranking/reranking/dashscope-ranker.md
@@ -1,0 +1,153 @@
+---
+id: dashscope-ranker.md
+title: "DashScope Ranker"
+summary: "This topic describes how to configure and use DashScope reranking models, such as Qwen rerank models, in Milvus."
+beta: Milvus 2.6.x
+---
+
+# DashScope Ranker
+
+The DashScope Ranker lets Milvus call Alibaba Cloud DashScope reranking models to reorder search results by semantic relevance.
+
+## Prerequisites
+
+Before using the DashScope Ranker, ensure that you have:
+
+- A Milvus collection with a `VARCHAR` field that contains the text to rerank.
+
+- A valid DashScope API key.
+
+- Access to a DashScope reranking model, such as `gte-rerank-v2`.
+
+For available rerank models and regional endpoints, refer to the [Alibaba Cloud Model Studio Text Rerank API](https://www.alibabacloud.com/help/en/model-studio/text-rerank-api).
+
+## Configure credentials
+
+Milvus must know your DashScope API key before it can request reranking from DashScope. You can configure the API key in `milvus.yaml` or through an environment variable.
+
+### Option 1: Configuration file
+
+Store your API key in `milvus.yaml` and point the DashScope rerank provider to the credential label.
+
+```yaml
+# milvus.yaml
+credential:
+  dashscope_apikey:
+    apikey: <YOUR_DASHSCOPE_API_KEY>
+
+function:
+  rerank:
+    model:
+      providers:
+        ali:
+          credential: dashscope_apikey
+          # url: https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+```
+
+### Option 2: Environment variable
+
+If no matching credential is configured in `milvus.yaml`, Milvus can read the DashScope API key from the following environment variable:
+
+<table>
+   <tr>
+     <th><p>Variable</p></th>
+     <th><p>Required?</p></th>
+     <th><p>Description</p></th>
+   </tr>
+   <tr>
+     <td><p><code>MILVUS_DASHSCOPE_API_KEY</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>DashScope API key used by the Milvus service to call Alibaba Cloud DashScope.</p></td>
+   </tr>
+</table>
+
+## Create a DashScope ranker function
+
+To use the DashScope Ranker, create a Function object that specifies the DashScope reranking model and query text. Use `provider: "ali"` for DashScope reranking.
+
+```python
+from pymilvus import Function, FunctionType
+
+dashscope_ranker = Function(
+    name="dashscope_semantic_ranker",
+    input_field_names=["document"],
+    function_type=FunctionType.RERANK,
+    params={
+        "reranker": "model",
+        "provider": "ali",
+        "model_name": "gte-rerank-v2",
+        "queries": ["renewable energy developments"],
+        "max_client_batch_size": 128,
+        "credential": "dashscope_apikey",
+    },
+)
+```
+
+### DashScope ranker-specific parameters
+
+<table>
+   <tr>
+     <th><p>Parameter</p></th>
+     <th><p>Required?</p></th>
+     <th><p>Description</p></th>
+     <th><p>Value / Example</p></th>
+   </tr>
+   <tr>
+     <td><p><code>reranker</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>Must be set to <code>"model"</code> to enable model reranking.</p></td>
+     <td><p><code>"model"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>provider</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>The model service provider to use for reranking. For DashScope, use <code>"ali"</code>.</p></td>
+     <td><p><code>"ali"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>model_name</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>The DashScope reranking model to use.</p></td>
+     <td><p><code>"gte-rerank-v2"</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>queries</code></p></td>
+     <td><p>Yes</p></td>
+     <td><p>List of query strings used by the rerank model to calculate relevance scores. The number of query strings must match the number of queries in the search request.</p></td>
+     <td><p><code>["renewable energy developments"]</code></p></td>
+   </tr>
+   <tr>
+     <td><p><code>max_client_batch_size</code></p></td>
+     <td><p>No</p></td>
+     <td><p>Maximum number of documents to send to the model service per request.</p></td>
+     <td><p><code>128</code> (default)</p></td>
+   </tr>
+   <tr>
+     <td><p><code>credential</code></p></td>
+     <td><p>No</p></td>
+     <td><p>The label of a credential defined in the top-level <code>credential:</code> section of <code>milvus.yaml</code>.</p></td>
+     <td><p><code>"dashscope_apikey"</code></p></td>
+   </tr>
+</table>
+
+<div class="alert note">
+
+For general parameters shared across all model rankers, such as `provider` and `queries`, refer to [Create a model ranker](model-ranker-overview.md#Create-a-model-ranker).
+
+</div>
+
+## Apply to standard vector search
+
+To apply DashScope Ranker to a standard vector search, pass the ranker Function to `search()`.
+
+```python
+results = client.search(
+    collection_name="your_collection",
+    data=[your_query_vector],
+    anns_field="dense_vector",
+    limit=5,
+    output_fields=["document"],
+    ranker=dashscope_ranker,
+    consistency_level="Bounded",
+)
+```

--- a/site/en/userGuide/embeddings-reranking/reranking/model-ranker-overview.md
+++ b/site/en/userGuide/embeddings-reranking/reranking/model-ranker-overview.md
@@ -85,6 +85,12 @@ Milvus supports the following model service providers for reranking, each with d
      <td><p>Technical documentation search system processing lengthy manuals and papers that need intelligent segmentation and overlap control</p></td>
    </tr>
    <tr>
+     <td><p>DashScope</p></td>
+     <td><p>Applications using Alibaba Cloud or Qwen reranking models</p></td>
+     <td><ul><li><p>Managed DashScope reranking API</p></li><li><p>Supports reranking models such as <code>gte-rerank-v2</code></p></li><li><p>API-key based authentication</p></li></ul></td>
+     <td><p>RAG applications that want to rerank candidates with Alibaba Cloud-hosted reranking models</p></td>
+   </tr>
+   <tr>
      <td><p>Hugging Face</p></td>
      <td><p>Applications using hosted Hugging Face sentence-similarity models</p></td>
      <td><ul><li><p>Uses the hosted <code>hf-inference</code> provider</p></li><li><p>Selects models from the Hugging Face Hub</p></li><li><p>Calculates one sentence-similarity score per candidate</p></li><li><p>Uses API-key authentication</p></li></ul></td>
@@ -103,6 +109,8 @@ For detailed information about implementation of each model service, refer to th
 - [Voyage AI Ranker](voyage-ai-ranker.md)
 
 - [SiliconFlow Ranker](siliconflow-ranker.md)
+
+- [DashScope Ranker](dashscope-ranker.md)
 
 - [Hugging Face Ranker](hugging-face-ranker.md)
 


### PR DESCRIPTION
## Summary

- promote the Yandex Cloud embedding guide from Preview to v3.0.x
- promote the DashScope Ranker guide from Preview to v3.0.x
- add both guides to the relevant overview pages and navigation

Source Preview PR: #3551

## Validation

- full repository link check
- menu JSON parsing
- front matter ID and filename consistency
- Python fenced-code syntax parsing
- git diff checks
- Milvus v3.0.0 source verification

## Not run

Real Yandex Cloud and DashScope service calls were not run because they require external provider credentials.