### PR TITLE
docs: add multi-SDK search aggregation examples

### DIFF
--- a/site/en/userGuide/search-query-get/search-aggregation.md
+++ b/site/en/userGuide/search-query-get/search-aggregation.md
@@ -80,6 +80,7 @@ The examples below use a product collection with brand, category, color, price, 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -288,6 +289,51 @@ private static JsonObject product(long id, float[] embedding, String name, Strin
 }
 ```
 
+```javascript
+const { DataType, MilvusClient } = require('@zilliz/milvus2-sdk-node');
+
+const client = new MilvusClient({
+  address: 'http://localhost:19530', username: 'root', password: 'Milvus',
+});
+const collectionName = 'product_search_aggregation';
+
+if ((await client.hasCollection({ collection_name: collectionName })).value) {
+  await client.dropCollection({ collection_name: collectionName });
+}
+await client.createCollection({
+  collection_name: collectionName,
+  consistency_level: 'Session',
+  fields: [
+    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: false },
+    { name: 'embedding', data_type: DataType.FloatVector, dim: 5 },
+    { name: 'name', data_type: DataType.VarChar, max_length: 200 },
+    { name: 'brand', data_type: DataType.VarChar, max_length: 100 },
+    { name: 'category', data_type: DataType.VarChar, max_length: 100 },
+    { name: 'color', data_type: DataType.VarChar, max_length: 50 },
+    { name: 'price', data_type: DataType.Double },
+    { name: 'rating', data_type: DataType.Double },
+    { name: 'in_stock', data_type: DataType.Bool },
+  ],
+});
+
+const data = [
+  { id: 1, embedding: [0.12, 0.42, 0.18, 0.66, 0.31], name: 'Runner A1', brand: 'Brand A', category: 'running_shoes', color: 'black', price: 129.99, rating: 4.7, in_stock: true },
+  { id: 2, embedding: [0.10, 0.39, 0.20, 0.61, 0.29], name: 'Trail A2', brand: 'Brand A', category: 'running_shoes', color: 'blue', price: 139.99, rating: 4.6, in_stock: true },
+  { id: 3, embedding: [0.14, 0.44, 0.19, 0.68, 0.33], name: 'Runner B1', brand: 'Brand B', category: 'running_shoes', color: 'white', price: 159.99, rating: 4.8, in_stock: true },
+  { id: 4, embedding: [0.16, 0.41, 0.22, 0.62, 0.30], name: 'Runner C1', brand: 'Brand C', category: 'running_shoes', color: 'red', price: 119.99, rating: 4.4, in_stock: false },
+  { id: 5, embedding: [0.48, 0.20, 0.59, 0.15, 0.71], name: 'Jacket A1', brand: 'Brand A', category: 'jackets', color: 'black', price: 99.99, rating: 4.5, in_stock: true },
+  { id: 6, embedding: [0.45, 0.18, 0.55, 0.17, 0.69], name: 'Jacket B1', brand: 'Brand B', category: 'jackets', color: 'blue', price: 89.99, rating: 4.3, in_stock: true },
+  { id: 7, embedding: [0.09, 0.38, 0.17, 0.60, 0.27], name: 'Runner A3', brand: 'Brand A', category: 'running_shoes', color: 'black', price: 159.99, rating: 4.8, in_stock: true },
+  { id: 8, embedding: [0.13, 0.43, 0.21, 0.65, 0.32], name: 'Runner A4', brand: 'Brand A', category: 'running_shoes', color: 'black', price: 149.99, rating: 4.9, in_stock: true },
+];
+await client.insert({ collection_name: collectionName, data });
+await client.createIndex({ collection_name: collectionName, field_name: 'embedding', index_type: 'AUTOINDEX', metric_type: 'COSINE' });
+await client.loadCollectionSync({ collection_name: collectionName });
+
+const queryVector = [0.11, 0.40, 0.19, 0.64, 0.30];
+const searchParams = { metric_type: 'COSINE', params: {} };
+```
+
 </details>
 
 The setup above configures `COSINE` for both the vector index and the search parameters. Therefore, later examples use `{"_score": "desc"}` to place higher cosine similarity first. For a distance metric such as `L2`, use `{"_score": "asc"}`.
@@ -303,6 +349,7 @@ The following configuration creates up to three brand buckets, calculates metric
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -349,11 +396,28 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .build();
 ```
 
