### PR TITLE
docs: clarify merge upsert behavior for missing primary keys (preview)

### DIFF
--- a/site/en/userGuide/insert-and-delete/upsert-entities.md
+++ b/site/en/userGuide/insert-and-delete/upsert-entities.md
@@ -10,7 +10,7 @@ The `upsert` operation provides a convenient way to insert or update entities in
 
 ## Overview
 
-You can use `upsert` to either insert a new entity or update an existing one, depending on whether the primary key provided in the upsert request exists in the collection. If the primary key is not found, an insert operation occurs. Otherwise, an update operation will be performed.
+You can use `upsert` to either insert a new entity or update an existing one, depending on whether the primary key provided in the upsert request exists in the collection. If the primary key is not found, an insert operation occurs. Otherwise, an update operation will be performed. Partial updates on `autoID` collections are an exception: they update existing entities only, as described below.
 
 An upsert in Milvus works in either **override** or **merge** mode.
 
@@ -26,13 +26,22 @@ For fields with `nullable` enabled, you can omit them in the `upsert` request if
 
 ### Upsert in merge mode | Milvus v2.6.2+
 
-You can also use the `partial_update` flag to make an upsert request work in merge mode. This allows you to include only the fields that need updating in the request payload.
+Use merge mode to update specific fields of an existing entity while keeping the other fields unchanged.
 
 ![Upsert In Merge Mode](https://milvus-docs.s3.us-west-2.amazonaws.com/assets/upsert-in-merge-mode.png)
 
-To perform a merge, set `partial_update` to `True` in the `upsert` request along with the primary key and the fields to update with their new values. 
+Set `partial_update=True` and provide the primary key and the fields you want to update.
 
-Upon receiving such a request, Milvus performs a query with strong consistency to retrieve the entity, updates the field values based on the data in the request, inserts the modified data, and then deletes the existing entity with the original primary key carried in the request.
+Milvus retrieves the existing entity with a strong-consistency query, merges your changes with the stored data, inserts the merged entity, and deletes the old entity.
+
+If the primary key does not exist, the result depends on whether `autoID` is enabled:
+
+- **With `autoID` disabled**, Milvus attempts to insert a new entity with the primary key you supplied. The request succeeds if it meets the normal insertion requirements. If a required field is missing, the request fails with a missing-field error. Nullable fields and fields with default values can be omitted, just as in a normal insert.
+- **With `autoID` enabled**, every primary key in the request must already exist. Milvus rejects the request if any primary key is missing, even if you provide all fields required for insertion. For existing entities, merge mode keeps the primary key unchanged.
+
+If a partial update fails with a missing-field error, check whether the target entity exists. Without an existing entity, Milvus cannot retrieve the values of fields you omitted.
+
+For new entities, use `insert` or an upsert in override mode. Use merge mode for subsequent updates to individual fields.
 
 For `ARRAY` fields, merge mode supports two operators in Milvus v2.6.17 and later: `ARRAY_APPEND` and `ARRAY_REMOVE`. These operators let you append elements to or remove matching elements from an existing `ARRAY` field, without first querying the entity to retrieve its current value. For details, see [Upsert ARRAY fields in merge mode](upsert-entities.md#Upsert-ARRAY-fields-in-merge-mode).
 
@@ -440,9 +449,7 @@ curl --request POST \
 
 ## Upsert entities in merge mode | Milvus v2.6.2+
 
-The following code example demonstrates how to upsert entities with partial updates. Provide only the fields needing updates and their new values, along with the explicit partial update flag.
-
-In the following example, the `issue` field of the entities specified in the upsert request will be updated to the values included in the request.
+The following example updates only the `issue` field of the entities with primary keys `1` and `2` in `my_collection`. Before running it, ensure that both entities already exist. Their other fields retain their current values.
 
 <div class="alert note">
 


### PR DESCRIPTION
Clarify what happens when a merge-mode upsert refers to a missing primary key: collections without AutoID attempt insertion and require the normal insert fields; AutoID collections require existing primary keys. Explain the missing-field error and recommend inserting entities before applying partial updates.

Rewrite the merge introduction around the user task and state that the example entities must already exist. Code examples are unchanged.

Validation: checked the server 3.0 branch at `981d5857c53fceb417c52751870aa3ad4484d5df` ([AutoID guard](https://github.com/milvus-io/milvus/blob/981d5857c53fceb417c52751870aa3ad4484d5df/internal/proxy/task_upsert.go#L433-L435), [insert validation](https://github.com/milvus-io/milvus/blob/981d5857c53fceb417c52751870aa3ad4484d5df/internal/proxy/task_upsert.go#L572-L600)). `git diff --check` passed; code blocks, headings, and SDK tabs were checked for preservation. No live-server or rendered-site tests were run.

Merge this PR first and verify the staging page before merging the corresponding `v3.0.x` PR #3648.
