### PR TITLE
docs: fix function chain heading hierarchy

### DIFF
--- a/site/en/release_notes.md
+++ b/site/en/release_notes.md
@@ -58,7 +58,7 @@ For more information, refer to [StructArray](array-of-structs.md) and [StructArr
 
 Query Aggregation from the beta computes exact statistics over filtered data; 3.0.0 adds faceting on the search path. Specify a facet field at search time and Milvus returns the top facet values, each represented by its best-matching member in ANN ranking and annotated with aggregates such as COUNT and AVG — the faceted-search sidebar (brand, price range, attributes) in one request, instead of over-fetching and counting client-side.
 
-### Function Chain reranking
+#### Function Chain reranking
 
 Reranking is now composable through the Function Chain API, which executes an ordered, typed pipeline as part of a single search request. A chain can combine early L0 rescoring on QueryNode with L2 post-reduction reranking on Proxy, supporting score transformation and combination, model-based reranking, sorting, and candidate trimming without client-side orchestration. This release also adds native XGBoost scoring for L0 reranking using UBJ models registered as FileResources, along with Hugging Face Inference Providers for server-managed text embedding and sentence-similarity reranking.
 


### PR DESCRIPTION
## Summary

- change `Function Chain reranking` from an H3 to an H4
- keep it parallel with the other feature headings under `What's new in 3.0.0`

## Validation

- `git diff --check`
- targeted heading hierarchy audit