+```javascript
+const aggregation = {
+  fields: ['brand'],
+  size: 3,
+  metrics: {
+    product_count: { op: 'count', field_name: '*' },
+    avg_price: { op: 'avg', field_name: 'price' },
+    min_price: { op: 'min', field_name: 'price' },
+  },
+  order: [
+    { key: 'avg_price', direction: 'desc' },
+    { key: '_key', direction: 'asc' },
+  ],
+};
+```
+
 Pass the object to the `search_aggregation` parameter of `MilvusClient.search()`:
 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -388,6 +452,20 @@ SearchResp result = client.search(SearchReq.builder()
         .build());
 
 List<AggregationBucket> buckets = result.getAggregationBuckets().get(0);
+```
+
+```javascript
+const result = await client.search({
+  collection_name: collectionName,
+  data: queryVector,
+  anns_field: 'embedding',
+  limit: 10,
+  ...searchParams,
+  output_fields: ['name', 'brand', 'category', 'color', 'price', 'rating', 'in_stock'],
+  search_aggregation: aggregation,
+});
+
+const buckets = result.agg_buckets;
 ```
 
 When `search_aggregation` is set, PyMilvus returns no ordinary entity hits in `result[0]`. Read the bucket response from `result.agg_buckets[0]` instead. The `output_fields` parameter controls which scalar fields appear in each returned `AggregationHit.fields` mapping; Milvus can still use metric-source and sort fields that are not listed in `output_fields`.
@@ -500,6 +578,7 @@ To sort buckets by vector match quality, first calculate a bucket-level metric f
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -520,6 +599,15 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .build();
 ```
 
+```javascript
+const aggregation = {
+  fields: ['brand'],
+  size: 3,
+  metrics: { max_score: { op: 'max', field_name: '_score' } },
+  order: [{ key: 'max_score', direction: 'desc' }],
+};
+```
+
 With `L2`, calculate the minimum `_score` value and sort the metric alias in ascending order so that buckets with the lowest distance come first.
 
 </details>
@@ -533,6 +621,7 @@ To create a composite bucket key, pass multiple field names in the same list:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -550,6 +639,13 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .fields(Arrays.asList("brand", "color"))
         .size(6)
         .build();
+```
+
+```javascript
+const aggregation = {
+  fields: ['brand', 'color'],
+  size: 6,
+};
 ```
 
 This configuration can produce keys such as `(Brand A, black)`, `(Brand A, blue)`, and `(Brand B, white)`. Two entities share a bucket only when both values match. Milvus preserves the list order, so `brand` is the first key component and `color` is the second. When `_key` is used in `order`, Milvus compares composite key components in the same order. Pass multiple strings in one flat list; nested lists are not supported.
@@ -571,6 +667,7 @@ Configure `TopHits` as follows:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -598,6 +695,20 @@ SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.s
                 .addSort(SortSpec.builder().fieldName("rating").direction(AggDirection.DESC).build())
                 .addSort(SortSpec.builder().fieldName("_score").direction(AggDirection.DESC).build()).build())
         .build();
+```
+
+```javascript
+const aggregation = {
+  fields: ['brand'],
+  size: 3,
+  top_hits: {
+    size: 2,
+    sort: [
+      { field_name: 'rating', direction: 'desc' },
+      { field_name: '_score', direction: 'desc' },
+    ],
+  },
+};
 ```
 
 <details>
@@ -690,6 +801,7 @@ The following configuration implements this hierarchy:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -731,6 +843,31 @@ SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.s
                 .addOrder(OrderSpec.builder().key("avg_rating").direction(AggDirection.DESC).build())
                 .topHits(TopHitsSpec.builder().size(2).addSort(SortSpec.builder().fieldName("rating").direction(AggDirection.DESC).build()).build()).build())
         .build();
