### PR TITLE
docs: propagate data infrastructure navigation to preview

### DIFF
--- a/site/en/adminGuide/data-infra-integration-overview.md
+++ b/site/en/adminGuide/data-infra-integration-overview.md
@@ -1,12 +1,12 @@
 ---
 id: data-infra-integration-overview.md
-title: Data Infrastructure & Integration
-summary: Overview of the third-party infrastructure Milvus integrates with — metadata, object storage, and message queues.
+title: Data Infrastructure
+summary: Overview of the metadata storage, object storage, and message queues that Milvus uses.
 ---
 
-# Data Infrastructure & Integration
+# Data Infrastructure
 
-Milvus builds on open data infrastructure for its core dependencies. This chapter covers the components you can plug in and configure:
+Milvus relies on metadata storage, object storage, and a message queue for its core data infrastructure. This chapter covers the components you can configure:
 
 - **[Metadata](etcd.md)** — Milvus stores metadata (collection schemas, node status, consumption checkpoints) in etcd.
 - **[Object Storage](object-storage.md)** — Milvus stores index files and binary logs in MinIO, AWS S3, or other S3-compatible / cloud object storage.

--- a/site/en/adminGuide/mqtype-overview.md
+++ b/site/en/adminGuide/mqtype-overview.md
@@ -21,7 +21,7 @@ Milvus relies on a message queue (write-ahead log, WAL) to manage logs of recent
 
 - Each Milvus instance uses exactly one message queue.
 - {{fragments/mq_upgrade_limitation.md}}
-- To change the message queue of a running instance, see [Switch MQ Type](switch-mq-type.md). The Switch MQ feature is available in **Milvus 3.0 and later** — upgrade to Milvus 3.0 or later first.
+- To change the message queue of a running instance, see [Switch Message Queue](switch-mq-type.md). The Switch MQ feature is available in **Milvus 3.0 and later** — upgrade to Milvus 3.0 or later first.
 
 </div>
 

--- a/site/en/adminGuide/switch-kafka-woodpecker.md
+++ b/site/en/adminGuide/switch-kafka-woodpecker.md
@@ -6,7 +6,7 @@ summary: Switch the message queue of a Milvus cluster between Kafka and Woodpeck
 
 # Switch between Kafka and Woodpecker
 
-This page describes how to switch the message queue (MQ) of a **Milvus cluster** between **Kafka** (builtin or external) and **Woodpecker** (MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch MQ Type](switch-mq-type.md).
+This page describes how to switch the message queue (MQ) of a **Milvus cluster** between **Kafka** (builtin or external) and **Woodpecker** (MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch Message Queue](switch-mq-type.md).
 
 <div class="alert note">
 

--- a/site/en/adminGuide/switch-mq-type.md
+++ b/site/en/adminGuide/switch-mq-type.md
@@ -1,10 +1,10 @@
 ---
 id: switch-mq-type.md
-title: Switch MQ Type
-summary: Switch the message queue of an existing Milvus deployment between Woodpecker and another message queue without downtime.
+title: Switch Message Queue
+summary: Switch an existing Milvus deployment between Woodpecker and another message queue without downtime.
 ---
 
-# Switch MQ Type
+# Switch Message Queue
 
 This guide describes how to switch the message queue (MQ) of an existing Milvus deployment **between Woodpecker and another message queue**, online and without downtime.
 

--- a/site/en/adminGuide/switch-pulsar-woodpecker.md
+++ b/site/en/adminGuide/switch-pulsar-woodpecker.md
@@ -6,7 +6,7 @@ summary: Switch the message queue of a Milvus cluster between Pulsar and Woodpec
 
 # Switch between Pulsar and Woodpecker
 
-This page describes how to switch the message queue (MQ) of a **Milvus cluster** between **Pulsar** (builtin or external) and **Woodpecker** (MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch MQ Type](switch-mq-type.md).
+This page describes how to switch the message queue (MQ) of a **Milvus cluster** between **Pulsar** (builtin or external) and **Woodpecker** (MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch Message Queue](switch-mq-type.md).
 
 <div class="alert note">
 

--- a/site/en/adminGuide/switch-rocksmq-woodpecker.md
+++ b/site/en/adminGuide/switch-rocksmq-woodpecker.md
@@ -6,7 +6,7 @@ summary: Switch the message queue of a Milvus Standalone (Docker Compose) deploy
 
 # Switch between RocksMQ and Woodpecker
 
-This page describes how to switch the message queue (MQ) of a **Milvus Standalone (Docker Compose)** deployment between **RocksMQ** and **Woodpecker** (local or MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch MQ Type](switch-mq-type.md).
+This page describes how to switch the message queue (MQ) of a **Milvus Standalone (Docker Compose)** deployment between **RocksMQ** and **Woodpecker** (local or MinIO backend), in both directions. For the general workflow and prerequisites, see [Switch Message Queue](switch-mq-type.md).
 
 <div class="alert note">
 

