### PR TITLE
docs: propagate MinHash Jaccard refinement guidance to preview

### DIFF
--- a/site/en/userGuide/embeddings-reranking/embedding-function/minhash-function.md
+++ b/site/en/userGuide/embeddings-reranking/embedding-function/minhash-function.md
@@ -49,7 +49,7 @@ During insertion, the binary vector produced by the shared pipeline is stored in
 
 ### Query processing
 
-During search, the query text goes through the same shared pipeline to produce a binary vector. This vector is used to perform an LSH lookup in the `MINHASH_LSH` index, which quickly identifies candidate pairs that are likely similar. Candidates are then ranked by estimated Jaccard similarity and the top-K results are returned.
+During search, the query text goes through the same shared pipeline to produce a binary vector. This vector is used to perform an LSH lookup in the `MINHASH_LSH` index, which quickly identifies candidate pairs that are likely similar. Without Jaccard refinement, Milvus returns LSH candidates that are not ranked by estimated Jaccard similarity. When Jaccard refinement is enabled, Milvus uses the stored raw MinHash signatures to rank the candidates by estimated Jaccard similarity and return the top-K results.
 
 Because both paths share the same transformation logic, two documents with highly overlapping content produce similar MinHash signatures. This makes the function effective for finding near-duplicates even when documents differ in word order, formatting, or minor phrasing.
 
@@ -252,6 +252,8 @@ index_params.add_index(
 # restful
 ```
 
+Set `with_raw_data` to `True` if searches will use Jaccard refinement. The raw MinHash signatures are required to calculate estimated Jaccard similarity for the candidates returned by the LSH lookup.
+
 ### Create the collection
 
 Create the collection using the schema and index parameters defined above:
@@ -329,7 +331,7 @@ client.insert(
 
 ## Step 3: Search with MinHash
 
-Once you have inserted data, search for near-duplicate documents by providing raw text queries. Milvus automatically converts your query text into a MinHash binary vector and retrieves the most similar documents using estimated Jaccard similarity.
+Once you have inserted data, search for near-duplicate documents by providing raw text queries. Milvus automatically converts each query into a MinHash binary vector. Enable Jaccard refinement to rank the LSH candidates by estimated Jaccard similarity.
 
 <div class="multipleCode">
     <a href="#python">Python</a>
@@ -342,7 +344,10 @@ Once you have inserted data, search for near-duplicate documents by providing ra
 ```python
 search_params = {
     "metric_type": "MHJACCARD",
-    "params": {},
+    "params": {
+        "mh_search_with_jaccard": True,
+        "refine_k": 3,
+    },
 }
 
 results = client.search(
@@ -375,6 +380,8 @@ for hits in results:
 ```bash
 # restful
 ```
+
+Set `mh_search_with_jaccard` to `True` to enable Jaccard refinement. `refine_k` controls the candidate-pool capacity used for refinement. Milvus uses `max(refine_k, limit)` as the capacity, but may refine fewer candidates if the LSH lookup returns fewer matches. Increasing `refine_k` can improve result quality at the cost of additional computation.
 
 ## What's next
 


### PR DESCRIPTION
## Summary

- Propagate the reviewed MinHash Jaccard refinement correction from the `v3.0.x` documentation to `preview`.
- Distinguish raw LSH candidates from estimated-Jaccard-ranked results.
- Enable refinement in the Python example, document the raw-data prerequisite, and describe `refine_k` as candidate-pool capacity.

Production fix: https://github.com/milvus-io/milvus-docs/pull/3605

## Validation

- [x] `git diff --check`
- [x] Confirmed the final page matches the `v3.0.x` task result
- [x] Parsed all 6 Python code blocks
- [x] Checked front matter, code fences, and linked page IDs
- [x] Reverified Knowhere v3.0.6 source behavior
- [x] Reverified archived Milvus 3.0.0 runtime-evidence checksums
- [x] Full repository link checker: `node check-link.js`

## Not run

- Fresh Milvus runtime rerun. The change reuses the existing validated Milvus 3.0.0 runtime archive; no new deployment was requested.