+```
+
+```javascript
+const aggregation = {
+  fields: ['category'],
+  size: 2,
+  metrics: {
+    product_count: { op: 'count', field_name: '*' },
+    avg_price: { op: 'avg', field_name: 'price' },
+  },
+  order: [{ key: 'product_count', direction: 'desc' }],
+  sub_aggregation: {
+    fields: ['brand'],
+    size: 3,
+    metrics: {
+      brand_count: { op: 'count', field_name: '*' },
+      avg_rating: { op: 'avg', field_name: 'rating' },
+    },
+    order: [{ key: 'avg_rating', direction: 'desc' }],
+    top_hits: {
+      size: 2,
+      sort: [{ field_name: 'rating', direction: 'desc' }],
+    },
+  },
+};
 ```
 
 <details>

--- a/site/en/userGuide/search-query-get/search-aggregation.md
+++ b/site/en/userGuide/search-query-get/search-aggregation.md
@@ -80,7 +80,9 @@ The examples below use a product collection with brand, category, color, price, 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -289,6 +291,10 @@ private static JsonObject product(long id, float[] embedding, String name, Strin
 }
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const { DataType, MilvusClient } = require('@zilliz/milvus2-sdk-node');
 
@@ -334,6 +340,25 @@ const queryVector = [0.11, 0.40, 0.19, 0.64, 0.30];
 const searchParams = { metric_type: 'COSINE', params: {} };
 ```
 
+```bash
+export CLUSTER_ENDPOINT="http://localhost:19530"
+export TOKEN="root:Milvus"
+export COLLECTION_NAME="product_search_aggregation"
+search() {
+  curl --request POST \
+    --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
+    --header "Authorization: Bearer ${TOKEN}" \
+    --header "Content-Type: application/json" \
+    --data "$1"
+}
+schema='{"autoID":false,"enableDynamicField":false,"fields":[{"fieldName":"id","dataType":"Int64","isPrimary":true},{"fieldName":"embedding","dataType":"FloatVector","elementTypeParams":{"dim":5}},{"fieldName":"name","dataType":"VarChar","elementTypeParams":{"max_length":200}},{"fieldName":"brand","dataType":"VarChar","elementTypeParams":{"max_length":100}},{"fieldName":"category","dataType":"VarChar","elementTypeParams":{"max_length":100}},{"fieldName":"color","dataType":"VarChar","elementTypeParams":{"max_length":50}},{"fieldName":"price","dataType":"Double"},{"fieldName":"rating","dataType":"Double"},{"fieldName":"in_stock","dataType":"Bool"}]}'
+indexParams='[{"fieldName":"embedding","indexType":"AUTOINDEX","metricType":"COSINE"}]'
+data='[{"id":1,"embedding":[0.12,0.42,0.18,0.66,0.31],"name":"Runner A1","brand":"Brand A","category":"running_shoes","color":"black","price":129.99,"rating":4.7,"in_stock":true},{"id":2,"embedding":[0.10,0.39,0.20,0.61,0.29],"name":"Trail A2","brand":"Brand A","category":"running_shoes","color":"blue","price":139.99,"rating":4.6,"in_stock":true},{"id":3,"embedding":[0.14,0.44,0.19,0.68,0.33],"name":"Runner B1","brand":"Brand B","category":"running_shoes","color":"white","price":159.99,"rating":4.8,"in_stock":true},{"id":4,"embedding":[0.16,0.41,0.22,0.62,0.30],"name":"Runner C1","brand":"Brand C","category":"running_shoes","color":"red","price":119.99,"rating":4.4,"in_stock":false},{"id":5,"embedding":[0.48,0.20,0.59,0.15,0.71],"name":"Jacket A1","brand":"Brand A","category":"jackets","color":"black","price":99.99,"rating":4.5,"in_stock":true},{"id":6,"embedding":[0.45,0.18,0.55,0.17,0.69],"name":"Jacket B1","brand":"Brand B","category":"jackets","color":"blue","price":89.99,"rating":4.3,"in_stock":true},{"id":7,"embedding":[0.09,0.38,0.17,0.60,0.27],"name":"Runner A3","brand":"Brand A","category":"running_shoes","color":"black","price":159.99,"rating":4.8,"in_stock":true},{"id":8,"embedding":[0.13,0.43,0.21,0.65,0.32],"name":"Runner A4","brand":"Brand A","category":"running_shoes","color":"black","price":149.99,"rating":4.9,"in_stock":true}]'
+curl --request POST --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/create" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --data "{\"collectionName\":\"${COLLECTION_NAME}\",\"schema\":${schema},\"indexParams\":${indexParams}}"
+curl --request POST --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/insert" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --data "{\"collectionName\":\"${COLLECTION_NAME}\",\"data\":${data}}"
+curl --request POST --url "${CLUSTER_ENDPOINT}/v2/vectordb/collections/load" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --data "{\"collectionName\":\"${COLLECTION_NAME}\"}"
+```
+
 </details>
 
 The setup above configures `COSINE` for both the vector index and the search parameters. Therefore, later examples use `{"_score": "desc"}` to place higher cosine similarity first. For a distance metric such as `L2`, use `{"_score": "asc"}`.
