### PR TITLE
docs: bump Woodpecker service version to v0.1.37

### DIFF
--- a/site/en/Variables.json
+++ b/site/en/Variables.json
@@ -20,7 +20,7 @@
   "milvus_restful_sdk_real_version": "3.0.0",
   "milvus_operator_version": "1.3.7",
   "milvus_helm_chart_version": "5.0.22",
-  "woodpecker_release_version": "0.1.36",
+  "woodpecker_release_version": "0.1.37",
   "milvus_image": "3.0.0",
   "attu_release": "v3.0.0-beta.6",
   "milvus_backup_release": "0.5.16",

--- a/site/en/adminGuide/woodpecker.md
+++ b/site/en/adminGuide/woodpecker.md
@@ -239,7 +239,7 @@ docker restart milvus-standalone
 
 <div class="alert note">
 
-For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.36 or later for compaction cleanup and group commit optimizations.
+For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.37 or later for compaction cleanup and group commit optimizations.
 
 </div>
 

--- a/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
+++ b/site/en/getstarted/run-milvus-k8s/install_cluster-helm.md
@@ -88,7 +88,7 @@ helm install my-release zilliztech/milvus \
 
 <div class="alert note">
 
-For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.36 or later for compaction cleanup and group commit optimizations.
+For Woodpecker service mode, we recommend using the upcoming Milvus 3.0.1 or a later release with Woodpecker v0.1.37 or later for compaction cleanup and group commit optimizations.
 
 </div>
 


### PR DESCRIPTION
## What this PR does

- Bumps the Woodpecker service image version to v0.1.37.
- Updates the Woodpecker service-mode recommendations to v0.1.37 or later.

## Verification

- `jq empty site/en/Variables.json`
- `git diff --check`