### PR TITLE
fix: correct nullable support claims in schema design AI prompt (preview)

### DIFF
--- a/site/en/aiTools/schema_design.md
+++ b/site/en/aiTools/schema_design.md
@@ -105,7 +105,7 @@ bm25_function = Function(
 schema.add_function(bm25_function)
 ```
 
-6. **Vector, JSON, and Array fields** do not support nullable. Only scalar fields support `nullable=True`.
+6. **Nullable fields:** `nullable=True` is supported on scalar fields (including JSON and Array) and on vector fields. Exceptions: primary keys and Array of Structs fields can never be nullable. Note: vector field nullable requires Milvus v3.0.x or later (v2.6.x supports scalar fields only); vector fields that allow NULL do not support `IS NULL` / `IS NOT NULL` filters.
 
 7. ALWAYS use `DataType.FLOAT_VECTOR`, `DataType.INT64`, etc. from the `DataType` enum. NEVER pass field types as strings.
 
@@ -117,7 +117,7 @@ schema.add_function(bm25_function)
 | Primary key type | `DataType.VARCHAR` | When you need application-controlled string IDs (e.g., UUIDs, composite keys). |
 | Dynamic fields | `enable_dynamic_field=True` | When entities have variable or unpredictable key-value metadata. Dynamic fields are queryable but not indexed as efficiently as schema-defined fields. |
 | Dynamic fields | `enable_dynamic_field=False` | When your schema is well-defined and all fields are known at creation time. Better query performance. |
-| Nullable fields | `nullable=True` | When some entities may not have a value for a scalar field. NOT supported for vector, JSON, or Array fields. |
+| Nullable fields | `nullable=True` | When some entities may lack a value for a scalar or vector field. Never nullable: primary keys, Array of Structs fields. |
 | Default values | `default_value=...` | When you want a fallback value for missing scalar fields during insertion. |
 
 ## Complete example: schema with all common field types
@@ -209,5 +209,5 @@ Before finishing, verify:
 - [ ] Only one primary key field per collection — no composite keys
 - [ ] Schema modifications account for version: immutable in v2.5.x, add nullable scalar fields in v2.6.x, drop scalar fields and non-last vector fields in v3.0.x
 - [ ] BM25 function and analyzer are defined at collection creation time, not added later
-- [ ] Nullable is only used on scalar fields, not on vector, JSON, or Array fields
+- [ ] Nullable is used only on scalar fields (all versions) or vector fields (v3.0.x+) — never on primary keys or Array of Structs fields
 ````


### PR DESCRIPTION
Preview propagation of https://github.com/milvus-io/milvus-docs/pull/3630 (same semantic fix for the preview integration branch).

## Problem

The schema design AI prompt (site/en/aiTools/schema_design.md) incorrectly states that vector, JSON, and Array fields do not support nullable:

- Rule 6: "Vector, JSON, and Array fields do not support nullable. Only scalar fields support nullable=True."
- Decision guide: "NOT supported for vector, JSON, or Array fields."
- Verification checklist: "Nullable is only used on scalar fields..."

This contradicts the canonical Nullable Fields page (userGuide/schema/nullable-and-default.md): "The nullable attribute is supported for both scalar and vector fields", with only Array of Structs excluded.

## Evidence (milvus-io/milvus v3.0.0)

- `pkg/util/typeutil/nullable_vector.go` `IsSupportedNullableVectorType`: FloatVector, BinaryVector, Float16Vector, BFloat16Vector, Int8Vector, SparseFloatVector all support nullable (new in 3.0).
- `internal/rootcoord/util.go` `checkFieldSchema`: the only type-level nullable rejection is the primary key; JSON and Array (scalar types) have no rejection.

## Change

Corrects the three statements to align with the canonical page: scalar fields (including JSON and Array) and vector fields support `nullable=True`; primary keys and Array of Structs fields never do. Also notes that vector nullable requires v3.0.x+ and that nullable vector fields do not support `IS NULL` / `IS NOT NULL` filters.