### PR TITLE
docs: correct nullable StructArray guidance

### DIFF
--- a/site/en/userGuide/schema/nullable-and-default.md
+++ b/site/en/userGuide/schema/nullable-and-default.md
@@ -18,7 +18,7 @@ Use nullable fields when:
 
 - Vector fields that allow NULL values do not support `IS NULL` or `IS NOT NULL` filter expressions. You cannot explicitly filter entities based on whether a vector field value is NULL.
 
-- [Array of Structs](array-of-structs.md) fields do not support NULL values. You cannot mark an Array of Structs field or any field nested inside it as nullable.
+- Starting in Milvus 3.0.0, the parent [StructArray](array-of-structs.md) field can be nullable. Set `nullable=True` on the parent StructArray field, not on individual subfields. NULL applies to the whole StructArray field, not to an individual Struct element, and Milvus propagates the parent's nullability to its subfields internally. A StructArray field added to an existing collection must be nullable so existing entities can return NULL for the new field. For details, refer to [StructArray Limits](structarray-limits.md#Nullable-and-dynamic-schema-limits).
 
 - The nullable attribute is defined when a field is created and cannot be modified afterward. You cannot enable or disable nullability for an existing field.
 
@@ -35,7 +35,7 @@ When a field is defined with `nullable=True`, Milvus allows the field value to b
 
 If a field is not defined as nullable (the default behavior), every entity must provide a valid value for that field. Omitting the field or explicitly assigning a NULL value will cause the insert or import operation to fail.
 
-The nullable attribute is supported for both **scalar and vector fields** in a collection schema. However, Array of Structs fields do not support the nullable attribute.
+The nullable attribute is supported for both **scalar and vector fields** in a collection schema. Starting in Milvus 3.0.0, it is also supported on the parent StructArray field. Do not configure Struct subfields as nullable independently; define nullability on the StructArray parent and Milvus propagates that setting to its subfields internally.
 
 <div class="alert note">
 

--- a/site/en/userGuide/schema/structarray-limits.md
+++ b/site/en/userGuide/schema/structarray-limits.md
@@ -66,15 +66,17 @@ Nullable StructArray behavior and dynamic StructArray field addition are version
 
 | Capability | Limit |
 | --- | --- |
-| Nullable StructArray field | Supported only in versions that include nullable StructArray and nullable vector-array support. |
+| Nullable StructArray field | Supported in Milvus 3.0.0 and later. Set `nullable=True` on the StructArray parent; do not configure Struct subfields as nullable independently. |
 | Null value in Python | Use `None` to insert a null StructArray value in Python. Do not use `Null` or `null`. |
 | Null scope | Null applies to the whole StructArray field. For example, `chunks=None` is valid only when `chunks` is nullable. |
 | Partially null StructArray value | When a StructArray field contains a valid array value, do not mix null subfield arrays with valid subfield arrays in the same value. |
-| Dynamic add StructArray field | Adding a StructArray field to an existing collection is supported only in versions that include dynamic StructArray field support. |
+| Dynamic add StructArray field | Supported in Milvus 3.0.0 and later. |
 | Nullable requirement for dynamic add | A StructArray field added to an existing collection must be nullable because existing entities have no value for the new field. |
-| Existing entities after dynamic add | Existing entities return `null` for the added StructArray field across its subfields. |
+| Existing entities after dynamic add | Existing entities return `null` for the added StructArray field. |
 
-In Milvus v3.0.x, nullable StructArray fields, nullable vector arrays, and dynamic StructArray field addition are available.
+Milvus 3.0.0 and later releases support nullable StructArray fields, nullable vector arrays, and dynamic StructArray field addition in both Standalone and Distributed deployments. Earlier Milvus versions do not support these capabilities.
+
+In Zilliz Cloud, these capabilities are available on On-Demand Clusters running Milvus 3.0.0 or later. Serving Clusters do not support them.
 
 For insert examples with nullable StructArray fields, see [Insert Data into StructArray Fields](insert-data-into-structarray-fields.md).
 


### PR DESCRIPTION
## Summary

- Correct the Nullable Fields limits so they no longer prohibit nullable StructArray fields.
- Document that nullable StructArray support starts in Milvus 3.0.0, applies to the parent field, and propagates internally to subfields.
- Clarify that dynamically added StructArray fields must be nullable so existing entities can return NULL.
- State the supported deployment modes: Milvus Standalone and Distributed, plus Zilliz Cloud On-Demand Clusters; Serving Clusters are not supported.
- Link the Nullable Fields page to the detailed StructArray limits.

## Validation

- `git diff --check upstream/v3.0.x...HEAD`
- `node check-link.js`
- Confirmed the relative link and `#nullable-and-dynamic-schema-limits` anchor resolve locally.

## Scope

Documentation-only change.
