### PR TITLE
docs: fix Woodpecker service image tag rendering

### DIFF
--- a/site/en/Variables.json
+++ b/site/en/Variables.json
@@ -20,6 +20,7 @@
   "milvus_restful_sdk_real_version": "3.0.0",
   "milvus_operator_version": "1.3.7",
   "milvus_helm_chart_version": "5.0.22",
+  "woodpecker_release_version": "0.1.36",
   "milvus_image": "3.0.0",
   "attu_release": "v3.0.0-beta.6",
   "milvus_backup_release": "0.5.16",


### PR DESCRIPTION
## What this PR does

- Defines the missing woodpecker_release_version variable as 0.1.36.
- Fixes Helm examples that currently render woodpecker.image.tag as only v.
- Keeps the existing recommendation to upgrade to Milvus 3.0.1 or a later release when available.

## Verification

- Validated site/en/Variables.json with jq.
- Confirmed all Woodpecker service image references resolve through the restored variable.
- git diff --check