### PR TITLE
docs: add Node.js, Go, and C++ primary-key search examples

### DIFF
--- a/site/en/userGuide/search-query-get/primary-key-search.md
+++ b/site/en/userGuide/search-query-get/primary-key-search.md
@@ -53,6 +53,7 @@ To conduct a basic primary-key search, simply replace the query vectors with pri
     <a href="#javascript">NodeJS</a>
     <a href="#go">Go</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -83,15 +84,94 @@ for hits in res:
 ```
 
 ```javascript
-// node.js
+import { MilvusClient } from "@zilliz/milvus2-sdk-node";
+
+const client = new MilvusClient({
+    address: "http://localhost:19530",
+    token: "root:Milvus",
+});
+
+const res = await client.search({
+    collection_name: "quick_setup",
+    anns_field: "vector",
+    // highlight-start
+    ids: [551, 296, 43], // a list of primary keys
+    // highlight-end
+    limit: 3,
+    metric_type: "IP",
+});
+
+console.log(res.results);
 ```
 
 ```go
-// go
+import (
+    "context"
+    "fmt"
+
+    "github.com/milvus-io/milvus/client/v3/column"
+    "github.com/milvus-io/milvus/client/v3/milvusclient"
+)
+
+ctx := context.Background()
+
+client, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
+    Address: "localhost:19530",
+    APIKey:  "root:Milvus",
+})
+if err != nil {
+    fmt.Println(err.Error())
+    // handle error
+}
+defer client.Close(ctx)
+
+// highlight-start
+ids := column.NewColumnInt64("id", []int64{551, 296, 43}) // a list of primary keys
+// highlight-end
+resultSets, err := client.Search(ctx, milvusclient.NewSearchByIDsOption(
+    "quick_setup", // collectionName
+    3,             // limit
+    ids,
+).WithANNSField("vector").
+    WithSearchParam("metric_type", "IP"))
+if err != nil {
+    fmt.Println(err.Error())
+    // handle error
+}
+
+for _, resultSet := range resultSets {
+    fmt.Println("IDs: ", resultSet.IDs)
+    fmt.Println("Scores: ", resultSet.Scores)
+}
 ```
 
 ```bash
 # restful
+```
+
+```cpp
+auto searchRequest = milvus::SearchRequest()
+                         .WithCollectionName("quick_setup")
+                         .WithAnnsField("vector")
+                         // highlight-start
+                         .WithIDs({551, 296, 43})
+                         // highlight-end
+                         .WithLimit(3)
+                         .WithMetricType(milvus::MetricType::IP);
+
+milvus::SearchResponse searchResponse;
+auto status = client->Search(searchRequest, searchResponse);
+if (!status.IsOk()) {
+    std::cerr << "Search failed: " << status.Message() << std::endl;
+    return;
+}
+
+for (const auto& result : searchResponse.Results().Results()) {
+    const auto ids = result.Ids().IntIDArray();
+    for (size_t i = 0; i < result.Scores().size(); ++i) {
+        std::cout << "id=" << ids[i] << ", score=" << result.Scores()[i] << std::endl;
+    }
+}
 ```
 
 ### Example 2: Filtered search using primary keys
@@ -104,6 +184,7 @@ The following example assumes that color and likes are two schema-defined fields
     <a href="#javascript">NodeJS</a>
     <a href="#go">Go</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -123,15 +204,74 @@ res = client.search(
 ```
 
 ```javascript
-// node.js
+const res = await client.search({
+    collection_name: "my_collection",
+    // highlight-start
+    ids: [551, 296, 43],
+    filter: 'color like "red%" and likes > 50',
+    output_fields: ["id", "color", "likes"],
+    // highlight-end
+    limit: 3,
+});
+
+console.log(res.results);
 ```
 
 ```go
-// go
+// highlight-start
+ids := column.NewColumnInt64("id", []int64{551, 296, 43})
+// highlight-end
+resultSets, err := client.Search(ctx, milvusclient.NewSearchByIDsOption(
+    "my_collection", // collectionName
+    3,               // limit
+    ids,
+).WithFilter(`color like "red%" and likes > 50`).
+    WithOutputFields("color", "likes"))
+if err != nil {
+    fmt.Println(err.Error())
+    // handle error
+}
+
+for _, resultSet := range resultSets {
+    fmt.Println("IDs: ", resultSet.IDs)
+    fmt.Println("Scores: ", resultSet.Scores)
+    fmt.Println("color: ", resultSet.GetColumn("color"))
+    fmt.Println("likes: ", resultSet.GetColumn("likes"))
+}
 ```
 
 ```bash
 # restful
+```
+
+```cpp
+auto searchRequest = milvus::SearchRequest()
+                         .WithCollectionName("my_collection")
+                         // highlight-start
+                         .WithIDs({551, 296, 43})
+                         .WithFilter(R"(color like "red%" and likes > 50)")
+                         .WithOutputFields({"color", "likes"})
+                         // highlight-end
+                         .WithLimit(3);
+
+milvus::SearchResponse searchResponse;
+auto status = client->Search(searchRequest, searchResponse);
+if (!status.IsOk()) {
+    std::cerr << "Search failed: " << status.Message() << std::endl;
+    return;
+}
+
+for (const auto& result : searchResponse.Results().Results()) {
+    const auto ids = result.Ids().IntIDArray();
+    const auto colors = result.OutputField<milvus::VarCharFieldData>("color");
+    const auto likes = result.OutputField<milvus::Int64FieldData>("likes");
+    for (size_t i = 0; i < result.Scores().size(); ++i) {
+        std::cout << "id=" << ids[i]
+                  << ", score=" << result.Scores()[i]
+                  << ", color=" << colors->Data()[i]
+                  << ", likes=" << likes->Data()[i] << std::endl;
+    }
+}
 ```
 
 ### Example 3: Range search using primary keys