@@ -349,7 +374,9 @@ The following configuration creates up to three brand buckets, calculates metric
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -396,6 +423,10 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .build();
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const aggregation = {
   fields: ['brand'],
@@ -412,12 +443,29 @@ const aggregation = {
 };
 ```
 
+```bash
+payload='{
+  "collectionName": "product_search_aggregation",
+  "data": [[0.11, 0.40, 0.19, 0.64, 0.30]],
+  "annsField": "embedding", "limit": 10,
+  "searchParams": {"metric_type": "COSINE", "params": {}},
+  "searchAggregation": {
+    "fields": ["brand"], "size": 3,
+    "metrics": {"product_count": {"op": "count", "fieldName": "*"}, "avg_price": {"op": "avg", "fieldName": "price"}, "min_price": {"op": "min", "fieldName": "price"}},
+    "order": [{"key": "avg_price", "direction": "desc"}, {"key": "_key", "direction": "asc"}]
+  }
+}'
+search "$payload"
+```
+
 Pass the object to the `search_aggregation` parameter of `MilvusClient.search()`:
 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -454,6 +502,10 @@ SearchResp result = client.search(SearchReq.builder()
 List<AggregationBucket> buckets = result.getAggregationBuckets().get(0);
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const result = await client.search({
   collection_name: collectionName,
@@ -466,6 +518,26 @@ const result = await client.search({
 });
 
 const buckets = result.agg_buckets;
+```
+
+```bash
+curl --request POST \
+  --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
+  --header "Authorization: Bearer ${TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "collectionName": "product_search_aggregation",
+    "data": [[0.11, 0.40, 0.19, 0.64, 0.30]],
+    "annsField": "embedding",
+    "limit": 10,
+    "outputFields": ["name", "brand", "category", "color", "price", "rating", "in_stock"],
+    "searchParams": {"metric_type": "COSINE", "params": {}},
+    "searchAggregation": {
+      "fields": ["brand"], "size": 3,
+      "metrics": {"product_count": {"op": "count", "fieldName": "*"}, "avg_price": {"op": "avg", "fieldName": "price"}, "min_price": {"op": "min", "fieldName": "price"}},
+      "order": [{"key": "avg_price", "direction": "desc"}, {"key": "_key", "direction": "asc"}]
+    }
+  }'
 ```
 
 When `search_aggregation` is set, PyMilvus returns no ordinary entity hits in `result[0]`. Read the bucket response from `result.agg_buckets[0]` instead. The `output_fields` parameter controls which scalar fields appear in each returned `AggregationHit.fields` mapping; Milvus can still use metric-source and sort fields that are not listed in `output_fields`.