--- a/site/en/getstarted/install-overview.md
+++ b/site/en/getstarted/install-overview.md
@@ -48,7 +48,7 @@ The choice of Milvus deployment mode depends on your project's stage and scale. 
 - **Milvus Standalone** is suitable for medium-sized datasets, scaling up to 100 million vectors.
 - **Milvus Distributed** is designed for large-scale deployments, capable of handling datasets from 100 million up to tens of billions of vectors.
 
-Regardless of the deployment mode, every Milvus instance relies on a message queue, object storage, and a metadata store — by default **Woodpecker**, **MinIO**, and **etcd**. To learn about these dependencies, tune them, or connect external services, see [Data Infrastructure & Integration](data-infra-integration-overview.md).
+Regardless of the deployment mode, every Milvus instance relies on a message queue, object storage, and a metadata store — by default **Woodpecker**, **MinIO**, and **etcd**. To learn about these dependencies, tune them, or connect external services, see [Data Infrastructure](data-infra-integration-overview.md).
 
 ![Select deployment option for your use case](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/select-deployment-option.png)
 

--- a/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
+++ b/site/en/getstarted/run-milvus-docker/install_standalone-docker-compose.md
@@ -118,7 +118,7 @@ mq:
   type: rocksmq
 ```
 
-To switch the message queue *after* upgrading, see [Switch MQ Type](switch-mq-type.md).
+To switch the message queue *after* upgrading, see [Switch Message Queue](switch-mq-type.md).
 
 ## Optional dependencies
 

--- a/site/en/menuStructure/en.json
+++ b/site/en/menuStructure/en.json
@@ -1636,95 +1636,10 @@
     ]
   },
   {
-    "label": "Data Infrastructure & Integration",
-    "id": "data_infra_integration",
-    "isMenu": true,
-    "order": 9,
-    "children": [
-      {
-        "label": "Overview",
-        "id": "data-infra-integration-overview.md",
-        "order": 0,
-        "children": []
-      },
-      {
-        "label": "Metadata",
-        "id": "metadata",
-        "isMenu": true,
-        "order": 1,
-        "children": [
-          {
-            "label": "etcd",
-            "id": "etcd.md",
-            "order": 0,
-            "children": []
-          }
-        ]
-      },
-      {
-        "label": "Object Storage",
-        "id": "object-storage.md",
-        "order": 2,
-        "children": []
-      },
-      {
-        "label": "Message Queue (mqType)",
-        "id": "mqtype",
-        "isMenu": true,
-        "order": 4,
-        "children": [
-          {
-            "label": "Overview",
-            "id": "mqtype-overview.md",
-            "order": 0,
-            "children": []
-          },
-          {
-            "label": "Woodpecker",
-            "id": "woodpecker.md",
-            "order": 1,
-            "children": []
-          },
-          {
-            "label": "Pulsar",
-            "id": "mq_pulsar.md",
-            "order": 2,
-            "children": [
-              {
-                "label": "Upgrade to Pulsar v3",
-                "id": "upgrade-pulsar-v3.md",
-                "order": 0,
-                "children": []
-              },
-              {
-                "label": "Continue Using Pulsar v2",
-                "id": "use-pulsar-v2.md",
-                "order": 1,
-                "children": []
-              }
-            ]
-          },
-          {
-            "label": "Kafka",
-            "id": "mq_kafka.md",
-            "order": 3,
-            "children": []
-          },
-          {
-            "label": "RocksMQ",
-            "id": "mq_rocksmq.md",
-            "order": 4,
-            "children": []
-          }
-        ]
-      }
-    ]
-  },
-  {
     "label": "Administration Guide",
     "id": "admin_guide",
     "isMenu": true,
-    "order": 10,
+    "order": 9,
     "children": [
       {
         "label": "Deployment",
@@ -1891,6 +1806,122 @@
             "id": "configure-querynode-localdisk.md",
             "order": 5,
             "children": []
+          }
+        ]
+      },
+      {
+        "label": "Data Infrastructure",
+        "id": "data_infra_integration",
+        "isMenu": true,
+        "order": 2,
+        "children": [
+          {
+            "label": "Overview",
+            "id": "data-infra-integration-overview.md",
+            "order": 0,
+            "children": []
+          },
+          {
+            "label": "Metadata",
+            "id": "metadata",
+            "isMenu": true,
+            "order": 1,
+            "children": [
+              {
+                "label": "etcd",
+                "id": "etcd.md",
+                "order": 0,
+                "children": []
+              }
+            ]
+          },
+          {
+            "label": "Object Storage",
+            "id": "object-storage.md",
+            "order": 2,
+            "children": []
+          },
+          {
+            "label": "Message Queue",
+            "id": "mqtype",
+            "isMenu": true,
+            "order": 3,
+            "children": [
+              {
+                "label": "Overview",
+                "id": "mqtype-overview.md",
+                "order": 0,
+                "children": []
+              },
+              {
+                "label": "Woodpecker",
+                "id": "woodpecker.md",
+                "order": 1,
+                "children": []
+              },
+              {
+                "label": "Pulsar",
+                "id": "mq_pulsar.md",
+                "order": 2,
+                "children": [
+                  {
+                    "label": "Upgrade to Pulsar v3",
+                    "id": "upgrade-pulsar-v3.md",
+                    "order": 0,
+                    "children": []
+                  },
+                  {
+                    "label": "Continue Using Pulsar v2",
+                    "id": "use-pulsar-v2.md",
+                    "order": 1,
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "label": "Kafka",
+                "id": "mq_kafka.md",
+                "order": 3,
+                "children": []
+              },
+              {
+                "label": "RocksMQ",
+                "id": "mq_rocksmq.md",
+                "order": 4,
+                "children": []
+              },
+              {
+                "label": "Switch Message Queue",
+                "id": "switch_milvus_mq_type",
+                "order": 5,
+                "children": [
+                  {
+                    "label": "Overview",
+                    "id": "switch-mq-type.md",
+                    "order": 0,
+                    "children": []
+                  },
+                  {
+                    "label": "RocksMQ ↔ Woodpecker",
+                    "id": "switch-rocksmq-woodpecker.md",
+                    "order": 1,
+                    "children": []
+                  },
+                  {
+                    "label": "Pulsar ↔ Woodpecker",
+                    "id": "switch-pulsar-woodpecker.md",
+                    "order": 2,
+                    "children": []
+                  },
+                  {
+                    "label": "Kafka ↔ Woodpecker",
+                    "id": "switch-kafka-woodpecker.md",
+                    "order": 3,
+                    "children": []
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -2121,37 +2152,6 @@
         "id": "milvus-webui.md",
         "order": "12",
         "children": []
-      },
-      {
-        "label": "Switch MQ Type",
-        "id": "switch_milvus_mq_type",
-        "order": 14,
-        "children": [
-          {
-            "label": "Overview",
-            "id": "switch-mq-type.md",
-            "order": 0,
-            "children": []
-          },
-          {
-            "label": "RocksMQ ↔ Woodpecker",
-            "id": "switch-rocksmq-woodpecker.md",
-            "order": 1,
-            "children": []
-          },
-          {
-            "label": "Pulsar ↔ Woodpecker",
-            "id": "switch-pulsar-woodpecker.md",
-            "order": 2,
-            "children": []
-          },
-          {
-            "label": "Kafka ↔ Woodpecker",
-            "id": "switch-kafka-woodpecker.md",
-            "order": 3,
-            "children": []
-          }
-        ]
       }
     ]
   },

--- a/site/en/reference/glossary.md
+++ b/site/en/reference/glossary.md
@@ -43,7 +43,7 @@ In Milvus, a collection is equivalent to a table in a relational database manage
 
 ## Dependency
 
-A dependency is a program that another program relies on to work. Milvus' dependencies include etcd (stores meta data), MinIO or S3 (object storage), and a message queue such as Woodpecker (manages snapshot logs). For more information, refer to [Data Infrastructure & Integration](https://milvus.io/docs/data-infra-integration-overview.md).
+A dependency is a program that another program relies on to work. Milvus' dependencies include etcd (stores meta data), MinIO or S3 (object storage), and a message queue such as Woodpecker (manages snapshot logs). For more information, refer to [Data Infrastructure](https://milvus.io/docs/data-infra-integration-overview.md).
 
 ## Dynamic schema
 


### PR DESCRIPTION
## What changed

Propagate the navigation reorganization from #3597 to the `preview` branch:

- Move **Data Infrastructure** under **Administration Guide**.
- Rename **Data Infrastructure & Integration** to **Data Infrastructure**.
- Rename **Message Queue (mqType)** to **Message Queue**.
- Move and rename **Switch MQ Type** to **Switch Message Queue** under **Message Queue**.
- Preserve both overview pages and all dedicated Woodpecker, Pulsar, Kafka, RocksMQ, and switch-guide pages.
- Update page titles and link labels to match the new navigation names.

All filenames, front-matter IDs, slugs, and URLs remain unchanged. The task patch has the same stable patch ID as the production change merged in #3597.

## Validation

- `NODE_PATH=/Users/liyun/milvus-docs/node_modules node check-link.js`
- `jq empty site/en/menuStructure/en.json`
- `git diff --check`
- Verified 519 menu node IDs are unique and all Markdown menu IDs resolve.
- Verified all dedicated Message Queue pages and both overview pages remain in navigation.
- Verified the pending-release warning remains unchanged.