### PR TITLE
docs: add multi-SDK pattern matching examples

### DIFF
--- a/site/en/userGuide/search-query-get/boolean/pattern-matching.md
+++ b/site/en/userGuide/search-query-get/boolean/pattern-matching.md
@@ -21,7 +21,9 @@ Pattern matching expressions are written in the `filter` parameter. For example,
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -56,6 +58,33 @@ QueryResp res = client.query(QueryReq.builder()
         .build());
 ```
 
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/milvus-io/milvus/client/v2/milvusclient"
+)
+
+ctx := context.Background()
+client, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
+    Address: "localhost:19530",
+})
+if err != nil {
+    // handle error
+}
+defer client.Close(ctx)
+
+res, err := client.Query(ctx, milvusclient.NewQueryOption("log_events").
+    // highlight-next-line
+    WithFilter(`message =~ "E[0-9]{4}"`).
+    WithOutputFields("message", "severity"))
+if err != nil {
+    // handle error
+}
+fmt.Println(res)
+```
+
 ```javascript
 const { MilvusClient } = require('@zilliz/milvus2-sdk-node');
 
@@ -67,6 +96,21 @@ const res = await client.query({
   filter: 'message =~ "E[0-9]{4}"',
   output_fields: ['message', 'severity'],
 });
+```
+
+```bash
+export CLUSTER_ENDPOINT="http://localhost:19530"
+export TOKEN="root:Milvus"
+
+curl --request POST \
+  --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/query" \
+  --header "Authorization: Bearer ${TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "collectionName": "log_events",
+    "filter": "message =~ \"E[0-9]{4}\"",
+    "outputFields": ["message", "severity"]
+  }'
 ```
 
 The examples on this page focus on the expression assigned to `filter`. You can use the same filter expression syntax in Milvus operations that accept a scalar filter, such as `query`, `search`, and hybrid search.
@@ -156,7 +200,9 @@ For example:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -167,8 +213,16 @@ filter = r'filename =~ r"\.json$"'
 String filter = "filename =~ r\"\\.json$\"";
 ```
 
+```go
+filter := `filename =~ r"\.json$"`
+```
+
 ```javascript
 const filter = 'filename =~ r"\\.json$"';
+```
+
+```bash
+filter='filename =~ r"\.json$"'
 ```
 
 This matches strings that end with `.json`, such as `report.json`.
@@ -195,7 +249,9 @@ To match one of several words, use alternation with `|`:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -206,16 +262,26 @@ filter = 'message =~ "error|failed|timeout"'
 String filter = "message =~ \"error|failed|timeout\"";
 ```
 
+```go
+filter := `message =~ "error|failed|timeout"`
+```
+
 ```javascript
 const filter = 'message =~ "error|failed|timeout"';
 ```
 
-When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python, Java, or Node.js source string:
+```bash
+filter='message =~ "error|failed|timeout"'
+```
+
+When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python, Java, Go, or Node.js source string:
 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -226,8 +292,16 @@ filter = 'email =~ "@gmail\\.com$"'
 String filter = "email =~ \"@gmail\\.com$\"";
 ```
 
+```go
+filter := `email =~ "@gmail\\.com$"`
+```
+
 ```javascript
 const filter = 'email =~ "@gmail\\.com$"';
+```
+
+```bash
+filter='email =~ "@gmail\\.com$"'
 ```
 
 Note: Milvus regex filters follow RE2 syntax. If a regex pattern uses syntax that RE2 does not support or is otherwise invalid, Milvus rejects the filter expression. For details about regex metacharacters, flags, and matching behavior, refer to the [RE2 syntax](https://github.com/google/re2/wiki/syntax) reference.
@@ -241,7 +315,9 @@ Milvus regex matching uses substring semantics. The pattern does not need to mat
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -252,8 +328,16 @@ filter = 'message =~ "E[0-9]{4}"'
 String filter = "message =~ \"E[0-9]{4}\"";
 ```
 
