### PR TITLE
docs: complete C++ examples for grouping search

### DIFF
--- a/site/en/userGuide/search-query-get/grouping-search.md
+++ b/site/en/userGuide/search-query-get/grouping-search.md
@@ -62,6 +62,7 @@ In the search request, set both `group_by_field` and `output_fields` to `docId`.
     <a href="#go">Go</a>
     <a href="#javascript">NodeJS</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -211,6 +212,48 @@ curl --request POST \
 }'
 ```
 
+```cpp
+#include "milvus/MilvusClientV2.h"
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+auto client = milvus::MilvusClientV2::Create();
+
+milvus::ConnectParam connect_param{"http://localhost:19530", "root:Milvus"};
+auto status = client->Connect(connect_param);
+if (!status.IsOk()) {
+    throw std::runtime_error(status.Message());
+}
+
+std::vector<float> query_vector = {0.3580376395471989f, -0.6023495712049978f, 0.18414012509913835f, -0.26286205330961354f, 0.9029438446296592f};
+auto request = milvus::SearchRequest()
+                   .WithCollectionName("my_collection")
+                   .AddFloatVector(query_vector)
+                   .WithLimit(3)
+                   .WithAnnsField("vector")
+                   .WithGroupByField("docId")
+                   .AddOutputField("docId");
+
+milvus::SearchResponse response;
+status = client->Search(request, response);
+if (!status.IsOk()) {
+    throw std::runtime_error(status.Message());
+}
+
+for (auto& result : response.Results().Results()) {
+    std::cout << "TopK results:" << std::endl;
+    milvus::EntityRows output_rows;
+    status = result.OutputRows(output_rows);
+    if (!status.IsOk()) {
+        throw std::runtime_error(status.Message());
+    }
+    for (const auto& row : output_rows) {
+        std::cout << "\t" << row << std::endl;
+    }
+}
+```
+
 In the request above, `limit=3` indicates that the system will return search results from three groups, with each group containing the single most similar entity to the query vector.
 
 ## Configure group size
@@ -223,6 +266,7 @@ By default, Grouping Search returns only one entity per group. If you want multi
     <a href="#go">Go</a>
     <a href="#javascript">NodeJS</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -357,6 +401,50 @@ curl --request POST \
     "strictGroupSize":true,
     "outputFields": ["docId"]
 }'
+```
+
+```cpp
+#include "milvus/MilvusClientV2.h"
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+auto client = milvus::MilvusClientV2::Create();
+
+milvus::ConnectParam connect_param{"http://localhost:19530", "root:Milvus"};
+auto status = client->Connect(connect_param);
+if (!status.IsOk()) {
+    throw std::runtime_error(status.Message());
+}
+
+std::vector<float> query_vector = {0.3580376395471989f, -0.6023495712049978f, 0.18414012509913835f, -0.26286205330961354f, 0.9029438446296592f};
+auto request = milvus::SearchRequest()
+                   .WithCollectionName("my_collection")
+                   .AddFloatVector(query_vector)
+                   .WithLimit(5)
+                   .WithAnnsField("vector")
+                   .WithGroupByField("docId")
+                   .WithGroupSize(2)
+                   .WithStrictGroupSize(true)
+                   .AddOutputField("docId");
+
+milvus::SearchResponse response;
+status = client->Search(request, response);
+if (!status.IsOk()) {
+    throw std::runtime_error(status.Message());
+}
+
+for (auto& result : response.Results().Results()) {
+    std::cout << "TopK results:" << std::endl;
+    milvus::EntityRows output_rows;
+    status = result.OutputRows(output_rows);
+    if (!status.IsOk()) {
+        throw std::runtime_error(status.Message());
+    }
+    for (const auto& row : output_rows) {
+        std::cout << "\t" << row << std::endl;
+    }
+}
 ```
 
 In the example above:


### PR DESCRIPTION
Add C++ SDK examples and language tabs to “Perform Grouping Search” and “Configure group size.” Together with the scalar-field ordering example merged in #3639, all three grouping-search sections now have C++ examples.

The imported examples reuse the connection status variable, include their standard-library headers, use float literals, and stop on connection, search, or result-conversion errors.

Validation:
- Both documented snippets compiled with Milvus C++ SDK 3.0.2 in a minimal main-function wrapper.
- Both searches ran against an existing Zilliz Cloud cluster with the documented 10-row dataset and matched the Python baseline: 3 groups for basic grouping; 5 groups and 9 entities for group size 2, including the undersized group. Temporary test data was removed.
- Repository link checker and whitespace checks passed. A standalone Milvus server was not used for live validation.

The same additions are included in #3640 for v3.0.x. Merge this Preview PR first, then review the preview before merging #3640.