@@ -142,6 +282,7 @@ res = client.search(
     <a href="#javascript">NodeJS</a>
     <a href="#go">Go</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -167,15 +308,78 @@ res = client.search(
 ```
 
 ```javascript
-// node.js
+const res = await client.search({
+    collection_name: "my_collection",
+    // highlight-start
+    ids: [551, 296, 43],
+    // highlight-end
+    limit: 3,
+    params: {
+        // highlight-start
+        radius: 0.4,
+        range_filter: 0.6,
+        // highlight-end
+    },
+});
+
+console.log(res.results);
 ```
 
 ```go
-// go
+annParam := index.NewCustomAnnParam()
+// highlight-start
+annParam.WithRadius(0.4)
+annParam.WithRangeFilter(0.6)
+// highlight-end
+
+// highlight-start
+ids := column.NewColumnInt64("id", []int64{551, 296, 43})
+// highlight-end
+resultSets, err := client.Search(ctx, milvusclient.NewSearchByIDsOption(
+    "my_collection", // collectionName
+    3,               // limit
+    ids,
+).WithANNSField("vector").
+    WithAnnParam(annParam))
+if err != nil {
+    fmt.Println(err.Error())
+    // handle error
+}
+
+for _, resultSet := range resultSets {
+    fmt.Println("IDs: ", resultSet.IDs)
+    fmt.Println("Scores: ", resultSet.Scores)
+}
 ```
 
 ```bash
 # restful
+```
+
+```cpp
+auto searchRequest = milvus::SearchRequest()
+                         .WithCollectionName("my_collection")
+                         .WithAnnsField("vector")
+                         // highlight-start
+                         .WithIDs({551, 296, 43})
+                         .WithRadius(0.4)
+                         .WithRangeFilter(0.6)
+                         // highlight-end
+                         .WithLimit(3);
+
+milvus::SearchResponse searchResponse;
+auto status = client->Search(searchRequest, searchResponse);
+if (!status.IsOk()) {
+    std::cerr << "Search failed: " << status.Message() << std::endl;
+    return;
+}
+
+for (const auto& result : searchResponse.Results().Results()) {
+    const auto ids = result.Ids().IntIDArray();
+    for (size_t i = 0; i < result.Scores().size(); ++i) {
+        std::cout << "id=" << ids[i] << ", score=" << result.Scores()[i] << std::endl;
+    }
+}
 ```
 
 ### Example 4: Grouping search using primary keys
@@ -188,6 +392,7 @@ The following example assumes `docId` is a schema-defined fields in the target c
     <a href="#javascript">NodeJS</a>
     <a href="#go">Go</a>
     <a href="#bash">cURL</a>
+    <a href="#cpp">C++</a>
 </div>
 
 ```python
@@ -207,14 +412,71 @@ res = client.search(
 ```
 
 ```javascript
-// node.js
+const res = await client.search({
+    collection_name: "my_collection",
+    // highlight-start
+    ids: [551, 296, 43],
+    // highlight-end
+    limit: 3,
+    group_by_field: "docId",
+    output_fields: ["id", "docId"],
+});
+
+console.log(res.results);
 ```
 
 ```go
-// go
+// highlight-start
+ids := column.NewColumnInt64("id", []int64{551, 296, 43})
+// highlight-end
+resultSets, err := client.Search(ctx, milvusclient.NewSearchByIDsOption(
+    "my_collection", // collectionName
+    3,               // limit
+    ids,
+).WithGroupByField("docId").
+    WithOutputFields("docId"))
+if err != nil {
+    fmt.Println(err.Error())
+    // handle error
+}
+
+for _, resultSet := range resultSets {
+    fmt.Println("IDs: ", resultSet.IDs)
+    fmt.Println("Scores: ", resultSet.Scores)
+    fmt.Println("docId: ", resultSet.GetColumn("docId"))
+}
 ```
 
 ```bash
 # restful
+```
+
+```cpp
+auto searchRequest = milvus::SearchRequest()
+                         .WithCollectionName("my_collection")
+                         .WithAnnsField("vector")
+                         // highlight-start
+                         .WithIDs({551, 296, 43})
+                         .WithGroupByField("docId")
+                         .WithOutputFields({"docId"})
+                         // highlight-end
+                         .WithLimit(3);
+
+milvus::SearchResponse searchResponse;
+auto status = client->Search(searchRequest, searchResponse);
+if (!status.IsOk()) {
+    std::cerr << "Search failed: " << status.Message() << std::endl;
+    return;
+}
+
+for (const auto& result : searchResponse.Results().Results()) {
+    const auto ids = result.Ids().IntIDArray();
+    const auto docIds = result.OutputField<milvus::Int64FieldData>("docId");
+    for (size_t i = 0; i < result.Scores().size(); ++i) {
+        std::cout << "id=" << ids[i]
+                  << ", score=" << result.Scores()[i]
+                  << ", docId=" << docIds->Data()[i] << std::endl;
+    }
+}
 ```
 


### PR DESCRIPTION
This PR adds primary-key search examples for Node.js, Go, and C++ to the primary-key search guide. All SDK examples have been validated against a Zilliz Cloud cluster.