+```go
+filter := `message =~ "E[0-9]{4}"`
+```
+
 ```javascript
 const filter = 'message =~ "E[0-9]{4}"';
+```
+
+```bash
+filter='message =~ "E[0-9]{4}"'
 ```
 
 To match the entire field value, use the `^` and `$` anchors:
@@ -261,7 +345,9 @@ To match the entire field value, use the `^` and `$` anchors:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -274,9 +360,19 @@ filter = 'code =~ "^E[0-9]{4}$"'
 String filter = "code =~ \"^E[0-9]{4}$\"";
 ```
 
+```go
+// Match only values that are exactly E followed by four digits
+filter := `code =~ "^E[0-9]{4}$"`
+```
+
 ```javascript
 // Match only values that are exactly E followed by four digits
 const filter = 'code =~ "^E[0-9]{4}$"';
+```
+
+```bash
+# Match only values that are exactly E followed by four digits
+filter='code =~ "^E[0-9]{4}$"'
 ```
 
 **Nullable VARCHAR fields**
@@ -286,7 +382,9 @@ Regex filters do not match null values. This applies to both `=~` and `!~`. If y
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#go">Go</a>
   <a href="#javascript">Node.js</a>
+  <a href="#bash">cURL</a>
 </div>
 
 ```python
@@ -297,8 +395,16 @@ filter = 'message !~ "^DEBUG" OR message IS NULL'
 String filter = "message !~ \"^DEBUG\" OR message IS NULL";
 ```
 
+```go
+filter := `message !~ "^DEBUG" OR message IS NULL`
+```
+
 ```javascript
 const filter = 'message !~ "^DEBUG" OR message IS NULL';
+```
+
+```bash
+filter='message !~ "^DEBUG" OR message IS NULL'
 ```
 
 **JSON paths**

--- a/site/en/userGuide/search-query-get/boolean/pattern-matching.md
+++ b/site/en/userGuide/search-query-get/boolean/pattern-matching.md
@@ -21,6 +21,7 @@ Pattern matching expressions are written in the `filter` parameter. For example,
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -53,6 +54,19 @@ QueryResp res = client.query(QueryReq.builder()
         .filter("message =~ \"E[0-9]{4}\"")
         .outputFields(Arrays.asList("message", "severity"))
         .build());
+```
+
+```javascript
+const { MilvusClient } = require('@zilliz/milvus2-sdk-node');
+
+const client = new MilvusClient({ address: 'http://localhost:19530' });
+
+const res = await client.query({
+  collection_name: 'log_events',
+  // highlight-next-line
+  filter: 'message =~ "E[0-9]{4}"',
+  output_fields: ['message', 'severity'],
+});
 ```
 
 The examples on this page focus on the expression assigned to `filter`. You can use the same filter expression syntax in Milvus operations that accept a scalar filter, such as `query`, `search`, and hybrid search.
@@ -142,6 +156,7 @@ For example:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -150,6 +165,10 @@ filter = r'filename =~ r"\.json$"'
 
 ```java
 String filter = "filename =~ r\"\\.json$\"";
+```
+
+```javascript
+const filter = 'filename =~ r"\\.json$"';
 ```
 
 This matches strings that end with `.json`, such as `report.json`.
@@ -176,6 +195,7 @@ To match one of several words, use alternation with `|`:
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -186,11 +206,16 @@ filter = 'message =~ "error|failed|timeout"'
 String filter = "message =~ \"error|failed|timeout\"";
 ```
 
-When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python or Java source string:
+```javascript
+const filter = 'message =~ "error|failed|timeout"';
+```
+
+When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python, Java, or Node.js source string:
 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -199,6 +224,10 @@ filter = 'email =~ "@gmail\\.com$"'
 
 ```java
 String filter = "email =~ \"@gmail\\.com$\"";