@@ -578,7 +650,9 @@ To sort buckets by vector match quality, first calculate a bucket-level metric f
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -599,6 +673,10 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .build();
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const aggregation = {
   fields: ['brand'],
@@ -606,6 +684,16 @@ const aggregation = {
   metrics: { max_score: { op: 'max', field_name: '_score' } },
   order: [{ key: 'max_score', direction: 'desc' }],
 };
+```
+
+```bash
+payload='{
+  "collectionName": "product_search_aggregation",
+  "data": [[0.11, 0.40, 0.19, 0.64, 0.30]], "annsField": "embedding", "limit": 10,
+  "searchParams": {"metric_type": "COSINE", "params": {}},
+  "searchAggregation": {"fields": ["brand"], "size": 3, "metrics": {"max_score": {"op": "max", "fieldName": "_score"}}, "order": [{"key": "max_score", "direction": "desc"}]}
+}'
+search "$payload"
 ```
 
 With `L2`, calculate the minimum `_score` value and sort the metric alias in ascending order so that buckets with the lowest distance come first.
@@ -621,7 +709,9 @@ To create a composite bucket key, pass multiple field names in the same list:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -641,11 +731,25 @@ SearchAggregation aggregation = SearchAggregation.builder()
         .build();
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const aggregation = {
   fields: ['brand', 'color'],
   size: 6,
 };
+```
+
+```bash
+payload='{
+  "collectionName": "product_search_aggregation",
+  "data": [[0.11, 0.40, 0.19, 0.64, 0.30]], "annsField": "embedding", "limit": 10,
+  "searchParams": {"metric_type": "COSINE", "params": {}},
+  "searchAggregation": {"fields": ["brand", "color"], "size": 6}
+}'
+search "$payload"
 ```
 
 This configuration can produce keys such as `(Brand A, black)`, `(Brand A, blue)`, and `(Brand B, white)`. Two entities share a bucket only when both values match. Milvus preserves the list order, so `brand` is the first key component and `color` is the second. When `_key` is used in `order`, Milvus compares composite key components in the same order. Pass multiple strings in one flat list; nested lists are not supported.
@@ -667,7 +771,9 @@ Configure `TopHits` as follows:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -697,6 +803,10 @@ SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.s
         .build();
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const aggregation = {
   fields: ['brand'],
@@ -709,6 +819,16 @@ const aggregation = {
     ],
   },
 };
+```
+
+```bash
+payload='{
+  "collectionName": "product_search_aggregation",
+  "data": [[0.11, 0.40, 0.19, 0.64, 0.30]], "annsField": "embedding", "limit": 10,
+  "searchParams": {"metric_type": "COSINE", "params": {}},
+  "searchAggregation": {"fields": ["brand"], "size": 3, "topHits": {"size": 2, "sort": [{"fieldName": "rating", "direction": "desc"}, {"fieldName": "_score", "direction": "desc"}]}}
+}'
+search "$payload"
 ```
 
 <details>
@@ -801,7 +921,9 @@ The following configuration implements this hierarchy:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -845,6 +967,10 @@ SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.s
         .build();
 ```
 
+```go
+// TBD: Search Aggregation is not yet available in the released Go SDK.
+```
+
 ```javascript
 const aggregation = {
   fields: ['category'],
@@ -868,6 +994,21 @@ const aggregation = {
     },
   },
 };
+```
+
+```bash
+payload='{
+  "collectionName": "product_search_aggregation",
+  "data": [[0.11, 0.40, 0.19, 0.64, 0.30]], "annsField": "embedding", "limit": 10,
+  "searchParams": {"metric_type": "COSINE", "params": {}},
+  "searchAggregation": {
+    "fields": ["category"], "size": 2,
+    "metrics": {"product_count": {"op": "count", "fieldName": "*"}, "avg_price": {"op": "avg", "fieldName": "price"}},
+    "order": [{"key": "product_count", "direction": "desc"}],
+    "subAggregation": {"fields": ["brand"], "size": 3, "metrics": {"brand_count": {"op": "count", "fieldName": "*"}, "avg_rating": {"op": "avg", "fieldName": "rating"}}, "order": [{"key": "avg_rating", "direction": "desc"}], "topHits": {"size": 2, "sort": [{"fieldName": "rating", "direction": "desc"}]}}
+  }
+}'
+search "$payload"
 ```
 
 <details>

