### PR TITLE
docs: complete scalar-ordered grouping search examples (preview)

### DIFF
--- a/site/en/userGuide/search-query-get/grouping-search.md
+++ b/site/en/userGuide/search-query-get/grouping-search.md
@@ -379,6 +379,7 @@ The following example groups search results by `category`, returns up to three e
     <a href="#javascript">NodeJS</a>
     <a href="#go">Go</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -400,19 +401,122 @@ res = client.search(
 ```
 
 ```java
-// java
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.request.aggregation.AggDirection;
+import io.milvus.v2.service.vector.request.aggregation.OrderByField;
+import io.milvus.v2.service.vector.response.SearchResp;
+import java.util.List;
+
+// Prerequisite: client is connected to Milvus and product_catalog is loaded.
+FloatVec queryVector = new FloatVec(new float[]{0.14529211512077012f, 0.9147257273453546f, 0.7965055218724449f, 0.7009258593102812f, 0.5605206522382088f});
+SearchReq request = SearchReq.builder()
+    .collectionName("product_catalog")
+    .data(List.of(queryVector))
+    .annsField("embedding")
+    .topK(20)
+    .groupByFieldName("category")
+    .groupSize(3)
+    .strictGroupSize(true)
+    .outputFields(List.of("category", "price", "rating"))
+    .orderByFields(List.of(OrderByField.builder()
+        .fieldName("price").direction(AggDirection.ASC).build()))
+    .build();
+SearchResp response = client.search(request);
+System.out.println(response.getSearchResults());
 ```
 
 ```javascript
-// nodejs
+// Prerequisite: client is connected to Milvus and product_catalog is loaded.
+const queryVector = [0.14529211512077012, 0.9147257273453546, 0.7965055218724449, 0.7009258593102812, 0.5605206522382088];
+const response = await client.search({
+  collection_name: "product_catalog",
+  data: [queryVector],
+  anns_field: "embedding",
+  limit: 20,
+  group_by_field: "category",
+  group_size: 3,
+  strict_group_size: true,
+  output_fields: ["category", "price", "rating"],
+  order_by_fields: [{ field: "price", order: "asc" }],
+});
+console.log(response.results);
 ```
 
 ```go
-// go
+import (
+    "fmt"
+    "github.com/milvus-io/milvus/client/v3/entity"
+    "github.com/milvus-io/milvus/client/v3/milvusclient"
+)
+
+// Prerequisite: client is connected to Milvus and product_catalog is loaded.
+queryVector := []float32{0.14529211512077012, 0.9147257273453546, 0.7965055218724449, 0.7009258593102812, 0.5605206522382088}
+results, err := client.Search(ctx, milvusclient.NewSearchOption(
+    "product_catalog", 20, []entity.Vector{entity.FloatVector(queryVector)},
+).
+    WithANNSField("embedding").
+    WithGroupByField("category").
+    WithGroupSize(3).
+    WithStrictGroupSize(true).
+    WithOutputFields("category", "price", "rating").
+    WithSearchParam("order_by_fields", "price:asc"))
+if err != nil {
+    panic(err)
+}
+for _, result := range results {
+    fmt.Println(result.IDs, result.Scores)
+    fmt.Println(result.GetColumn("category"), result.GetColumn("price"), result.GetColumn("rating"))
+}
 ```
 
 ```bash
-# restful
+# Prerequisite: set CLUSTER_ENDPOINT and TOKEN for your Milvus instance.
+curl --request POST \
+  --url "${CLUSTER_ENDPOINT}/v2/vectordb/entities/search" \
+  --header "Authorization: Bearer ${TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "collectionName": "product_catalog",
+    "data": [[0.14529211512077012, 0.9147257273453546, 0.7965055218724449, 0.7009258593102812, 0.5605206522382088]],
+    "annsField": "embedding",
+    "limit": 20,
+    "groupingField": "category",
+    "groupSize": 3,
+    "strictGroupSize": true,
+    "outputFields": ["category", "price", "rating"],
+    "orderByFields": ["price:asc"]
+  }'
+```
+
+```cpp
+#include "milvus/MilvusClientV2.h"
+#include <iostream>
+#include <stdexcept>
+
+// Prerequisite: client is connected to Milvus and product_catalog is loaded.
+std::vector<float> query_vector = {0.14529211512077012f, 0.9147257273453546f, 0.7965055218724449f, 0.7009258593102812f, 0.5605206522382088f};
+auto request = milvus::SearchRequest()
+    .WithCollectionName("product_catalog")
+    .AddFloatVector(query_vector)
+    .WithAnnsField("embedding")
+    .WithLimit(20)
+    .WithGroupByField("category")
+    .WithGroupSize(3)
+    .WithStrictGroupSize(true)
+    .AddOutputField("category")
+    .AddOutputField("price")
+    .AddOutputField("rating")
+    .AddOrderByField(milvus::OrderByField("price", milvus::AggregationDirection::ASC));
+milvus::SearchResponse response;
+auto status = client->Search(request, response);
+if (!status.IsOk()) { throw std::runtime_error(status.Message()); }
+for (const auto& result : response.Results().Results()) {
+    milvus::EntityRows rows;
+    status = result.OutputRows(rows);
+    if (!status.IsOk()) { throw std::runtime_error(status.Message()); }
+    std::cout << rows << std::endl;
+}
 ```
 
 In the request above, `limit=20` means Milvus selects up to 20 groups, not 20 entities. Because `group_size=3`, the flat result list can contain up to 60 entities in total.


### PR DESCRIPTION
Fill the Java, Node.js, Go, REST, and C++ examples in “Order groups by a scalar field” and add the missing C++ tab. The examples group by category, return up to three hits per group, and order groups by price while preserving similarity order within each group.

Validation: all five Milvus-adapted snippets passed compilation or syntax checks. Equivalent examples passed live tests on an existing Zilliz Cloud ONDEMAND cluster against a Python baseline; a Milvus server was not tested. The repository's inner-link check and `git diff --check` passed.

Merge and inspect this Preview change first. Apply the corresponding v3.0.x PR only after Preview acceptance.

Corresponding release-branch PR: #3640.