+```
+
+```javascript
+const filter = 'email =~ "@gmail\\.com$"';
 ```
 
 Note: Milvus regex filters follow RE2 syntax. If a regex pattern uses syntax that RE2 does not support or is otherwise invalid, Milvus rejects the filter expression. For details about regex metacharacters, flags, and matching behavior, refer to the [RE2 syntax](https://github.com/google/re2/wiki/syntax) reference.
@@ -212,6 +241,7 @@ Milvus regex matching uses substring semantics. The pattern does not need to mat
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -222,11 +252,16 @@ filter = 'message =~ "E[0-9]{4}"'
 String filter = "message =~ \"E[0-9]{4}\"";
 ```
 
+```javascript
+const filter = 'message =~ "E[0-9]{4}"';
+```
+
 To match the entire field value, use the `^` and `$` anchors:
 
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -239,6 +274,11 @@ filter = 'code =~ "^E[0-9]{4}$"'
 String filter = "code =~ \"^E[0-9]{4}$\"";
 ```
 
+```javascript
+// Match only values that are exactly E followed by four digits
+const filter = 'code =~ "^E[0-9]{4}$"';
+```
+
 **Nullable VARCHAR fields**
 
 Regex filters do not match null values. This applies to both `=~` and `!~`. If you want to exclude a regex pattern but keep null values, explicitly add `OR field IS NULL`:
@@ -246,6 +286,7 @@ Regex filters do not match null values. This applies to both `=~` and `!~`. If y
 <div class="multipleCode">
   <a href="#python">Python</a>
   <a href="#java">Java</a>
+  <a href="#javascript">Node.js</a>
 </div>
 
 ```python
@@ -254,6 +295,10 @@ filter = 'message !~ "^DEBUG" OR message IS NULL'
 
 ```java
 String filter = "message !~ \"^DEBUG\" OR message IS NULL";
+```
+
+```javascript
+const filter = 'message !~ "^DEBUG" OR message IS NULL';
 ```
 
 **JSON paths**

--- a/site/en/userGuide/search-query-get/boolean/pattern-matching.md
+++ b/site/en/userGuide/search-query-get/boolean/pattern-matching.md
@@ -88,13 +88,21 @@ fmt.Println(res)
 ```javascript
 const { MilvusClient } = require('@zilliz/milvus2-sdk-node');
 
-const client = new MilvusClient({ address: 'http://localhost:19530' });
+async function main() {
+  const client = new MilvusClient({ address: 'http://localhost:19530' });
 
-const res = await client.query({
-  collection_name: 'log_events',
-  // highlight-next-line
-  filter: 'message =~ "E[0-9]{4}"',
-  output_fields: ['message', 'severity'],
+  const res = await client.query({
+    collection_name: 'log_events',
+    // highlight-next-line
+    filter: 'message =~ "E[0-9]{4}"',
+    output_fields: ['message', 'severity'],
+  });
+  console.log(res);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
 });
 ```
 

--- a/site/en/userGuide/search-query-get/boolean/pattern-matching.md
+++ b/site/en/userGuide/search-query-get/boolean/pattern-matching.md
@@ -18,6 +18,11 @@ This page describes pattern matching in scalar filter expressions used by `query
 
 Pattern matching expressions are written in the `filter` parameter. For example, the following query matches log messages that contain an error code such as `E1001`:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 from pymilvus import MilvusClient
 
@@ -29,6 +34,25 @@ res = client.query(
     filter='message =~ "E[0-9]{4}"',
     output_fields=["message", "severity"],
 )
+```
+
+```java
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.response.QueryResp;
+import java.util.Arrays;
+
+MilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
+        .uri("http://localhost:19530")
+        .build());
+
+QueryResp res = client.query(QueryReq.builder()
+        .collectionName("log_events")
+        // highlight-next-line
+        .filter("message =~ \"E[0-9]{4}\"")
+        .outputFields(Arrays.asList("message", "severity"))
+        .build());
 ```
 
 The examples on this page focus on the expression assigned to `filter`. You can use the same filter expression syntax in Milvus operations that accept a scalar filter, such as `query`, `search`, and hybrid search.
@@ -115,13 +139,22 @@ Raw string literals are recommended for regex patterns that contain backslashes.
 
 For example:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