--- a/site/en/userGuide/search-query-get/search-aggregation.md
+++ b/site/en/userGuide/search-query-get/search-aggregation.md
@@ -77,6 +77,11 @@ The examples below use a product collection with brand, category, color, price, 
 
 <summary>Set up the example collection</summary>
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 from pymilvus import DataType, MilvusClient, SearchAggregation, TopHits
 
@@ -219,6 +224,70 @@ search_params = {
 }
 ```
 
+```java
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+MilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
+        .uri("http://localhost:19530").token("root:Milvus").build());
+String collectionName = "product_search_aggregation";
+
+CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(true).autoID(false).build());
+schema.addField(AddFieldReq.builder().fieldName("embedding").dataType(DataType.FloatVector).dimension(5).build());
+schema.addField(AddFieldReq.builder().fieldName("name").dataType(DataType.VarChar).maxLength(200).build());
+schema.addField(AddFieldReq.builder().fieldName("brand").dataType(DataType.VarChar).maxLength(100).build());
+schema.addField(AddFieldReq.builder().fieldName("category").dataType(DataType.VarChar).maxLength(100).build());
+schema.addField(AddFieldReq.builder().fieldName("color").dataType(DataType.VarChar).maxLength(50).build());
+schema.addField(AddFieldReq.builder().fieldName("price").dataType(DataType.Double).build());
+schema.addField(AddFieldReq.builder().fieldName("rating").dataType(DataType.Double).build());
+schema.addField(AddFieldReq.builder().fieldName("in_stock").dataType(DataType.Bool).build());
+
+client.createCollection(CreateCollectionReq.builder().collectionName(collectionName).collectionSchema(schema)
+        .indexParams(Collections.singletonList(IndexParam.builder().fieldName("embedding")
+                .indexType(IndexParam.IndexType.AUTOINDEX).metricType(IndexParam.MetricType.COSINE).build()))
+        .build());
+
+List<JsonObject> data = Arrays.asList(
+        product(1, new float[]{0.12f, 0.42f, 0.18f, 0.66f, 0.31f}, "Runner A1", "Brand A", "running_shoes", "black", 129.99, 4.7, true),
+        product(2, new float[]{0.10f, 0.39f, 0.20f, 0.61f, 0.29f}, "Trail A2", "Brand A", "running_shoes", "blue", 139.99, 4.6, true),
+        product(3, new float[]{0.14f, 0.44f, 0.19f, 0.68f, 0.33f}, "Runner B1", "Brand B", "running_shoes", "white", 159.99, 4.8, true),
+        product(4, new float[]{0.16f, 0.41f, 0.22f, 0.62f, 0.30f}, "Runner C1", "Brand C", "running_shoes", "red", 119.99, 4.4, false),
+        product(5, new float[]{0.48f, 0.20f, 0.59f, 0.15f, 0.71f}, "Jacket A1", "Brand A", "jackets", "black", 99.99, 4.5, true),
+        product(6, new float[]{0.45f, 0.18f, 0.55f, 0.17f, 0.69f}, "Jacket B1", "Brand B", "jackets", "blue", 89.99, 4.3, true),
+        product(7, new float[]{0.09f, 0.38f, 0.17f, 0.60f, 0.27f}, "Runner A3", "Brand A", "running_shoes", "black", 159.99, 4.8, true),
+        product(8, new float[]{0.13f, 0.43f, 0.21f, 0.65f, 0.32f}, "Runner A4", "Brand A", "running_shoes", "black", 149.99, 4.9, true));
+client.insert(InsertReq.builder().collectionName(collectionName).data(data).build());
+
+List<Float> queryVector = Arrays.asList(0.11f, 0.40f, 0.19f, 0.64f, 0.30f);
+
+private static JsonObject product(long id, float[] embedding, String name, String brand,
+                                  String category, String color, double price, double rating,
+                                  boolean inStock) {
+    JsonObject row = new JsonObject();
+    row.addProperty("id", id);
+    row.add("embedding", new Gson().toJsonTree(embedding));
+    row.addProperty("name", name);
+    row.addProperty("brand", brand);
+    row.addProperty("category", category);
+    row.addProperty("color", color);
+    row.addProperty("price", price);
+    row.addProperty("rating", rating);
+    row.addProperty("in_stock", inStock);
+    return row;
+}
+```
+
 </details>
 
 The setup above configures `COSINE` for both the vector index and the search parameters. Therefore, later examples use `{"_score": "desc"}` to place higher cosine similarity first. For a distance metric such as `L2`, use `{"_score": "asc"}`.
@@ -230,6 +299,11 @@ Use this pattern when you need to compare groups of retrieved entities using cal
 If your goal is only to improve result diversity by returning one or more entities per field value, use [Grouping Search](grouping-search.md) instead.
 
 The following configuration creates up to three brand buckets, calculates metrics for each bucket, and sorts the buckets by average price:
+
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
 
 ```python
 aggregation = SearchAggregation(
@@ -254,7 +328,33 @@ aggregation = SearchAggregation(
 )
 ```
 
+```java
+import io.milvus.v2.service.vector.request.aggregation.AggDirection;
+import io.milvus.v2.service.vector.request.aggregation.MetricOps;
+import io.milvus.v2.service.vector.request.aggregation.MetricSpec;
+import io.milvus.v2.service.vector.request.aggregation.OrderSpec;
+import io.milvus.v2.service.vector.request.aggregation.SearchAggregation;
+import io.milvus.v2.service.vector.request.aggregation.SortSpec;
+import io.milvus.v2.service.vector.request.aggregation.TopHitsSpec;
+import java.util.Collections;
+
+SearchAggregation aggregation = SearchAggregation.builder()
+        .fields(Collections.singletonList("brand"))
+        .size(3)
+        .addMetric("product_count", MetricSpec.builder().op(MetricOps.COUNT).fieldName("*").build())
+        .addMetric("avg_price", MetricSpec.builder().op(MetricOps.AVG).fieldName("price").build())
+        .addMetric("min_price", MetricSpec.builder().op(MetricOps.MIN).fieldName("price").build())
+        .addOrder(OrderSpec.builder().key("avg_price").direction(AggDirection.DESC).build())
+        .addOrder(OrderSpec.builder().key("_key").direction(AggDirection.ASC).build())
+        .build();
+```
+
 Pass the object to the `search_aggregation` parameter of `MilvusClient.search()`:
+
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
 
 ```python
 result = client.search(
@@ -274,6 +374,20 @@ result = client.search(
     # highlight-next-line
     search_aggregation=aggregation,
 )
+```
+
+```java
+SearchResp result = client.search(SearchReq.builder()
+        .collectionName(collectionName)
+        .data(Collections.singletonList(new FloatVec(queryVector)))
+        .annsField("embedding")
+        .limit(10)
+        .searchParams(Collections.singletonMap("metric_type", "COSINE"))
+        .outputFields(Arrays.asList("name", "brand", "category", "color", "price", "rating", "in_stock"))
+        .searchAggregation(aggregation)
+        .build());
+
+List<AggregationBucket> buckets = result.getAggregationBuckets().get(0);
 ```
 
 When `search_aggregation` is set, PyMilvus returns no ordinary entity hits in `result[0]`. Read the bucket response from `result.agg_buckets[0]` instead. The `output_fields` parameter controls which scalar fields appear in each returned `AggregationHit.fields` mapping; Milvus can still use metric-source and sort fields that are not listed in `output_fields`.
@@ -383,6 +497,11 @@ Each `order` entry maps a key to `"asc"` or `"desc"`. Milvus evaluates multiple 
 
 To sort buckets by vector match quality, first calculate a bucket-level metric from `_score`, and then use the metric alias in `order`. You cannot use `_score` directly as a bucket-order key because each bucket can contain multiple entity scores. For example, with `COSINE` or `IP`:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 aggregation = SearchAggregation(
     fields=["brand"],
@@ -390,6 +509,15 @@ aggregation = SearchAggregation(
     metrics={"max_score": {"max": "_score"}},
     order=[{"max_score": "desc"}],
 )
+```
+
+```java
+SearchAggregation aggregation = SearchAggregation.builder()
+        .fields(Collections.singletonList("brand"))
+        .size(3)
+        .addMetric("max_score", MetricSpec.builder().op(MetricOps.MAX).fieldName("_score").build())
+        .addOrder(OrderSpec.builder().key("max_score").direction(AggDirection.DESC).build())
+        .build();
 ```
 
 With `L2`, calculate the minimum `_score` value and sort the metric alias in ascending order so that buckets with the lowest distance come first.
@@ -402,6 +530,11 @@ With `L2`, calculate the minimum `_score` value and sort the metric alias in asc
 
 To create a composite bucket key, pass multiple field names in the same list:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 aggregation = SearchAggregation(
     # highlight-start
@@ -410,6 +543,13 @@ aggregation = SearchAggregation(
     # highlight-end
     size=6,
 )
+```
+
+```java
+SearchAggregation aggregation = SearchAggregation.builder()
+        .fields(Arrays.asList("brand", "color"))
+        .size(6)
+        .build();
 ```
 
 This configuration can produce keys such as `(Brand A, black)`, `(Brand A, blue)`, and `(Brand B, white)`. Two entities share a bucket only when both values match. Milvus preserves the list order, so `brand` is the first key component and `color` is the second. When `_key` is used in `order`, Milvus compares composite key components in the same order. Pass multiple strings in one flat list; nested lists are not supported.
@@ -428,6 +568,11 @@ Include representative entities when the application needs to show actual produc
 
 Configure `TopHits` as follows:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 aggregation = SearchAggregation(
     fields=["brand"],
@@ -445,6 +590,14 @@ aggregation = SearchAggregation(
     ),
     # highlight-end
 )
+```
+
+```java
+SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.singletonList("brand")).size(3)
+        .topHits(TopHitsSpec.builder().size(2)
+                .addSort(SortSpec.builder().fieldName("rating").direction(AggDirection.DESC).build())
+                .addSort(SortSpec.builder().fieldName("_score").direction(AggDirection.DESC).build()).build())
+        .build();
 ```
 
 <details>
@@ -534,6 +687,11 @@ Each level can independently use multiple fields. For example, using `fields=["b
 
 The following configuration implements this hierarchy:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 aggregation = SearchAggregation(
     fields=["category"],
@@ -560,6 +718,19 @@ aggregation = SearchAggregation(
     ),
     # highlight-end
 )
+```
+
+```java
+SearchAggregation aggregation = SearchAggregation.builder().fields(Collections.singletonList("category")).size(2)
+        .addMetric("product_count", MetricSpec.builder().op(MetricOps.COUNT).fieldName("*").build())
+        .addMetric("avg_price", MetricSpec.builder().op(MetricOps.AVG).fieldName("price").build())
+        .addOrder(OrderSpec.builder().key("product_count").direction(AggDirection.DESC).build())
+        .subAggregation(SearchAggregation.builder().fields(Collections.singletonList("brand")).size(3)
+                .addMetric("brand_count", MetricSpec.builder().op(MetricOps.COUNT).fieldName("*").build())
+                .addMetric("avg_rating", MetricSpec.builder().op(MetricOps.AVG).fieldName("rating").build())
+                .addOrder(OrderSpec.builder().key("avg_rating").direction(AggDirection.DESC).build())
+                .topHits(TopHitsSpec.builder().size(2).addSort(SortSpec.builder().fieldName("rating").direction(AggDirection.DESC).build()).build()).build())
+        .build();
 ```
 
 <details>


### PR DESCRIPTION
## Summary
- add validated Java, Node.js, and cURL Search Aggregation examples
- add Go tabs with an explicit TBD marker because released Go SDK support is not available
- retain the existing Python examples

## Validation
- Preview PR #3623 was reviewed and accepted in the preview environment
- Java, Node.js, and REST candidates were validated against Milvus 3.0.0 using milvus-cell
- `git diff --check` passed

## Scope
Production backport for v3.0.x. Feishu synchronization is intentionally excluded and will be handled separately after local source acceptance.