-filter = 'message =~ r"\d{4}-\d{2}-\d{2}"'
+filter = r'filename =~ r"\.json$"'
 ```
 
-This matches strings that contain a date-like value such as `2026-07-01`.
+```java
+String filter = "filename =~ r\"\\.json$\"";
+```
 
-Without a raw string, ordinary string literals process escape sequences before the regex pattern is evaluated, so patterns such as `\d`, `\s`, or escaped literal characters may require additional backslashes.
+This matches strings that end with `.json`, such as `report.json`.
+
+Without a raw string in the Milvus filter expression, ordinary string literals process escape sequences before the regex pattern is evaluated. Escaped literal characters may therefore require additional backslashes in the host-language string.
 
 ### Common regex patterns
 
@@ -140,14 +173,32 @@ The following examples use common RE2 syntax in Milvus filter expressions. For c
 
 To match one of several words, use alternation with `|`:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 filter = 'message =~ "error|failed|timeout"'
 ```
 
-When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python filter string:
+```java
+String filter = "message =~ \"error|failed|timeout\"";
+```
+
+When matching regex metacharacters literally, escape them in the regex pattern. For example, to match a literal dot (`\.` in regex), write `\\.` in a Python or Java source string:
+
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
 
 ```python
 filter = 'email =~ "@gmail\\.com$"'
+```
+
+```java
+String filter = "email =~ \"@gmail\\.com$\"";
 ```
 
 Note: Milvus regex filters follow RE2 syntax. If a regex pattern uses syntax that RE2 does not support or is otherwise invalid, Milvus rejects the filter expression. For details about regex metacharacters, flags, and matching behavior, refer to the [RE2 syntax](https://github.com/google/re2/wiki/syntax) reference.
@@ -158,23 +209,51 @@ Note: Milvus regex filters follow RE2 syntax. If a regex pattern uses syntax tha
 
 Milvus regex matching uses substring semantics. The pattern does not need to match the entire field value. For example, the following filter matches both `E1001` and `failed with E1001 after retry`:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 filter = 'message =~ "E[0-9]{4}"'
 ```
 
+```java
+String filter = "message =~ \"E[0-9]{4}\"";
+```
+
 To match the entire field value, use the `^` and `$` anchors:
+
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
 
 ```python
 # Match only values that are exactly E followed by four digits
 filter = 'code =~ "^E[0-9]{4}$"'
 ```
 
+```java
+// Match only values that are exactly E followed by four digits
+String filter = "code =~ \"^E[0-9]{4}$\"";
+```
+
 **Nullable VARCHAR fields**
 
 Regex filters do not match null values. This applies to both `=~` and `!~`. If you want to exclude a regex pattern but keep null values, explicitly add `OR field IS NULL`:
 
+<div class="multipleCode">
+  <a href="#python">Python</a>
+  <a href="#java">Java</a>
+</div>
+
 ```python
 filter = 'message !~ "^DEBUG" OR message IS NULL'
+```
+
+```java
+String filter = "message !~ \"^DEBUG\" OR message IS NULL";
 ```
 
 **JSON paths**


### PR DESCRIPTION
## What this PR does

- adds Java, Node.js, Go, and cURL examples to the Pattern Matching guide
- aligns host-language, JSON, and shell escaping for LIKE and RE2 filters
- replaces the original raw-string `\d` example with a validated literal-suffix example using `\.json$`
- covers substring matching, anchors, alternation, case-insensitive matching, exclusions, and nullable fields

## Validation

All executable candidates were tested against released Milvus 3.0.0 (`milvusdb/milvus:v3.0.0`).

- Java (`milvus-sdk-java 2.6.18`): 18/18 assertions passed
- Node.js (`milvus2-sdk-node 3.0.0`): 18/18 assertions passed
- Go (`client/v2 2.6.5`): 18/18 assertions passed
- REST/cURL: 18/18 assertions passed

Each harness created its test collection, inserted representative and nullable data, loaded the collection, checked returned IDs for every filter, and removed the collection afterward.
